### PR TITLE
feat(setup): provision the stemsplit model beside ffmpeg

### DIFF
--- a/docs/encoder-errors.md
+++ b/docs/encoder-errors.md
@@ -25,6 +25,7 @@ shows up below wrapped in backticks. Add a new ID → add a new bullet here in t
 
 ## Capabilities
 - `capability.fpcalc_missing` — chromaprint binary not on PATH; intro detection disabled.
+- `capability.stemsplit_missing` — stemsplit GGUF model file missing or not configured; stem separation disabled.
 - `capability.tesseract_model_missing` — required Tesseract `*.traineddata` not in the configured directory.
 - `capability.whisper_missing` — whisper-cli binary not on PATH; speech transcription disabled.
 

--- a/src/NoMercy.Api/Controllers/V1/Encoder/EncoderHardwareController.cs
+++ b/src/NoMercy.Api/Controllers/V1/Encoder/EncoderHardwareController.cs
@@ -133,7 +133,7 @@ public class EncoderHardwareController(
     /// <summary>
     /// Returns the cached FFmpeg capability report: protocol support (BluRay,
     /// DVD), available encoders, missing filters and muxers, and optional-tool
-    /// presence (fpcalc, Whisper model, Tesseract eng.traineddata).
+    /// presence (fpcalc, Whisper model, stemsplit model, Tesseract eng.traineddata).
     /// Returns <c>probe_pending</c> if the background probe has not yet completed.
     /// </summary>
     [HttpGet("/api/v{version:apiVersion}/encoder/capabilities")]

--- a/src/NoMercy.Encoder/Composition/EncoderOptions.cs
+++ b/src/NoMercy.Encoder/Composition/EncoderOptions.cs
@@ -118,6 +118,12 @@ public class EncoderOptions
     public string? WhisperModelPath { get; set; }
 
     /// <summary>
+    /// Path to the stemsplit GGUF model; the analysis job passes its file name
+    /// relative to the ffmpeg folder.
+    /// </summary>
+    public string? StemsplitModelPath { get; set; }
+
+    /// <summary>
     /// Webhook URLs that receive a JSON POST for each encoder lifecycle event
     /// (started / completed / failed). Empty by default. Each URL is retried up
     /// to 3 times with exponential backoff; failures are logged and swallowed

--- a/src/NoMercy.Encoder/Errors/EncoderRuleId.cs
+++ b/src/NoMercy.Encoder/Errors/EncoderRuleId.cs
@@ -110,6 +110,7 @@ public static class EncoderRuleId
     // ---- Capabilities ----------------------------------------------------
     public const string CapabilityFpcalcMissing = "capability.fpcalc_missing";
     public const string CapabilityWhisperMissing = "capability.whisper_missing";
+    public const string CapabilityStemsplitMissing = "capability.stemsplit_missing";
     public const string CapabilityTesseractModelMissing = "capability.tesseract_model_missing";
 
     // ---- Disc ------------------------------------------------------------

--- a/src/NoMercy.Encoder/Errors/EncoderRuntimeErrorId.cs
+++ b/src/NoMercy.Encoder/Errors/EncoderRuntimeErrorId.cs
@@ -59,6 +59,8 @@ public static class EncoderRuntimeErrorId
 
     public const string CapabilityWhisperMissing = EncoderRuleId.CapabilityWhisperMissing;
 
+    public const string CapabilityStemsplitMissing = EncoderRuleId.CapabilityStemsplitMissing;
+
     public const string CapabilityTesseractModelMissing =
         EncoderRuleId.CapabilityTesseractModelMissing;
 

--- a/src/NoMercy.Encoder/Startup/FfmpegCapabilityProbe.cs
+++ b/src/NoMercy.Encoder/Startup/FfmpegCapabilityProbe.cs
@@ -92,11 +92,14 @@ public sealed class FfmpegCapabilityProbe(
 
         bool whisperModelPresent = ProbeWhisperModel();
 
+        bool stemsplitModelPresent = ProbeStemsplitModel();
+
         (bool tesseractPresent, string? tesseractDir) = ProbeTesseract();
 
         List<EncoderRule> issues = BuildIssues(
             fpcalcPresent,
             whisperModelPresent,
+            stemsplitModelPresent,
             tesseractPresent
         );
 
@@ -108,19 +111,21 @@ public sealed class FfmpegCapabilityProbe(
             MissingMuxers: missingMuxers,
             FpcalcPresent: fpcalcPresent,
             WhisperModelPresent: whisperModelPresent,
+            StemsplitModelPresent: stemsplitModelPresent,
             TesseractEngTraineddataPresent: tesseractPresent,
             TesseractModelsDirectory: tesseractDir,
             Issues: issues
         );
 
         logger.LogInformation(
-            "Capability probe complete — BluRay={BluRay}, DvdRead={DvdRead}, MissingFilters={FilterCount}, MissingMuxers={MuxerCount}, fpcalc={Fpcalc}, WhisperModel={Whisper}, Tesseract={Tesseract}",
+            "Capability probe complete — BluRay={BluRay}, DvdRead={DvdRead}, MissingFilters={FilterCount}, MissingMuxers={MuxerCount}, fpcalc={Fpcalc}, WhisperModel={Whisper}, StemsplitModel={Stemsplit}, Tesseract={Tesseract}",
             bluRay,
             dvdRead,
             missingFilters.Count,
             missingMuxers.Count,
             fpcalcPresent,
             whisperModelPresent,
+            stemsplitModelPresent,
             tesseractPresent
         );
     }
@@ -167,6 +172,22 @@ public sealed class FfmpegCapabilityProbe(
         }
     }
 
+    private bool ProbeStemsplitModel()
+    {
+        string? modelPath = options.StemsplitModelPath;
+        if (string.IsNullOrWhiteSpace(modelPath))
+            return false;
+
+        try
+        {
+            return storage.Exists(modelPath);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
     private (bool present, string? directory) ProbeTesseract()
     {
         string? dir = options.TesseractModelsDirectory;
@@ -187,6 +208,7 @@ public sealed class FfmpegCapabilityProbe(
     private static List<EncoderRule> BuildIssues(
         bool fpcalcPresent,
         bool whisperModelPresent,
+        bool stemsplitModelPresent,
         bool tesseractPresent
     )
     {
@@ -211,6 +233,17 @@ public sealed class FfmpegCapabilityProbe(
                     "WhisperModelPath",
                     "Whisper model file is missing or not configured.",
                     "Set EncoderOptions.WhisperModelPath to a valid ggml .bin model file."
+                )
+            );
+
+        if (!stemsplitModelPresent)
+            issues.Add(
+                new(
+                    EncoderRuleId.CapabilityStemsplitMissing,
+                    EncoderRuleSeverity.Warning,
+                    "StemsplitModelPath",
+                    "Stemsplit model file is missing or not configured.",
+                    "Set EncoderOptions.StemsplitModelPath to a valid stemsplit .gguf model file."
                 )
             );
 

--- a/src/NoMercy.Encoder/Startup/IFfmpegCapabilityProbe.cs
+++ b/src/NoMercy.Encoder/Startup/IFfmpegCapabilityProbe.cs
@@ -15,7 +15,8 @@ namespace NoMercy.Encoder.Startup;
 
 /// <summary>
 /// Probes for optional runtime dependencies (fpcalc, whisper.cpp model,
-/// Tesseract traineddata) and validates that the installed FFmpeg build
+/// stemsplit GGUF model, Tesseract traineddata) and validates that the
+/// installed FFmpeg build
 /// contains the filters, protocols, and muxers the server relies on.
 /// Results are cached after the first probe and returned via
 /// <see cref="GetCachedReport"/>. The probe itself runs deferred — never
@@ -44,6 +45,7 @@ public sealed record CapabilityReport(
     IReadOnlyList<string> MissingMuxers,
     bool FpcalcPresent,
     bool WhisperModelPresent,
+    bool StemsplitModelPresent,
     bool TesseractEngTraineddataPresent,
     string? TesseractModelsDirectory,
     IReadOnlyList<EncoderRule> Issues

--- a/src/NoMercy.NmSystem/Information/AppFiles.cs
+++ b/src/NoMercy.NmSystem/Information/AppFiles.cs
@@ -136,6 +136,14 @@ public static class AppFiles
     // libbluray jars — the build output puts everything ffmpeg-runtime there.
     public static string WhisperModelPath => Path.Combine(FfmpegFolder, WhisperModel + ".bin");
 
+    public static string StemsplitModel { get; set; } = "spleeter-2stems-f16";
+
+    // The model ships beside ffmpeg (like the whisper model above) so a relative
+    // file name resolves when ffmpeg runs from FfmpegFolder — the analysis job
+    // passes the stemsplit filter a relative name because a Windows drive-letter
+    // colon in an absolute path splits the filter argument.
+    public static string StemsplitModelPath => Path.Combine(FfmpegFolder, StemsplitModel + ".gguf");
+
     public static string CloudflareDPath =>
         Path.Combine(DependenciesPath, "cloudflared" + Info.ExecSuffix);
 

--- a/src/NoMercy.Service/Configuration/ServiceConfiguration.Core.cs
+++ b/src/NoMercy.Service/Configuration/ServiceConfiguration.Core.cs
@@ -614,6 +614,7 @@ public static partial class ServiceConfiguration
             opts.FfprobePathOverride = AppFiles.FfProbePath;
             opts.TesseractModelsDirectory = AppFiles.TesseractModelsFolder;
             opts.WhisperModelPath = AppFiles.WhisperModelPath;
+            opts.StemsplitModelPath = AppFiles.StemsplitModelPath;
             // Without this the JsonSpeedIndexStore silently no-ops on Save
             // ("No SpeedIndexCachePath configured — skipping save"), and every
             // reboot triggers a fresh ~20 min hardware benchmark calibration.

--- a/src/NoMercy.Setup/Server/Binaries.cs
+++ b/src/NoMercy.Setup/Server/Binaries.cs
@@ -62,6 +62,8 @@ public class Binaries
         "https://api.github.com/repos/NoMercy-Entertainment/nomercy-tesseract/releases/latest";
     private const string GithubWhisperModelApiUrl =
         "https://api.github.com/repos/NoMercy-Entertainment/nomercy-whisper-models/releases/latest";
+    private const string GithubStemsplitModelApiUrl =
+        "https://api.github.com/repos/NoMercy-Entertainment/nomercy-stemsplit-models/releases/latest";
 
     private const string GithubYtdlpApiUrl =
         "https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest";
@@ -512,6 +514,7 @@ public class Binaries
                 await DownloadYtdlp();
                 await DownloadShakaPackager();
                 await DownloadWhisperModels(AppFiles.WhisperModel);
+                await DownloadStemsplitModel(AppFiles.StemsplitModel);
 
                 List<string> tesseractLanguages = ["eng", "jpn"];
                 if (!CultureInfo.CurrentCulture.Equals(CultureInfo.InvariantCulture))
@@ -1942,21 +1945,109 @@ public class Binaries
             // DownloadWithVerificationAsync's destPath argument above) — without this
             // move+stamp, CheckLocalVersion's next-boot check reads FfmpegFolder/{model}.bin,
             // finds nothing, and re-downloads the ~2GB model on every single boot forever.
-            // FfmpegFolder normally already exists (DownloadFfmpeg's extraction step creates
-            // it, and runs earlier in DownloadAll's sequence) — mirrors ConcatenateModelParts'
-            // own guard for a caller that invokes DownloadWhisperModels directly.
-            if (!_driver.DirectoryExists(AppFiles.FfmpegFolder))
-                _storage.CreateDirectory(AppFiles.FfmpegFolder);
-
-            if (_driver.FileExists(destinationPath))
-                _driver.DeleteFile(destinationPath);
-
-            _driver.MoveFile(paths[0], destinationPath);
-
-            await FileAttributes.SetCreatedAttribute(destinationPath, releaseInfo.PublishedAt);
-
-            Logger.Setup($"Downloaded Whisper model to {destinationPath}");
+            await MoveDownloadedModelIntoPlaceAsync(
+                paths[0],
+                destinationPath,
+                releaseInfo.PublishedAt,
+                "Whisper model"
+            );
         }
+    }
+
+    /// <summary>
+    /// Moves a downloaded, hash-verified single-asset model from its staging path
+    /// (<see cref="AppFiles.DependenciesPath"/>) into its final resting place beside
+    /// ffmpeg, then stamps <see cref="FileAttributes.SetCreatedAttribute"/> so the next
+    /// boot's <see cref="CheckLocalVersion"/> sees it as current instead of re-downloading
+    /// it forever. Shared by <see cref="DownloadWhisperModels"/>'s single-asset branch and
+    /// <see cref="DownloadStemsplitModel"/> — both models ship as one GitHub asset that
+    /// lands beside ffmpeg under a different extension.
+    /// </summary>
+    /// <remarks>
+    /// FfmpegFolder normally already exists (DownloadFfmpeg's extraction step creates it,
+    /// and runs earlier in DownloadAll's sequence) — mirrors ConcatenateModelParts' own
+    /// guard for a caller that invokes one of these Download* methods directly.
+    /// </remarks>
+    private async Task MoveDownloadedModelIntoPlaceAsync(
+        string sourcePath,
+        string destinationPath,
+        DateTimeOffset publishedAt,
+        string label
+    )
+    {
+        if (!_driver.DirectoryExists(AppFiles.FfmpegFolder))
+            _storage.CreateDirectory(AppFiles.FfmpegFolder);
+
+        if (_driver.FileExists(destinationPath))
+            _driver.DeleteFile(destinationPath);
+
+        _driver.MoveFile(sourcePath, destinationPath);
+
+        await FileAttributes.SetCreatedAttribute(destinationPath, publishedAt);
+
+        Logger.Setup($"Downloaded {label} to {destinationPath}");
+    }
+
+    /// <summary>
+    /// Downloads and verifies the stemsplit GGUF model (Spleeter 2stems on ggml) that the
+    /// ffmpeg <c>stemsplit</c> filter needs at runtime, from the dedicated
+    /// nomercy-stemsplit-models release. Mirrors <see cref="DownloadWhisperModels"/>'s
+    /// single-asset branch: unlike whisper's largest models, the stemsplit model always
+    /// ships as exactly one ~39 MB asset, so there is no multi-part concatenation path here.
+    /// </summary>
+    internal async Task DownloadStemsplitModel(string modelName = "spleeter-2stems-f16")
+    {
+        string destinationPath = Path.Combine(AppFiles.FfmpegFolder, modelName + ".gguf");
+
+        GithubReleaseResponse releaseInfo = await GetLatestReleaseInfo(GithubStemsplitModelApiUrl);
+        if (releaseInfo.Assets.Length == 0)
+        {
+            Logger.Setup(
+                "No assets found for nomercy-stemsplit-models release.",
+                LogEventLevel.Warning
+            );
+            return;
+        }
+
+        if (CheckLocalVersion(releaseInfo, destinationPath, out string version))
+        {
+            _binaryReport.Add($"Stemsplit = {version}");
+            return;
+        }
+
+        await Downloader.DeleteSourceDownload(_storage, destinationPath);
+
+        string assetName = modelName + ".gguf";
+        Asset? asset = releaseInfo.Assets.FirstOrDefault(a =>
+            a.Name.Equals(assetName, StringComparison.OrdinalIgnoreCase)
+        );
+
+        if (asset is null)
+        {
+            Logger.Setup(
+                $"No asset found for model {modelName} in nomercy-stemsplit-models release.",
+                LogEventLevel.Warning
+            );
+            return;
+        }
+
+        string partDestPath = Path.Combine(AppFiles.DependenciesPath, asset.Name);
+        string downloadedPath = await DownloadWithVerificationAsync(
+            GithubStemsplitModelApiUrl,
+            "nomercy-stemsplit-models",
+            asset.BrowserDownloadUrl,
+            partDestPath,
+            releaseInfo,
+            asset.Name,
+            enforceSignedManifest: true
+        );
+
+        await MoveDownloadedModelIntoPlaceAsync(
+            downloadedPath,
+            destinationPath,
+            releaseInfo.PublishedAt,
+            "Stemsplit model"
+        );
     }
 
     internal async Task<string> ConcatenateModelParts(

--- a/tests/NoMercy.Tests.Api/Media/EncoderHardwareControllerTests.cs
+++ b/tests/NoMercy.Tests.Api/Media/EncoderHardwareControllerTests.cs
@@ -293,6 +293,7 @@ public class EncoderHardwareControllerTests
             MissingMuxers: [],
             FpcalcPresent: true,
             WhisperModelPresent: false,
+            StemsplitModelPresent: false,
             TesseractEngTraineddataPresent: true,
             TesseractModelsDirectory: "/models",
             Issues: []

--- a/tests/NoMercy.Tests.Encoder/Errors/RuntimeErrorCatalogTests.cs
+++ b/tests/NoMercy.Tests.Encoder/Errors/RuntimeErrorCatalogTests.cs
@@ -97,6 +97,7 @@ public class RuntimeErrorCatalogTests
     [InlineData("license.unreachable")]
     [InlineData("capability.fpcalc_missing")]
     [InlineData("capability.whisper_missing")]
+    [InlineData("capability.stemsplit_missing")]
     [InlineData("capability.tesseract_model_missing")]
     [InlineData("disc.drive_busy")]
     [InlineData("disc.aacs_cert_missing")]
@@ -155,8 +156,8 @@ public class RuntimeErrorCatalogTests
     // ---- 5. Constant count guard — catches accidental deletions ----------------
 
     [Fact]
-    public void EncoderRuntimeErrorId_declares_exactly_21_constants()
+    public void EncoderRuntimeErrorId_declares_exactly_22_constants()
     {
-        RuntimeErrorIds.Should().HaveCount(21);
+        RuntimeErrorIds.Should().HaveCount(22);
     }
 }

--- a/tests/NoMercy.Tests.Encoder/Profiles/RuleCompleteness/ProfileRuleCompletenessTests.cs
+++ b/tests/NoMercy.Tests.Encoder/Profiles/RuleCompleteness/ProfileRuleCompletenessTests.cs
@@ -124,6 +124,8 @@ public class ProfileRuleCompletenessTests
             "runtime-only: fpcalc binary availability checked at runtime",
         [EncoderRuleId.CapabilityWhisperMissing] =
             "runtime-only: whisper binary availability checked at runtime",
+        [EncoderRuleId.CapabilityStemsplitMissing] =
+            "runtime-only: stemsplit model availability checked at runtime",
         [EncoderRuleId.CapabilityTesseractModelMissing] =
             "runtime-only: tesseract model availability checked at runtime",
 
@@ -495,10 +497,7 @@ public class ProfileRuleCompletenessTests
             ),
             [EncoderRuleId.DrmHttpNotHttps] = MakeProfile(VideoTranscode()) with
             {
-                Drm = new(
-                    "aes-128",
-                    new() { ["key_uri"] = "http://server/key.bin" }
-                ),
+                Drm = new("aes-128", new() { ["key_uri"] = "http://server/key.bin" }),
             },
             [EncoderRuleId.DrmKeyMissing] = MakeProfile(VideoTranscode()) with
             {
@@ -754,17 +753,11 @@ public class ProfileRuleCompletenessTests
             ),
             [EncoderRuleId.DrmHttpNotHttps] = MakeProfile(VideoTranscode()) with
             {
-                Drm = new(
-                    "aes-128",
-                    new() { ["key_uri"] = "https://server/key.bin" }
-                ),
+                Drm = new("aes-128", new() { ["key_uri"] = "https://server/key.bin" }),
             },
             [EncoderRuleId.DrmKeyMissing] = MakeProfile(VideoTranscode()) with
             {
-                Drm = new(
-                    "aes-128",
-                    new() { ["key_uri"] = "https://server/key.bin" }
-                ),
+                Drm = new("aes-128", new() { ["key_uri"] = "https://server/key.bin" }),
             },
         };
 
@@ -801,8 +794,8 @@ public class ProfileRuleCompletenessTests
         count
             .Should()
             .Be(
-                71,
-                "EncoderRuleId currently catalogues 71 rules; "
+                72,
+                "EncoderRuleId currently catalogues 72 rules; "
                     + "if this count changed, update the completeness sets above and this guard"
             );
     }

--- a/tests/NoMercy.Tests.Encoder/Startup/FfmpegCapabilityProbeTests.cs
+++ b/tests/NoMercy.Tests.Encoder/Startup/FfmpegCapabilityProbeTests.cs
@@ -205,6 +205,56 @@ public class FfmpegCapabilityProbeTests
     }
 
     // -------------------------------------------------------------------------
+    // Stemsplit model
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ProbeAsync_emits_CapabilityStemsplitMissing_rule_when_model_absent()
+    {
+        Mock<IFfmpegCapabilities> caps = CapsWithProtocol(false, false);
+        Mock<IProcessRunner> runner = new();
+        Mock<IStorage> storage = new();
+        SetupMuxerOutput(runner, AllMuxersOutput());
+        SetupFpcalc(runner, 0);
+
+        EncoderOptions options = new() { StemsplitModelPath = "/models/spleeter-2stems-f16.gguf" };
+        storage.Setup(s => s.Exists("/models/spleeter-2stems-f16.gguf")).Returns(false);
+        storage
+            .Setup(s => s.Exists(It.Is<string>(p => p != "/models/spleeter-2stems-f16.gguf")))
+            .Returns(false);
+
+        FfmpegCapabilityProbe probe = BuildProbe(caps, runner, storage, options);
+        await probe.ProbeAsync();
+
+        CapabilityReport report = probe.GetCachedReport()!;
+        report.StemsplitModelPresent.Should().BeFalse();
+        report.Issues.Should().Contain(r => r.Id == EncoderRuleId.CapabilityStemsplitMissing);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_returns_StemsplitModelPresent_true_when_model_exists()
+    {
+        Mock<IFfmpegCapabilities> caps = CapsWithProtocol(false, false);
+        Mock<IProcessRunner> runner = new();
+        Mock<IStorage> storage = new();
+        SetupMuxerOutput(runner, AllMuxersOutput());
+        SetupFpcalc(runner, 0);
+
+        EncoderOptions options = new() { StemsplitModelPath = "/models/spleeter-2stems-f16.gguf" };
+        storage.Setup(s => s.Exists("/models/spleeter-2stems-f16.gguf")).Returns(true);
+        storage
+            .Setup(s => s.Exists(It.Is<string>(p => p != "/models/spleeter-2stems-f16.gguf")))
+            .Returns(false);
+
+        FfmpegCapabilityProbe probe = BuildProbe(caps, runner, storage, options);
+        await probe.ProbeAsync();
+
+        CapabilityReport report = probe.GetCachedReport()!;
+        report.StemsplitModelPresent.Should().BeTrue();
+        report.Issues.Should().NotContain(r => r.Id == EncoderRuleId.CapabilityStemsplitMissing);
+    }
+
+    // -------------------------------------------------------------------------
     // Tesseract traineddata
     // -------------------------------------------------------------------------
 

--- a/tests/NoMercy.Tests.Setup/Server/BinariesDownloadMethodsTests.cs
+++ b/tests/NoMercy.Tests.Setup/Server/BinariesDownloadMethodsTests.cs
@@ -739,6 +739,115 @@ public sealed class BinariesDownloadMethodsTests : IDisposable
     }
 
     // -------------------------------------------------------------------------
+    // DownloadStemsplitModel — single-asset, mirrors DownloadWhisperModels'
+    // single-asset branch (no multi-part concatenation for this model).
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task DownloadStemsplitModel_NoAssetsInRelease_DoesNotThrow()
+    {
+        FakeHttpHandler handler = new();
+        handler.RegisterReleaseInfo(
+            "https://api.github.com/repos/NoMercy-Entertainment/nomercy-stemsplit-models/releases/latest",
+            ReleaseWithAssets()
+        );
+
+        Binaries binaries = BuildBinaries(handler);
+        await binaries.DownloadStemsplitModel("spleeter-2stems-f16");
+
+        string destination = Path.Combine(AppFiles.FfmpegFolder, "spleeter-2stems-f16.gguf");
+        Assert.False(File.Exists(destination));
+    }
+
+    [Fact]
+    public async Task DownloadStemsplitModel_AssetPresent_MovesToFfmpegFolderAndStampsCreatedAttribute()
+    {
+        byte[] payload = [.. "stemsplit-model-bytes"u8];
+        string assetUrl = "https://example.com/spleeter-2stems-f16.gguf";
+        DateTimeOffset publishedAt = DateTimeOffset.UtcNow.AddDays(-3);
+
+        FakeHttpHandler handler = new();
+        handler.Register(assetUrl, payload);
+        handler.RegisterReleaseInfo(
+            "https://api.github.com/repos/NoMercy-Entertainment/nomercy-stemsplit-models/releases/latest",
+            ReleaseWithAssets(
+                publishedAt,
+                "v1.0.0",
+                MakeAsset("spleeter-2stems-f16.gguf", assetUrl, payload)
+            )
+        );
+
+        Binaries binaries = BuildBinaries(handler);
+        await binaries.DownloadStemsplitModel("spleeter-2stems-f16");
+
+        string destination = Path.Combine(AppFiles.FfmpegFolder, "spleeter-2stems-f16.gguf");
+        Assert.True(File.Exists(destination));
+        Assert.Equal(payload, await File.ReadAllBytesAsync(destination));
+        Assert.False(
+            File.Exists(Path.Combine(AppFiles.DependenciesPath, "spleeter-2stems-f16.gguf")),
+            "the staging download must be moved, not left behind, at DependenciesPath"
+        );
+
+        // Re-running against the SAME release must now see the model as already
+        // current — CheckLocalVersion reads the CreatedAttribute stamp this branch
+        // must apply.
+        bool alreadyCurrent = binaries.CheckLocalVersion(
+            ReleaseWithAssets(
+                publishedAt,
+                "v1.0.0",
+                MakeAsset("spleeter-2stems-f16.gguf", assetUrl, payload)
+            ),
+            destination,
+            out string _
+        );
+        Assert.True(alreadyCurrent, "DownloadStemsplitModel must stamp CreatedAttribute");
+    }
+
+    [Fact]
+    public async Task DownloadStemsplitModel_NoMatchingAsset_WarnsAndReturnsWithoutThrowing()
+    {
+        FakeHttpHandler handler = new();
+        handler.RegisterReleaseInfo(
+            "https://api.github.com/repos/NoMercy-Entertainment/nomercy-stemsplit-models/releases/latest",
+            ReleaseWithAssets(MakeAsset("unrelated-file.gguf", "https://example.com/unrelated"))
+        );
+
+        Binaries binaries = BuildBinaries(handler);
+        await binaries.DownloadStemsplitModel("spleeter-2stems-f16");
+
+        string destination = Path.Combine(AppFiles.FfmpegFolder, "spleeter-2stems-f16.gguf");
+        Assert.False(File.Exists(destination));
+    }
+
+    [Fact]
+    public async Task DownloadStemsplitModel_AlreadyCurrentVersion_SkipsDownload()
+    {
+        Directory.CreateDirectory(AppFiles.FfmpegFolder);
+        string destination = Path.Combine(AppFiles.FfmpegFolder, "spleeter-2stems-f16.gguf");
+        await File.WriteAllTextAsync(destination, "existing-stemsplit-model");
+        // CheckLocalVersion compares file LastModified against the release's PublishedAt —
+        // touch the file to a time after the release so it reads as already current.
+        File.SetLastWriteTimeUtc(destination, DateTime.UtcNow);
+
+        FakeHttpHandler handler = new();
+        handler.RegisterReleaseInfo(
+            "https://api.github.com/repos/NoMercy-Entertainment/nomercy-stemsplit-models/releases/latest",
+            ReleaseWithAssets(
+                DateTimeOffset.UtcNow.AddDays(-10),
+                "v1.0.0",
+                MakeAsset("spleeter-2stems-f16.gguf", "https://example.com/should-not-be-fetched")
+            )
+        );
+
+        Binaries binaries = BuildBinaries(handler);
+        string originalContent = await File.ReadAllTextAsync(destination);
+
+        await binaries.DownloadStemsplitModel("spleeter-2stems-f16");
+
+        Assert.Equal(originalContent, await File.ReadAllTextAsync(destination));
+    }
+
+    // -------------------------------------------------------------------------
     // DownloadTesseractData — per-language loop
     // -------------------------------------------------------------------------
 
@@ -773,6 +882,18 @@ public sealed class BinariesDownloadMethodsTests : IDisposable
         await binaries.DownloadTesseractData(["eng"]);
 
         Assert.False(File.Exists(Path.Combine(AppFiles.TesseractModelsFolder, "eng.traineddata")));
+    }
+
+    // -------------------------------------------------------------------------
+    // AppFiles.StemsplitModelPath — shape only, mirrors AppFiles.WhisperModelPath
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void AppFiles_StemsplitModelPath_PointsAtFfmpegFolderWithGgufExtension()
+    {
+        string expected = Path.Combine(AppFiles.FfmpegFolder, AppFiles.StemsplitModel + ".gguf");
+        Assert.Equal(expected, AppFiles.StemsplitModelPath);
+        Assert.Equal("spleeter-2stems-f16", AppFiles.StemsplitModel);
     }
 
     // -------------------------------------------------------------------------
@@ -960,6 +1081,7 @@ public sealed class BinariesDownloadMethodsTests : IDisposable
                 "https://api.github.com/repos/NoMercy-Entertainment/nomercy-ffmpeg/releases/latest",
                 "https://api.github.com/repos/NoMercy-Entertainment/nomercy-tesseract/releases/latest",
                 "https://api.github.com/repos/NoMercy-Entertainment/nomercy-whisper-models/releases/latest",
+                "https://api.github.com/repos/NoMercy-Entertainment/nomercy-stemsplit-models/releases/latest",
             }
         )
             handler.RegisterReleaseInfo(apiUrl, ReleaseWithAssets());
@@ -1035,6 +1157,10 @@ public sealed class BinariesDownloadMethodsTests : IDisposable
             "https://api.github.com/repos/NoMercy-Entertainment/nomercy-whisper-models/releases/latest",
             ReleaseWithAssets()
         );
+        handler.RegisterReleaseInfo(
+            "https://api.github.com/repos/NoMercy-Entertainment/nomercy-stemsplit-models/releases/latest",
+            ReleaseWithAssets()
+        );
         foreach (
             string listUrl in new[]
             {
@@ -1103,6 +1229,7 @@ public sealed class BinariesDownloadMethodsTests : IDisposable
                 "https://api.github.com/repos/NoMercy-Entertainment/nomercy-ffmpeg/releases/latest",
                 "https://api.github.com/repos/NoMercy-Entertainment/nomercy-tesseract/releases/latest",
                 "https://api.github.com/repos/NoMercy-Entertainment/nomercy-whisper-models/releases/latest",
+                "https://api.github.com/repos/NoMercy-Entertainment/nomercy-stemsplit-models/releases/latest",
             }
         )
             handler.RegisterReleaseInfo(apiUrl, ReleaseWithAssets());


### PR DESCRIPTION
nomercy-ffmpeg v1.0.40+ ships the `stemsplit` filter (Spleeter 2stems on ggml), which needs a 39 MB GGUF at runtime. This makes the server fetch and report that model the way it already handles the whisper model. Nothing consumes it yet; the automix analysis job will (R1.3 of the automix roadmap).

## What changes

- `Binaries.DownloadStemsplitModel` downloads `spleeter-2stems-f16.gguf` from the latest release of [nomercy-stemsplit-models](https://github.com/NoMercy-Entertainment/nomercy-stemsplit-models) (a signed manifest, like the whisper models), checks the local copy against the release date, verifies the hash, and places the file beside the ffmpeg binary. Called in `DownloadAll` right after the whisper model. The single-asset move-into-place tail is shared with the whisper download (`MoveDownloadedModelIntoPlaceAsync`); the whisper behaviour is unchanged and still covered by its own tests.
- `AppFiles.StemsplitModel` / `StemsplitModelPath` and `EncoderOptions.StemsplitModelPath`, wired in `ServiceConfiguration.Core`. The model sits next to ffmpeg on purpose: on Windows a drive-letter colon splits the `model=` filter argument, so the analysis job will run ffmpeg with the ffmpeg folder as working directory and pass the bare file name.
- `FfmpegCapabilityProbe` reports `StemsplitModelPresent`, logs it, and lists a warning-severity rule with a remediation when the file is missing. Nothing gates start-up or encoder readiness on it.
- New rule id documented in `docs/encoder-errors.md`; the two catalogue-count guards updated (21 → 22, 71 → 72). One test file picked up csharpier reformatting of two unrelated `Drm = new(...)` call sites.

## Tests

- Setup: download happy path, missing asset, no matching asset, already-current short-circuit, `AppFiles` path shape. Encoder: probe present / absent.
- `dotnet build NoMercy.Server.sln`: 0 errors, 0 warnings. `dotnet test`: Setup 662, Service 180, Api 14 (targeted), Encoder 5167 passed; the 17 ffmpeg integration cases that need the NoMercy build were not run on this machine.

Tracked as issue #3 of the automix plugin's roadmap (Forgejo).
