### PR TITLE
Stage a plugin update beside the install instead of unpacking over it

### DIFF
--- a/src/NoMercy.Api/Controllers/V1/Dashboard/Plugins/PluginRepositoryController.cs
+++ b/src/NoMercy.Api/Controllers/V1/Dashboard/Plugins/PluginRepositoryController.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------------
 //  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
 //
 //  This file is part of NoMercy MediaServer, source-available software (NOT open
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Mvc;
 using NoMercy.Api.DTOs.Common;
 using NoMercy.Api.DTOs.Dashboard;
 using NoMercy.NmSystem.Information;
+using NoMercy.Plugins;
 using NoMercy.Plugins.Abstractions;
 using NoMercy.Plugins.Verification;
 using NoMercy.Storage;
@@ -195,6 +196,14 @@ public class PluginRepositoryController(
             else
                 await pluginManager.InstallPluginAsync(stagedPath, target.Checksum, ct);
         }
+        // Not a failure: the new version is unpacked and verified, and the next
+        // start applies it. Updating a plugin that is running is the ordinary
+        // case, and the file being locked while it runs is the expected outcome
+        // on Windows - it used to reach the owner as a 500 with a stack trace.
+        catch (PluginUpdatePendingRestartException ex)
+        {
+            return ConflictResponse(ex.Message);
+        }
         catch (PluginVerificationException ex)
         {
             return UnprocessableEntityResponse(ex.Message);
@@ -202,6 +211,14 @@ public class PluginRepositoryController(
         catch (HttpRequestException ex)
         {
             return UnprocessableEntityResponse($"The download failed: {ex.Message}");
+        }
+        // Anything else the filesystem refuses - a permission, a full disk, a
+        // second install running at the same time. The installed plugin is
+        // untouched either way, because nothing is written over it until the
+        // staged copy is complete.
+        catch (IOException ex)
+        {
+            return UnprocessableEntityResponse($"The install could not be written: {ex.Message}");
         }
         catch (InvalidOperationException ex)
         {

--- a/src/NoMercy.Plugins/PluginManager.cs
+++ b/src/NoMercy.Plugins/PluginManager.cs
@@ -37,6 +37,11 @@ public class PluginManager : IPluginManager, IDisposable
     private readonly PluginLoader _loader;
     private readonly PluginLifecycleManager _lifecycle;
 
+    // Held because an install has to know whether the copy it would replace is
+    // still resident, and the answer decides whether the update lands now or on
+    // the next start.
+    private readonly IPluginAssemblyTracker? _assemblyTracker;
+
     public PluginManager(
         IEventBus eventBus,
         IServiceProvider serviceProvider,
@@ -71,6 +76,7 @@ public class PluginManager : IPluginManager, IDisposable
                 )
             );
         _registry = new PluginRegistry();
+        _assemblyTracker = assemblyTracker;
 
         // Built here only when DI did not supply one, which is the test and
         // direct-construction path. Its protector is ephemeral, so a secret
@@ -224,15 +230,179 @@ public class PluginManager : IPluginManager, IDisposable
 
         PluginManifestEntry manifest = FindManifest(archive, fullPath);
         string pluginDir = Path.Combine(_pluginsPath, manifest.FolderName);
+        string staging = Path.Combine(_pluginsPath, PendingUpdatesFolder, manifest.FolderName);
 
-        if (!_storage.Exists(pluginDir))
+        // Unpacked beside the installed copy, never over it. Extraction writes
+        // one entry at a time, so anything that fails part way through used to
+        // leave the folder holding some of the new plugin and some of the old.
+        // That state is worse than a refusal: the manifest would name one
+        // version while the assembly actually running is another, and a
+        // catalogue comparing versions would call it up to date and never offer
+        // the update again.
+        if (_driver.DirectoryExists(staging))
         {
-            _storage.CreateDirectory(pluginDir);
+            _driver.DeleteDirectory(staging, recursive: true);
         }
 
-        string assemblyPath = await ExtractAsync(archive, manifest, pluginDir, ct);
+        _driver.CreateDirectory(staging);
 
-        await LoadPluginAssemblyAsync(assemblyPath, ct);
+        await ExtractAsync(archive, manifest, staging, ct);
+
+        // Replacing a loaded plugin's own assembly cannot work: unloading a
+        // collectible context is best-effort, one live reference anywhere keeps
+        // it, and on Windows the file stays locked for as long as it does. So
+        // the staged copy is left where the next start finds it, before a single
+        // assembly is loaded and while nothing holds the file.
+        if (IsResident(manifest.Id))
+        {
+            _logger.LogInformation(
+                "Plugin update for {Folder} is staged: its assembly is still loaded, so it is applied on the next start.",
+                manifest.FolderName
+            );
+
+            throw new PluginUpdatePendingRestartException(manifest.FolderName);
+        }
+
+        ApplyStaged(staging, pluginDir);
+
+        await LoadPluginAssemblyAsync(Path.Combine(pluginDir, manifest.AssemblyFileName), ct);
+    }
+
+    /// <summary>
+    /// Where an update waits when the copy it replaces is still loaded.
+    ///
+    /// Inside the plugins folder rather than in temp, because a pending update
+    /// has to survive the shutdown it is waiting for, and temp does not have to.
+    /// The boot scan skips it by name for the same reason it skips
+    /// <c>configurations</c> and <c>data</c>: it holds plugins that are not
+    /// installed yet, and loading one from here would run a version the rest of
+    /// the server does not know about.
+    /// </summary>
+    internal const string PendingUpdatesFolder = ".pending-updates";
+
+    /// <summary>
+    /// Whether this plugin's assembly is loaded in this process right now.
+    ///
+    /// Two questions, because they fail the same way and neither alone covers
+    /// it: the registry answers for a plugin that is loaded, and the tracker
+    /// answers for one that has been unloaded and whose files are still held —
+    /// which is the case a best-effort unload leaves behind.
+    /// </summary>
+    private bool IsResident(Ulid pluginId) =>
+        _registry.TryGetValue(pluginId, out _) || (_assemblyTracker?.IsStillLoaded(pluginId) ?? false);
+
+    /// <summary>
+    /// Moves a staged plugin into place, replacing what is there.
+    ///
+    /// Only ever called once the assembly is known to be replaceable, so this
+    /// is the point where the update becomes visible and there is nothing to
+    /// roll back.
+    /// </summary>
+    private void ApplyStaged(string staging, string pluginDir)
+    {
+        if (!_driver.DirectoryExists(pluginDir))
+        {
+            _driver.CreateDirectory(pluginDir);
+        }
+
+        // Through the driver rather than IStorage: a StorageEntry's path is
+        // relative to the storage scope, and the two roots here are real paths.
+        // Mixing the two produced a destination full of `..` segments that the
+        // path guard refused - correctly.
+        foreach (
+            StorageEntryInfo info in _driver.EnumerateEntries(
+                staging,
+                "*",
+                SearchOption.AllDirectories
+            )
+        )
+        {
+            if (info.IsDirectory)
+            {
+                continue;
+            }
+
+            string relative = Path.GetRelativePath(staging, info.Path);
+            string destination = Path.Combine(pluginDir, relative);
+            string? parent = Path.GetDirectoryName(destination);
+
+            if (parent is not null && !_driver.DirectoryExists(parent))
+            {
+                _driver.CreateDirectory(parent);
+            }
+
+            using (Stream source = _driver.OpenRead(info.Path))
+            using (Stream target = _driver.OpenWrite(destination, overwrite: true))
+            {
+                source.CopyTo(target);
+            }
+        }
+
+        _driver.DeleteDirectory(staging, recursive: true);
+
+        // And the folder they wait in, once the last one has gone. An empty
+        // .pending-updates sitting in the plugins directory reads like something
+        // is still queued when nothing is.
+        string pending = Path.Combine(_pluginsPath, PendingUpdatesFolder);
+
+        if (
+            _driver.DirectoryExists(pending)
+            && !_driver.EnumerateEntries(pending, "*", SearchOption.TopDirectoryOnly).Any()
+        )
+        {
+            _driver.DeleteDirectory(pending, recursive: false);
+        }
+    }
+
+    /// <summary>
+    /// Applies every update that was waiting on this restart.
+    ///
+    /// Before anything is loaded, which is the whole point: this is the one
+    /// moment in the process's life when no plugin assembly is held and the
+    /// files can be replaced. A single failure is logged and skipped rather
+    /// than thrown, because one plugin that cannot be updated must not stop the
+    /// server from starting the others.
+    /// </summary>
+    private void ApplyPendingUpdates()
+    {
+        string pending = Path.Combine(_pluginsPath, PendingUpdatesFolder);
+
+        if (!_driver.DirectoryExists(pending))
+        {
+            return;
+        }
+
+        foreach (
+            StorageEntryInfo entry in _driver
+                .EnumerateEntries(pending, "*", SearchOption.TopDirectoryOnly)
+                .ToList()
+        )
+        {
+            if (!entry.IsDirectory)
+            {
+                continue;
+            }
+
+            string folderName = Path.GetFileName(entry.Path);
+
+            try
+            {
+                ApplyStaged(entry.Path, Path.Combine(_pluginsPath, folderName));
+
+                _logger.LogInformation(
+                    "Applied the staged update for {Folder}.",
+                    folderName
+                );
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Could not apply the staged update for {Folder}. The installed version is untouched and the update stays staged.",
+                    folderName
+                );
+            }
+        }
     }
 
     /// <summary>
@@ -278,7 +448,12 @@ public class PluginManager : IPluginManager, IDisposable
             );
         }
 
-        return new(prefix, parsed.Assembly, Path.GetFileNameWithoutExtension(parsed.Assembly));
+        return new(
+            prefix,
+            parsed.Assembly,
+            Path.GetFileNameWithoutExtension(parsed.Assembly),
+            parsed.Id
+        );
     }
 
     private async Task<string> ExtractAsync(
@@ -363,7 +538,8 @@ public class PluginManager : IPluginManager, IDisposable
     private sealed record PluginManifestEntry(
         string Prefix,
         string AssemblyFileName,
-        string FolderName
+        string FolderName,
+        Ulid Id
     );
 
     public Task EnablePluginAsync(Ulid pluginId, CancellationToken ct = default)
@@ -388,6 +564,10 @@ public class PluginManager : IPluginManager, IDisposable
             return;
         }
 
+        // Before the scan below, because this is the one moment no plugin
+        // assembly is held and a staged update can replace the files it needs to.
+        ApplyPendingUpdates();
+
         IReadOnlyList<StorageEntry> entries = _storage.List(_pluginsPath, null, recursive: false);
         foreach (StorageEntry entry in entries)
         {
@@ -398,7 +578,7 @@ public class PluginManager : IPluginManager, IDisposable
 
             string pluginDir = entry.Path;
             string dirName = Path.GetFileName(pluginDir);
-            if (dirName is "configurations" or "data")
+            if (dirName is "configurations" or "data" or PendingUpdatesFolder)
             {
                 continue;
             }

--- a/src/NoMercy.Plugins/PluginUpdatePendingRestartException.cs
+++ b/src/NoMercy.Plugins/PluginUpdatePendingRestartException.cs
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using NoMercy.Plugins.Abstractions;
+
+namespace NoMercy.Plugins;
+
+/// <summary>
+/// The update was unpacked and verified, and is waiting for a restart because
+/// the copy it replaces is still loaded.
+/// <para>
+/// Not a failure. Nothing was lost and nothing has to be done again: the new
+/// version is on disk and the next start applies it before a single assembly is
+/// loaded. This exists so the caller can say that plainly instead of reporting
+/// the <see cref="IOException" /> that used to reach the owner as a 500 — the
+/// file being locked is the expected outcome of updating a running plugin on
+/// Windows, not something that went wrong.
+/// </para>
+/// </summary>
+public class PluginUpdatePendingRestartException(string folderName)
+    : Exception(
+        $"The update to {folderName} is ready and applies when the server restarts: "
+            + "its files are still in use and cannot be changed until then."
+    )
+{
+    /// <summary>The plugin folder the staged update belongs to.</summary>
+    public string FolderName { get; } = folderName;
+
+    /// <summary>
+    /// Why a restart is needed, in the vocabulary the dashboard already draws
+    /// for enable and uninstall, so this reads as the same kind of answer
+    /// rather than a second one invented here.
+    /// </summary>
+    public PluginRestartRequirement Restart { get; } =
+        new(PluginRestartReason.AssemblyStillLoaded);
+}

--- a/tests/NoMercy.Tests.Plugins/PluginArchiveUpdateTests.cs
+++ b/tests/NoMercy.Tests.Plugins/PluginArchiveUpdateTests.cs
@@ -1,0 +1,229 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using System.IO.Compression;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NoMercy.Events;
+using NoMercy.Plugins;
+using Xunit;
+
+namespace NoMercy.Tests.Plugins;
+
+/// <summary>
+/// Installing over a plugin that is already there.
+/// <para>
+/// The catalogue's Update button lands here, and it used to unpack straight over
+/// the installed folder. Extraction writes one entry at a time, so a failure part
+/// way through left the folder holding the new manifest beside the old assembly —
+/// and replacing a loaded plugin's own assembly is not a failure that might
+/// happen, it is what always happens on Windows, where the file stays locked for
+/// as long as the process lives. The owner saw a 500 with a stack trace, and the
+/// server was then reporting a version it was not running.
+/// </para>
+/// <para>
+/// What these assert is where the files land and what the installed copy looks
+/// like afterwards. The assemblies written here are not real ones; loading is
+/// expected to fail and everything under test is decided before the loader is
+/// reached.
+/// </para>
+/// </summary>
+public class PluginArchiveUpdateTests : IDisposable
+{
+    private readonly string _tempDir = Path.Combine(
+        Path.GetTempPath(),
+        $"nm-plugin-update-{Ulid.NewUlid():N}"
+    );
+    private readonly string _pluginsDir;
+    private readonly PluginManager _manager;
+
+    private const string FolderName = "NoMercy.Plugin.InternetRadio";
+    private const string AssemblyName = "NoMercy.Plugin.InternetRadio.dll";
+
+    /// <summary>
+    /// Spelled out rather than read off PluginManager: this is where an update
+    /// waits on disk, so a rename that the boot scan was not told about should
+    /// fail here rather than pass by following the constant.
+    /// </summary>
+    private const string PendingUpdates = ".pending-updates";
+
+    public PluginArchiveUpdateTests()
+    {
+        _pluginsDir = Path.Combine(_tempDir, "plugins");
+        Directory.CreateDirectory(_pluginsDir);
+
+        _manager = new(
+            new InMemoryEventBus(),
+            new MinimalServiceProvider(),
+            NullLogger<PluginManager>.Instance,
+            _pluginsDir,
+            TestStorageHelper.CreateStorage(_pluginsDir),
+            TestStorageHelper.CreateBackend()
+        );
+    }
+
+    public void Dispose()
+    {
+        _manager.Dispose();
+
+        try
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private sealed class MinimalServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static string Manifest(string version) =>
+        $$"""
+        {
+          "id": "5KTKRT4Z2Y9P59Y40W5CX4TQKF",
+          "name": "Internet Radio",
+          "description": "Browse and play internet radio stations in the built-in player.",
+          "version": "{{version}}",
+          "targetAbi": "10.0",
+          "author": "NoMercy Community",
+          "assembly": "{{AssemblyName}}"
+        }
+        """;
+
+    private static void Write(ZipArchive archive, string entryName, string content)
+    {
+        using StreamWriter writer = new(archive.CreateEntry(entryName).Open(), Encoding.UTF8);
+        writer.Write(content);
+    }
+
+    /// <summary>An archive of the published shape, at a named version.</summary>
+    private string Archive(string version)
+    {
+        string path = Path.Combine(_tempDir, $"radio-{version}.zip");
+
+        using ZipArchive archive = ZipFile.Open(path, ZipArchiveMode.Create);
+        Write(archive, $"{FolderName}/plugin.json", Manifest(version));
+        Write(archive, $"{FolderName}/{AssemblyName}", $"MZ {version}");
+        Write(archive, $"{FolderName}/lang/en.json", $$"""{"version":"{{version}}"}""");
+
+        return path;
+    }
+
+    private async Task InstallIgnoringLoad(string archivePath)
+    {
+        try
+        {
+            await _manager.InstallPluginArchiveAsync(archivePath, null, CancellationToken.None);
+        }
+        catch (BadImageFormatException)
+        {
+            // Everything under test happened before the loader saw the file.
+        }
+    }
+
+    private string Installed(params string[] parts) =>
+        Path.Combine([_pluginsDir, FolderName, .. parts]);
+
+    [Fact]
+    public async Task InstallingOverAnEarlierVersion_ReplacesEveryFile()
+    {
+        await InstallIgnoringLoad(Archive("1.0.0"));
+        await InstallIgnoringLoad(Archive("1.2.0"));
+
+        File.ReadAllText(Installed(AssemblyName)).Should().Be("MZ 1.2.0");
+        File.ReadAllText(Installed("plugin.json")).Should().Contain("\"version\": \"1.2.0\"");
+        File.ReadAllText(Installed("lang", "en.json"))
+            .Should()
+            .Contain("1.2.0", "a plugin's other files are part of the version, not decoration");
+    }
+
+    /// <summary>
+    /// The defect this exists for. An archive is unpacked beside the installed
+    /// copy and only moved in once all of it is there, so a failure cannot leave
+    /// the manifest and the assembly disagreeing about which version is running.
+    /// </summary>
+    [Fact]
+    public async Task UnpackingIsNotDoneOverTheInstalledCopy()
+    {
+        await InstallIgnoringLoad(Archive("1.0.0"));
+
+        string manifestBefore = File.ReadAllText(Installed("plugin.json"));
+        string corrupt = Path.Combine(_tempDir, "corrupt.zip");
+        await File.WriteAllTextAsync(corrupt, "this is not a zip");
+
+        Func<Task> act = () =>
+            _manager.InstallPluginArchiveAsync(corrupt, null, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidDataException>();
+
+        File.ReadAllText(Installed("plugin.json"))
+            .Should()
+            .Be(manifestBefore, "a failed install must leave the working one exactly as it was");
+        File.ReadAllText(Installed(AssemblyName)).Should().Be("MZ 1.0.0");
+    }
+
+    [Fact]
+    public async Task ASuccessfulInstall_LeavesNothingStagedBehind()
+    {
+        await InstallIgnoringLoad(Archive("1.0.0"));
+
+        Directory
+            .Exists(Path.Combine(_pluginsDir, PendingUpdates))
+            .Should()
+            .BeFalse("staging is where an update waits, not where it accumulates");
+    }
+
+    /// <summary>
+    /// The boot scan must not treat the staging folder as a plugin: it holds
+    /// versions that are not installed yet, and loading one would run something
+    /// the rest of the server does not know about.
+    /// </summary>
+    [Fact]
+    public async Task AStagedUpdate_IsAppliedOnTheNextStartAndNotLoadedFromStaging()
+    {
+        await InstallIgnoringLoad(Archive("1.0.0"));
+
+        // What a locked assembly leaves behind, written directly because the
+        // lock itself cannot be reproduced without loading a real plugin.
+        string staged = Path.Combine(
+            _pluginsDir,
+            PendingUpdates,
+            FolderName
+        );
+        Directory.CreateDirectory(Path.Combine(staged, "lang"));
+        await File.WriteAllTextAsync(Path.Combine(staged, "plugin.json"), Manifest("1.2.0"));
+        await File.WriteAllTextAsync(Path.Combine(staged, AssemblyName), "MZ 1.2.0");
+        await File.WriteAllTextAsync(
+            Path.Combine(staged, "lang", "en.json"),
+            """{"version":"1.2.0"}"""
+        );
+
+        await _manager.LoadPluginsFromDirectoryAsync(CancellationToken.None);
+
+        File.ReadAllText(Installed(AssemblyName))
+            .Should()
+            .Be("MZ 1.2.0", "the restart is when the files are free to be replaced");
+        File.ReadAllText(Installed("plugin.json")).Should().Contain("1.2.0");
+        File.ReadAllText(Installed("lang", "en.json")).Should().Contain("1.2.0");
+        Directory
+            .Exists(staged)
+            .Should()
+            .BeFalse("an update that has landed is no longer pending");
+    }
+}


### PR DESCRIPTION
Closes #28.

Updating a plugin from the catalogue threw an unhandled `IOException` and the owner got a 500
with a stack trace. The archive was extracted straight over the installed folder, and a
plugin's own assembly is locked for as long as it is loaded — on Windows until the process
exits, because unloading a collectible context is best-effort and one live reference anywhere
keeps it.

That is not an edge case: updating any running plugin hit it every time. The Update button
could not work.

## The part that was worse than the 500

Extraction writes one entry at a time, so some of the new version had already been written
before it reached the assembly. That left the folder holding the **new `plugin.json` beside
the old `.dll`** — the server then reports a version it is not running, and a catalogue
comparing versions calls it up to date and never offers the update again.

## What this does

**Stage, then apply.** An archive is unpacked into `.pending-updates/<folder>` beside the
installed copy and only moved into place once all of it is there. Nothing is written over a
working install until the new one is complete, so a corrupt zip, a full disk or a refused
permission leaves what is installed exactly as it was.

**When the plugin is resident, the staged copy waits.** `LoadAllAsync` applies it on the next
start — before a single assembly is loaded and while nothing holds the files. The install
reports `PluginUpdatePendingRestartException`, which the controller answers as a **409**
carrying the sentence the dashboard already draws for enable and uninstall:

> Its files are still in use and cannot be changed until the server stops.

That reuses `PluginRestartReason.AssemblyStillLoaded` rather than inventing a second
vocabulary for the same fact. `PluginOperation.Update` and the advisor already described this
situation exactly; the install path simply never consulted them.

**Residency is asked of the registry and the tracker together.** The registry answers for a
plugin that is loaded, `IPluginAssemblyTracker` for one that has been unloaded and whose files
are still held. Neither alone covers it.

**The boot scan skips `.pending-updates` by name**, next to `configurations` and `data`. It
holds versions that are not installed yet, and loading one would run something the rest of the
server does not know about.

## One implementation note worth reviewing

Staging walks `IStorageDriver` rather than `IStorage`. A `StorageEntry`'s path is relative to
the storage scope while both roots here are real paths, and mixing the two builds destinations
full of `..` segments that `StoragePathGuard` refuses — correctly. The first version of this
did exactly that and the guard caught it, which is the guard doing its job.

## Verification

`NoMercy.Tests.Plugins`: **540 pass, 0 fail** — 536 before this branch, plus the four added
here. `NoMercy.Api` and `NoMercy.Plugins` both build clean.

New tests in `PluginArchiveUpdateTests`:

| test | what it pins |
| --- | --- |
| `InstallingOverAnEarlierVersion_ReplacesEveryFile` | the assembly, the manifest **and** `lang/` all move to the new version |
| `UnpackingIsNotDoneOverTheInstalledCopy` | a failed install leaves the working one byte-for-byte as it was — the defect above |
| `ASuccessfulInstall_LeavesNothingStagedBehind` | staging is where an update waits, not where it accumulates |
| `AStagedUpdate_IsAppliedOnTheNextStartAndNotLoadedFromStaging` | the pending copy lands on boot and is never loaded from staging |

The locked-file case itself is written as the state it leaves behind rather than by locking a
real assembly: reproducing the lock needs a genuinely loaded plugin, and what matters — that a
staged update is applied on the next start and never loaded from staging — is testable without
it. Worth a reviewer's eye on whether that is the right line to draw.

## Not covered here

Anyone whose update failed before this may already have a plugin folder holding a manifest and
an assembly that disagree. This stops it happening again; it does not detect or repair an
install already in that state. If that is worth doing, it wants its own issue — the check
would be comparing the loaded assembly's version against the manifest on disk at boot.
