### PR TITLE
ci(test): fetch exactly the resolved nomercy-ffmpeg tarball

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,12 @@ jobs:
             exit 1
           fi
 
+          # /tmp/nmff survives between runs on a self-hosted runner, so an older
+          # release's tarball would otherwise sit next to the new one and the
+          # extraction glob below would match both.
+          rm -rf /tmp/nmff
+          mkdir -p /tmp/nmff
+
           downloaded=""
           for attempt in 1 2 3 4 5; do
             if gh release download "$tag" --repo NoMercy-Entertainment/nomercy-ffmpeg --pattern 'ffmpeg-*-linux-x86_64-*.tar.gz' --dir /tmp/nmff --clobber; then
@@ -105,7 +111,7 @@ jobs:
             exit 1
           fi
 
-          tar -xzf /tmp/nmff/ffmpeg-*-linux-x86_64-*.tar.gz -C "$dest"
+          tar -xzf /tmp/nmff/ffmpeg-*-linux-x86_64-"$tag".tar.gz -C "$dest"
           chmod +x "$dest/ffmpeg" "$dest/ffprobe"
           echo "NOMERCY_FFMPEG_PATH=$dest/ffmpeg" >> "$GITHUB_ENV"
           echo "Fetched nomercy-ffmpeg $tag -> $dest"
@@ -169,6 +175,12 @@ jobs:
             exit 1
           fi
 
+          # /tmp/nmff survives between runs on a self-hosted runner, so an older
+          # release's tarball would otherwise sit next to the new one and the
+          # extraction glob below would match both.
+          rm -rf /tmp/nmff
+          mkdir -p /tmp/nmff
+
           downloaded=""
           for attempt in 1 2 3 4 5; do
             if gh release download "$tag" --repo NoMercy-Entertainment/nomercy-ffmpeg --pattern 'ffmpeg-*-linux-x86_64-*.tar.gz' --dir /tmp/nmff --clobber; then
@@ -184,7 +196,7 @@ jobs:
             exit 1
           fi
 
-          tar -xzf /tmp/nmff/ffmpeg-*-linux-x86_64-*.tar.gz -C "$dest"
+          tar -xzf /tmp/nmff/ffmpeg-*-linux-x86_64-"$tag".tar.gz -C "$dest"
           chmod +x "$dest/ffmpeg" "$dest/ffprobe"
           echo "NOMERCY_FFMPEG_PATH=$dest/ffmpeg" >> "$GITHUB_ENV"
           echo "Fetched nomercy-ffmpeg $tag -> $dest"


### PR DESCRIPTION
The `test / coverage` job started failing on the self-hosted runner after nomercy-ffmpeg v1.0.40 was released (run 34271413671 on PR #40, twice): the fetch step downloads the latest release into `/tmp/nmff`, which survives between runs there, so `tar -xzf /tmp/nmff/ffmpeg-*-linux-x86_64-*.tar.gz` expanded to the v1.0.39 and the v1.0.40 tarballs and tar read the second as a member name (`Not found in archive`, exit 2).

Both fetch steps now empty `/tmp/nmff` before downloading and extract the tarball named by the resolved tag. No test or code change.
