### PR TITLE
chore(deps): bump 50 packages to latest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,45 +5,45 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- API & Web -->
-    <PackageVersion Include="Asp.Versioning.Http" Version="8.1.1" />
-    <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.1" />
-    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
+    <PackageVersion Include="Asp.Versioning.Http" Version="10.0.0" />
+    <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
+    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
     <PackageVersion Include="AspNetCore.SwaggerUI.Themes" Version="3.0.2" />
     <PackageVersion Include="Makaretu.Dns" Version="2.0.1" />
     <PackageVersion Include="Makaretu.Dns.Multicast" Version="0.27.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Http.Extensions" Version="2.3.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.3.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Extensions" Version="2.3.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.3.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.2.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.17.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.2.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
     <PackageVersion Include="MimeMapping" Version="4.0.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
     <!-- Swagger -->
     <PackageVersion Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.7" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.7" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.8" />
     <!-- Entity Framework -->
     <PackageVersion Include="FlexLabs.EntityFrameworkCore.Upsert" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8" />
     <!-- Serialization -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <!-- Logging -->
@@ -56,30 +56,30 @@
     <PackageVersion Include="BDInfo" Version="0.8.0" />
     <PackageVersion Include="HeyRed.ImageSharp.Heif" Version="2.1.3" />
     <PackageVersion Include="LibHeif.Native" Version="1.15.1" />
-    <PackageVersion Include="MediaBrowser.Model.Signed" Version="3.0.647" />
+    <PackageVersion Include="MediaBrowser.Model.Signed" Version="3.0.648" />
     <PackageVersion Include="MediaInfo.Wrapper.Core" Version="26.1.0" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="4.0.0" />
     <PackageVersion Include="SubtitlesParserV2" Version="2.4.0" />
     <PackageVersion Include="TagLibSharp" Version="2.3.0" />
     <!-- Providers -->
     <PackageVersion Include="AcoustID.NET" Version="1.3.3" />
-    <PackageVersion Include="ExtendedNumerics.BigRational" Version="3000.0.2.132" />
+    <PackageVersion Include="ExtendedNumerics.BigRational" Version="2023.221.2134" />
     <PackageVersion Include="MusixmatchClientLib" Version="1.1.9" />
     <!-- Plugin System -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <!-- Hosting -->
-    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.8" />
     <!-- Avalonia (Tray App) -->
-    <PackageVersion Include="Avalonia" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.0" />
+    <PackageVersion Include="Avalonia" Version="12.0.3" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.3" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.3" />
     <!-- Diagnostics -->
-    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.7" />
+    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.8" />
     <!-- System & Infrastructure -->
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="DeviceId" Version="6.11.0" />
@@ -92,8 +92,8 @@
     <PackageVersion Include="Humanizer" Version="3.0.10" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
     <PackageVersion Include="I18N.DotNet" Version="1.3.1" />
-    <PackageVersion Include="InfiniLore.InfiniFrame" Version="0.5.0" />
-    <PackageVersion Include="InfiniLore.InfiniFrame.WebServer" Version="0.5.0" />
+    <PackageVersion Include="InfiniLore.InfiniFrame" Version="0.13.1" />
+    <PackageVersion Include="InfiniLore.InfiniFrame.WebServer" Version="0.13.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
@@ -109,16 +109,16 @@
     <PackageVersion Include="Sharpcaster" Version="3.0.0" />
     <PackageVersion Include="Stowage" Version="2.0.1" />
     <PackageVersion Include="Stun.Net" Version="10.0.6" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.5" />
-    <PackageVersion Include="System.Management" Version="10.0.7" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.8" />
+    <PackageVersion Include="System.Management" Version="10.0.8" />
     <PackageVersion Include="Ulid" Version="1.4.1" />
     <!-- Security pins for transitive deps (clears GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf, GHSA-xrw6-gwf8-vvr9) -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.8" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.93.0" />
     <!-- Testing -->
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
-    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
Automated dependency bump by Shield (latest scope).

- `Asp.Versioning.Http` `8.1.1` → `10.0.0` (Nuget)
- `Asp.Versioning.Mvc` `8.1.1` → `10.0.0` (Nuget)
- `Asp.Versioning.Mvc.ApiExplorer` `8.1.1` → `10.0.0` (Nuget)
- `Avalonia` `12.0.0` → `12.0.3` (Nuget)
- `Avalonia.Desktop` `12.0.0` → `12.0.3` (Nuget)
- `Avalonia.Themes.Fluent` `12.0.0` → `12.0.3` (Nuget)
- `coverlet.collector` `8.0.1` → `10.0.0` (Nuget)
- `ExtendedNumerics.BigRational` `3000.0.2.132` → `2023.221.2134` (Nuget)
- `FluentAssertions` `8.9.0` → `8.10.0` (Nuget)
- `InfiniLore.InfiniFrame` `0.5.0` → `0.13.1` (Nuget)
- `InfiniLore.InfiniFrame.WebServer` `0.5.0` → `0.13.1` (Nuget)
- `MediaBrowser.Model.Signed` `3.0.647` → `3.0.648` (Nuget)
- `Microsoft.AspNetCore.Authentication.JwtBearer` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.AspNetCore.DataProtection` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.AspNetCore.Http.Extensions` `2.3.9` → `2.3.10` (Nuget)
- `Microsoft.AspNetCore.Mvc` `2.3.9` → `2.3.10` (Nuget)
- `Microsoft.AspNetCore.Mvc.NewtonsoftJson` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.AspNetCore.Mvc.Testing` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.AspNetCore.SignalR` `1.2.9` → `1.2.10` (Nuget)
- `Microsoft.AspNetCore.SignalR.Client` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.EntityFrameworkCore` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.EntityFrameworkCore.Abstractions` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.EntityFrameworkCore.Design` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.EntityFrameworkCore.InMemory` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.EntityFrameworkCore.Relational` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.EntityFrameworkCore.Sqlite` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.EntityFrameworkCore.Sqlite.Core` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.EntityFrameworkCore.Tools` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.Extensions.Configuration.Json` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.Extensions.DependencyInjection` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.Extensions.DependencyInjection.Abstractions` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.Extensions.FileProviders.Embedded` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.Extensions.Hosting.Abstractions` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.Extensions.Hosting.Systemd` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.Extensions.Hosting.WindowsServices` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.Extensions.Http` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.Extensions.Localization` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.Extensions.Logging` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.Extensions.Logging.Abstractions` `10.0.7` → `10.0.8` (Nuget)
- `Microsoft.IdentityModel.Protocols.OpenIdConnect` `8.17.0` → `8.18.0` (Nuget)
- `Microsoft.NET.Test.Sdk` `18.4.0` → `18.5.1` (Nuget)
- `OpenTelemetry.Instrumentation.Http` `1.15.0` → `1.15.1` (Nuget)
- `SixLabors.ImageSharp` `3.1.12` → `4.0.0` (Nuget)
- `System.CommandLine` `2.0.5` → `2.0.8` (Nuget)
- `System.Diagnostics.PerformanceCounter` `10.0.7` → `10.0.8` (Nuget)
- `System.IdentityModel.Tokens.Jwt` `8.17.0` → `8.18.0` (Nuget)
- `System.Management` `10.0.7` → `10.0.8` (Nuget)
- `System.Security.Cryptography.Xml` `10.0.7` → `10.0.8` (Nuget)
- `Tmds.DBus.Protocol` `0.92.0` → `0.93.0` (Nuget)

---
Generated by [Shield](https://github.com/nomercylabs/shield). Review before merging.