### PR TITLE
fix(plugins): load plugins under the storage facade on every platform

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,12 @@ jobs:
           --blame-hang-timeout 5m
           --filter "(Category=Unit|Category=ErrorHandling|Category=Characterization)&Category!=Integration"
 
-  # Optional coverage job - non-blocking, only runs on master or when manually triggered
+  # Full-suite coverage job — runs on master or manual dispatch (the release path).
+  # MUST block: it is the only job that runs uncategorized tests (e.g. the plugin
+  # suite, which carries no Category trait and is excluded from the fast `test`
+  # filter). With continue-on-error a red full suite sailed straight to release.
   coverage:
     runs-on: ubuntu-latest
-    continue-on-error: true
     if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
     
     steps:

--- a/src/NoMercy.Plugins/PluginManager.cs
+++ b/src/NoMercy.Plugins/PluginManager.cs
@@ -492,7 +492,38 @@ public class PluginManager : IPluginManager, IDisposable
 
     internal async Task LoadPluginAssemblyAsync(string assemblyPath, CancellationToken ct = default)
     {
-        PluginLoadContext loadContext = new(assemblyPath);
+        PluginLoadContext loadContext;
+        try
+        {
+            // AssemblyDependencyResolver reads the assembly's .deps.json via the
+            // native host. On Linux it throws for a DLL with no/invalid deps
+            // manifest (a stray file, a plugin shipped without its deps);
+            // Windows tolerates it. Constructing outside the try let that escape
+            // and abort discovery of every other plugin — guard it so a bad
+            // assembly is skipped and reported, not fatal.
+            loadContext = new(assemblyPath);
+        }
+        catch (Exception loadContextEx)
+        {
+            _logger.LogWarning(
+                "Failed to initialize plugin load context for {AssemblyPath}: {Error}",
+                assemblyPath,
+                loadContextEx.Message
+            );
+
+            await _eventBus.PublishAsync(
+                new PluginErrorEvent
+                {
+                    PluginId = Guid.Empty.ToString(),
+                    PluginName = Path.GetFileNameWithoutExtension(assemblyPath),
+                    ErrorMessage =
+                        $"Failed to initialize plugin load context: {loadContextEx.Message}",
+                    ExceptionType = loadContextEx.GetType().Name,
+                },
+                ct
+            );
+            return;
+        }
 
         try
         {

--- a/src/NoMercy.Plugins/PluginManager.cs
+++ b/src/NoMercy.Plugins/PluginManager.cs
@@ -36,6 +36,15 @@ public class PluginManager : IPluginManager, IDisposable
         _storage = storage ?? throw new ArgumentNullException(nameof(storage));
     }
 
+    // AssemblyLoadContext and AssemblyDependencyResolver are raw filesystem APIs and need a
+    // real absolute path. IStorage hands back paths relative to the plugins root, so resolve
+    // them against the absolute local root before loading. An already-absolute path is returned
+    // unchanged. Plugin assemblies are always local — they cannot be loaded from a remote driver.
+    private string ToLocalAssemblyPath(string storagePath)
+    {
+        return Path.GetFullPath(Path.Combine(_pluginsPath, storagePath));
+    }
+
     public IReadOnlyList<PluginInfo> GetInstalledPlugins()
     {
         return _loadedPlugins.Values.Select(lp => lp.Info).ToList().AsReadOnly();
@@ -305,11 +314,12 @@ public class PluginManager : IPluginManager, IDisposable
                 return;
             }
 
-            PluginLoadContext loadContext = new(assemblyPath);
+            string absoluteAssemblyPath = ToLocalAssemblyPath(assemblyPath);
+            PluginLoadContext loadContext = new(absoluteAssemblyPath);
 
             try
             {
-                Assembly assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+                Assembly assembly = loadContext.LoadFromAssemblyPath(absoluteAssemblyPath);
                 List<Type> pluginTypes = assembly
                     .GetTypes()
                     .Where(t =>
@@ -492,6 +502,7 @@ public class PluginManager : IPluginManager, IDisposable
 
     internal async Task LoadPluginAssemblyAsync(string assemblyPath, CancellationToken ct = default)
     {
+        string absoluteAssemblyPath = ToLocalAssemblyPath(assemblyPath);
         PluginLoadContext loadContext;
         try
         {
@@ -501,7 +512,7 @@ public class PluginManager : IPluginManager, IDisposable
             // Windows tolerates it. Constructing outside the try let that escape
             // and abort discovery of every other plugin — guard it so a bad
             // assembly is skipped and reported, not fatal.
-            loadContext = new(assemblyPath);
+            loadContext = new(absoluteAssemblyPath);
         }
         catch (Exception loadContextEx)
         {
@@ -527,7 +538,7 @@ public class PluginManager : IPluginManager, IDisposable
 
         try
         {
-            Assembly assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+            Assembly assembly = loadContext.LoadFromAssemblyPath(absoluteAssemblyPath);
             List<Type> pluginTypes = assembly
                 .GetTypes()
                 .Where(t =>

--- a/tests/NoMercy.Plugin.Samples.Echo/NoMercy.Plugin.Samples.Echo.csproj
+++ b/tests/NoMercy.Plugin.Samples.Echo/NoMercy.Plugin.Samples.Echo.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
 
   <!-- Opt out of the shared test infrastructure (TestEnvironmentSetup, NmSystem).

--- a/tests/NoMercy.Tests.Plugins/PluginBootScanTests.cs
+++ b/tests/NoMercy.Tests.Plugins/PluginBootScanTests.cs
@@ -63,13 +63,18 @@ public class PluginBootScanTests : IDisposable
         // copy) — loading it through PluginLoadContext requires clean isolation.
         string testBinDir = Path.GetDirectoryName(typeof(PluginBootScanTests).Assembly.Location)!;
         string repoRoot = Path.GetFullPath(Path.Combine(testBinDir, "..", "..", "..", "..", ".."));
+        // Mirror the test's own build configuration + TFM so this works under
+        // both Debug (local) and Release (CI coverage) — hardcoding "Debug"
+        // makes every Echo-staging test fail when CI builds Release.
+        string tfm = Path.GetFileName(testBinDir);
+        string configuration = Path.GetFileName(Path.GetDirectoryName(testBinDir)!);
         return Path.Combine(
             repoRoot,
             "tests",
             "NoMercy.Plugin.Samples.Echo",
             "bin",
-            "Debug",
-            "net10.0"
+            configuration,
+            tfm
         );
     }
 
@@ -86,6 +91,13 @@ public class PluginBootScanTests : IDisposable
 
         // Copy DLL and all dependencies that the Echo assembly needs at runtime.
         foreach (string file in Directory.EnumerateFiles(binDir, "*.dll"))
+            File.Copy(file, Path.Combine(_echoPluginDir, Path.GetFileName(file)), overwrite: true);
+
+        // Copy the .deps.json — AssemblyDependencyResolver reads it to resolve the
+        // plugin's dependencies. Without it the resolver constructor throws and the
+        // plugin silently fails to load (results come back empty). This mirrors how
+        // a real plugin package ships its DLL alongside its deps manifest.
+        foreach (string file in Directory.EnumerateFiles(binDir, "*.deps.json"))
             File.Copy(file, Path.Combine(_echoPluginDir, Path.GetFileName(file)), overwrite: true);
 
         // Copy the plugin manifest.

--- a/tests/NoMercy.Tests.Plugins/PluginDiIntegrationTests.cs
+++ b/tests/NoMercy.Tests.Plugins/PluginDiIntegrationTests.cs
@@ -39,6 +39,7 @@ public class PluginDiIntegrationTests : IDisposable
         ServiceCollection services = new();
         services.AddSingleton<IEventBus, InMemoryEventBus>();
         services.AddLogging();
+        services.AddSingleton(TestStorageHelper.CreateBackend());
 
         services.AddPluginSystem(_tempPluginsDir);
 
@@ -171,6 +172,7 @@ public class PluginDiIntegrationTests : IDisposable
         InMemoryEventBus bus = new();
         services.AddSingleton<IEventBus>(bus);
         services.AddLogging();
+        services.AddSingleton(TestStorageHelper.CreateBackend());
 
         services.AddPluginSystem(_tempPluginsDir);
 

--- a/tests/NoMercy.Tests.Plugins/PluginManifestParserTests.cs
+++ b/tests/NoMercy.Tests.Plugins/PluginManifestParserTests.cs
@@ -233,8 +233,12 @@ public class PluginManifestParserTests : IDisposable
     public async Task ParseFileAsync_FileNotFound_ThrowsFileNotFoundException()
     {
         IStorage storage = TestStorageHelper.CreateStorage(_tempDir);
-        Func<Task> act = () =>
-            PluginManifestParser.ParseFileAsync("/nonexistent/plugin.json", storage);
+        // Missing file UNDER the scoped root. An out-of-root absolute path is
+        // rejected by the storage guard before the existence check, and a leading
+        // "/" path is absolute on Linux but relative on Windows — so it must stay
+        // inside the allowed root to test the not-found path cross-platform.
+        string missingPath = Path.Combine(_tempDir, "nonexistent", "plugin.json");
+        Func<Task> act = () => PluginManifestParser.ParseFileAsync(missingPath, storage);
 
         await act.Should().ThrowAsync<FileNotFoundException>();
     }


### PR DESCRIPTION
## What

Brings the two plugin-loader fixes onto `dev` so the storage-facade release can load plugins on every platform.

- **Scoped→absolute path resolution** — `PluginManager` handed `IStorage` root-relative paths straight to `AssemblyLoadContext` / `AssemblyDependencyResolver`, which are raw filesystem APIs that need an absolute path. Plugins failed to load under the new storage facade on every platform (`-2147450734`, "Failed to locate managed application"). Now scoped paths resolve against the absolute plugins root before loading.
- **Cross-platform / CI-safe loader + tests** — guard `PluginLoadContext` construction so a DLL with a missing/invalid `.deps.json` is skipped and reported instead of crashing discovery (Linux threw `-2147450734`; Windows tolerated it). Echo sample emits a loadable component manifest. Plugin tests stage the `.deps.json` next to the DLL, derive the build configuration, and use an in-root path for the not-found test.
- **Close the coverage gate** — remove `continue-on-error` from the coverage job so a red full suite blocks the release instead of shipping on red.

## Why this branch and not `feat/encoder-v3` directly

`dev` already contains all of encoder-v3's work (it is the squash) **plus** release fixes that v3 predates — version `0.1.374`, the MediaAnalyzer ffprobe fix, and the StorageDriverGrouper path-separator fix. A literal `feat/encoder-v3 → dev` merge conflicts on those files and would roll the version and both Linux fixes backward.

This branch is `dev` + the two plugin commits only. Diff against `dev` is exactly six plugin files — zero conflicts, zero regression.

## Verification

- `dotnet build -c Release` — 0 errors
- `NoMercy.Tests.Plugins` — 170/170 passed
