### PR TITLE
feat(music): audio analysis runs with every music import and rescan

### DIFF
--- a/src/NoMercy.Api/Controllers/V1/Dashboard/Admin/TasksController.cs
+++ b/src/NoMercy.Api/Controllers/V1/Dashboard/Admin/TasksController.cs
@@ -35,6 +35,7 @@ using NoMercy.Encoder.Execution;
 using NoMercy.Encoder.Profiles;
 using NoMercy.Events;
 using NoMercy.Events.Encoding;
+using NoMercy.MediaProcessing.AudioAnalysis;
 using NoMercy.MediaProcessing.Jobs.MediaJobs;
 using NoMercy.MediaProcessing.Jobs.MediaJobs.Support;
 using NoMercy.MediaProcessing.Jobs.SubtitleJobs;
@@ -60,7 +61,8 @@ public class TasksController(
     IDbContextFactory<QueueContext> queueContextFactory,
     IEncoderProcessRegistry processRegistry,
     ProcessThrottle processThrottle,
-    IEncodingHistoryRepository historyRepository
+    IEncodingHistoryRepository historyRepository,
+    IAudioAnalysisScheduler audioAnalysisScheduler
 ) : BaseController
 {
     [HttpGet]
@@ -1151,6 +1153,33 @@ public class TasksController(
                 Failed = failed,
             }
         );
+    }
+
+    /// <summary>
+    /// Queues the outstanding audio analysis for every music library that wants
+    /// it, right now.
+    /// <para>
+    /// The extra, not the way in: analysis already runs as part of every import
+    /// and rescan, and the hourly sweep catches what those missed. This is for
+    /// the operator who does not want to wait for either.
+    /// </para>
+    /// </summary>
+    [HttpPost]
+    [Route("audio-analysis/sweep")]
+    public async Task<IActionResult> AudioAnalysisSweep()
+    {
+        // Its own context, not the scoped one this controller is handed, for
+        // the same reason AudioAnalysisStatus takes one: the shared instance is
+        // already serving this request.
+        await using MediaContext libraryContext = await mediaContextFactory.CreateDbContextAsync();
+
+        List<Ulid> libraryIds = await AudioAnalysisQueries
+            .LibrariesToAnalyze(libraryContext)
+            .ToListAsync();
+
+        int queued = await audioAnalysisScheduler.QueueAsync(libraryIds);
+
+        return Ok(new { queued });
     }
 
     /// <summary>

--- a/src/NoMercy.Database/Contexts/MediaContext.cs
+++ b/src/NoMercy.Database/Contexts/MediaContext.cs
@@ -186,6 +186,19 @@ public class MediaContext : DbContext
                 .ToTable(tb => tb.HasTrigger($"update_{tableName}_updated_at"));
         }
 
+        // Audio analysis is part of every music import, so a library that says
+        // nothing about it gets it. The sentinel — the value EF reads as "not
+        // set" and leaves out of the INSERT — is that same "on", which is what
+        // keeps the opt-out real: an explicit "off" differs from it and is
+        // written, instead of being dropped and replaced by the store default.
+        // EF infers the sentinel from the property initializer on Library, but
+        // the opt-out is too important to rest on an inference.
+        modelBuilder
+            .Entity<Library>()
+            .Property(library => library.AnalyzeAudio)
+            .HasDefaultValue(true)
+            .HasSentinel(true);
+
         // Explicit cascade for direct entity → Library FKs. These use ConfigurationSource.Explicit
         // so they cannot be reset by convention re-processing (the mutation loop above only sets
         // ConventionSource and gets overridden when HasTrigger calls re-process those entities).

--- a/src/NoMercy.Database/Migrations/20260909230447_AnalyzeAudioDefaultsOn.Designer.cs
+++ b/src/NoMercy.Database/Migrations/20260909230447_AnalyzeAudioDefaultsOn.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NoMercy.Database;
 
@@ -10,9 +11,11 @@ using NoMercy.Database;
 namespace NoMercy.Database.Migrations
 {
     [DbContext(typeof(MediaContext))]
-    partial class MediaContextModelSnapshot : ModelSnapshot
+    [Migration("20260909230447_AnalyzeAudioDefaultsOn")]
+    partial class AnalyzeAudioDefaultsOn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NoMercy.Database/Migrations/20260909230447_AnalyzeAudioDefaultsOn.cs
+++ b/src/NoMercy.Database/Migrations/20260909230447_AnalyzeAudioDefaultsOn.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NoMercy.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AnalyzeAudioDefaultsOn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "AnalyzeAudio",
+                table: "Libraries",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldType: "INTEGER");
+
+            // A store default only reaches rows written from now on. Every music
+            // library that already exists was created while the column could
+            // only be off — nothing in the API or the UI could ever set it — so
+            // an existing row means "never asked", not "said no". Turning them
+            // on is what makes the promise reach installs that predate this.
+            migrationBuilder.Sql("UPDATE Libraries SET AnalyzeAudio = 1 WHERE Type = 'music';");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "AnalyzeAudio",
+                table: "Libraries",
+                type: "INTEGER",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldType: "INTEGER",
+                oldDefaultValue: true);
+        }
+    }
+}

--- a/src/NoMercy.Database/Models/Libraries/Library.cs
+++ b/src/NoMercy.Database/Models/Libraries/Library.cs
@@ -56,8 +56,12 @@ public class Library : Timestamps
     [JsonProperty("order")]
     public int? Order { get; set; }
 
+    /// <summary>
+    /// The opt-out for audio analysis. On by default, because analysis is part
+    /// of every music import rather than a switch a user has to find.
+    /// </summary>
     [JsonProperty("analyze_audio")]
-    public bool AnalyzeAudio { get; set; }
+    public bool AnalyzeAudio { get; set; } = true;
 
     [JsonProperty("perfect_subtitle_match")]
     public bool PerfectSubtitleMatch { get; set; }

--- a/src/NoMercy.MediaProcessing/AudioAnalysis/AudioAnalysisDispatch.cs
+++ b/src/NoMercy.MediaProcessing/AudioAnalysis/AudioAnalysisDispatch.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using NoMercy.Database.Models.Libraries;
+using NoMercy.MediaProcessing.Jobs.MediaJobs;
+using NoMercyQueue.Core.Interfaces;
+
+namespace NoMercy.MediaProcessing.AudioAnalysis;
+
+/// <summary>
+/// The one line an import runs for every track it stores. A small named type
+/// rather than three lines inside the import loop, because the rule it carries
+/// — the library's opt-out — has to read the same wherever a track is written.
+/// </summary>
+public static class AudioAnalysisDispatch
+{
+    /// <summary>
+    /// Queues analysis for a track an import has just written, unless the
+    /// library opted out.
+    /// <para>
+    /// This is the layer that reaches a brand-new library. The scan-completed
+    /// hook cannot: a music scan only dispatches the import jobs and then
+    /// announces itself, so no <c>Track</c> row exists yet when it runs.
+    /// </para>
+    /// <para>
+    /// Costs nothing on a rescan. The queue drops an identical payload, and
+    /// <see cref="MusicAnalysisJob" /> returns immediately for a track that
+    /// already carries a verdict from the current analyzer — so a rescan of an
+    /// analysed library is one cheap no-op per track, never a re-analysis.
+    /// </para>
+    /// </summary>
+    public static void AfterStore(IJobDispatcher dispatcher, Library library, Guid trackId)
+    {
+        if (!library.AnalyzeAudio)
+        {
+            return;
+        }
+
+        dispatcher.Dispatch(new MusicAnalysisJob { TrackId = trackId });
+    }
+}

--- a/src/NoMercy.MediaProcessing/AudioAnalysis/AudioAnalysisQueries.cs
+++ b/src/NoMercy.MediaProcessing/AudioAnalysis/AudioAnalysisQueries.cs
@@ -16,11 +16,26 @@ using NoMercy.Database.Models.Music;
 namespace NoMercy.MediaProcessing.AudioAnalysis;
 
 /// <summary>
-/// The one query the sweep runs, in one place so a test can assert its plan
-/// rather than assert a copy of it.
+/// The queries the analysis sweep runs, in one place so a test can assert their
+/// plan rather than assert a copy of it.
 /// </summary>
 public static class AudioAnalysisQueries
 {
+    private const string MusicLibraryType = "music";
+
+    /// <summary>
+    /// The music libraries that want their audio analyzed. The hourly sweep,
+    /// the hook that fires when a scan finishes and the dashboard's run-now
+    /// button all mean this same set, so none of them spells it out again.
+    /// </summary>
+    public static IQueryable<Ulid> LibrariesToAnalyze(MediaContext context)
+    {
+        return context
+            .Libraries.AsNoTracking()
+            .Where(library => library.AnalyzeAudio && library.Type == MusicLibraryType)
+            .Select(library => library.Id);
+    }
+
     /// <summary>
     /// Tracks in the named libraries that carry no verdict from this analyzer
     /// version — no row at all, a row from an older analyzer, or a row left

--- a/src/NoMercy.MediaProcessing/AudioAnalysis/IAudioAnalysisScheduler.cs
+++ b/src/NoMercy.MediaProcessing/AudioAnalysis/IAudioAnalysisScheduler.cs
@@ -1,0 +1,35 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.MediaProcessing.AudioAnalysis;
+
+/// <summary>
+/// Puts every track in the named libraries that still lacks a verdict from the
+/// current analyzer onto the music queue.
+/// <para>
+/// The hourly sweep, the hook that fires when a library scan finishes and the
+/// dashboard's run-now button all ask the same question, so they all ask it
+/// here. The contract lives beside the query it runs rather than beside the
+/// implementation, because the API layer calls it and never references the
+/// host.
+/// </para>
+/// </summary>
+public interface IAudioAnalysisScheduler
+{
+    /// <summary>
+    /// Queues the outstanding tracks of the given libraries and answers how
+    /// many jobs were dispatched. An empty set queues nothing.
+    /// </summary>
+    Task<int> QueueAsync(
+        IReadOnlyCollection<Ulid> libraryIds,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/NoMercy.MediaProcessing/Jobs/MediaJobs/AudioImportJob.cs
+++ b/src/NoMercy.MediaProcessing/Jobs/MediaJobs/AudioImportJob.cs
@@ -17,6 +17,7 @@ using NoMercy.Database.Models.Libraries;
 using NoMercy.Events;
 using NoMercy.Events.Library;
 using NoMercy.MediaProcessing.Artists;
+using NoMercy.MediaProcessing.AudioAnalysis;
 using NoMercy.MediaProcessing.Common;
 using NoMercy.MediaProcessing.Images;
 using NoMercy.MediaProcessing.Jobs.Dto;
@@ -547,6 +548,14 @@ public class AudioImportJob : AbstractMusicFolderJob
                 folderLibrary,
                 coverPalette
             );
+
+            // Analysis is part of the import, not a switch to find afterwards.
+            // It belongs here rather than on LibraryScanCompletedEvent: a music
+            // scan dispatches these import jobs and then announces itself, so at
+            // that moment no Track row exists yet and a brand-new library would
+            // wait for the hourly sweep. The library's own AnalyzeAudio is the
+            // opt-out, the same way AutoEncodeOnScan gates the encode below.
+            AudioAnalysisDispatch.AfterStore(jobDispatcher, albumLibrary, musicBrainzTrack.Id);
 
             // Same per-library opt-in AutoEncodeSubscriber already enforces for
             // video — a preset assignment is "the preset to use when I encode",

--- a/src/NoMercy.Service/Configuration/ServiceConfiguration.Core.cs
+++ b/src/NoMercy.Service/Configuration/ServiceConfiguration.Core.cs
@@ -677,6 +677,10 @@ public static partial class ServiceConfiguration
         services.AddHostedService<EncodingNotificationSubscriber>();
         services.AddHostedService<AutoEncodeSubscriber>();
         services.AddHostedService<IntroDetectionSubscriber>();
+        // Analysis is part of every music import and rescan, not a switch a
+        // user has to find. Same shape as AutoEncodeSubscriber above: a hosted
+        // service that subscribes on start and unsubscribes on stop.
+        services.AddHostedService<Subscribers.AudioAnalysisSubscriber>();
         services.AddHostedService<PaletteBackfillStartupService>();
         services.AddHostedService<AnimeEnrichmentBackfillStartupService>();
         services.AddHostedService<MusicQueryWarmupService>();

--- a/src/NoMercy.Service/Configuration/ServiceConfiguration.Core.cs
+++ b/src/NoMercy.Service/Configuration/ServiceConfiguration.Core.cs
@@ -646,6 +646,14 @@ public static partial class ServiceConfiguration
             MediaProcessing.AudioAnalysis.FfmpegAudioAnalyzer
         >();
 
+        // One scheduler for every path that wants a library analyzed: the hourly
+        // sweep, the hook that fires when a scan finishes, and the dashboard's
+        // run-now button. It holds nothing but a context factory, so a singleton.
+        services.AddSingleton<
+            MediaProcessing.AudioAnalysis.IAudioAnalysisScheduler,
+            Jobs.AudioAnalysisScheduler
+        >();
+
         // Transcode-scoped IStorage — paths are relative to AppFiles.TranscodePath.
         // HomeController uses this so it can pass scope-relative paths (Rule 1 of
         // the IStorage path contract) instead of Path.Combine(TranscodePath, ...).

--- a/src/NoMercy.Service/Jobs/AudioAnalysisScheduler.cs
+++ b/src/NoMercy.Service/Jobs/AudioAnalysisScheduler.cs
@@ -1,0 +1,110 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Microsoft.EntityFrameworkCore;
+using NoMercy.Database;
+using NoMercy.MediaProcessing.AudioAnalysis;
+using NoMercy.MediaProcessing.Jobs.MediaJobs;
+using NoMercyQueue.Core.Interfaces;
+
+namespace NoMercy.Service.Jobs;
+
+/// <inheritdoc />
+public class AudioAnalysisScheduler : IAudioAnalysisScheduler
+{
+    /// <summary>
+    /// Read per page. A large library must not be materialized into memory in
+    /// one pass; the tracks are handed to the queue a page at a time.
+    /// </summary>
+    private const int BatchSize = 500;
+
+    private readonly IJobDispatcher _dispatcher;
+    private readonly IAudioAnalyzer _analyzer;
+    private readonly IDbContextFactory<MediaContext> _contextFactory;
+    private readonly ILogger<AudioAnalysisScheduler> _logger;
+
+    public AudioAnalysisScheduler(
+        IJobDispatcher dispatcher,
+        IAudioAnalyzer analyzer,
+        IDbContextFactory<MediaContext> contextFactory,
+        ILogger<AudioAnalysisScheduler> logger
+    )
+    {
+        _dispatcher = dispatcher;
+        _analyzer = analyzer;
+        _contextFactory = contextFactory;
+        _logger = logger;
+    }
+
+    public async Task<int> QueueAsync(
+        IReadOnlyCollection<Ulid> libraryIds,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (libraryIds.Count == 0)
+        {
+            return 0;
+        }
+
+        await using MediaContext mediaContext = await _contextFactory.CreateDbContextAsync(
+            cancellationToken
+        );
+
+        int version = _analyzer.Version;
+        int queued = 0;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Skip past what this run already queued rather than re-reading the
+            // first page: dispatching writes no verdict, so the same page would
+            // come back for ever and the rest of the library would never be
+            // reached. The queue's payload dedup absorbs the overlap when a
+            // worker finishes a track mid-run.
+            List<Guid> trackIds = await AudioAnalysisQueries
+                .TracksNeedingAnalysis(mediaContext, libraryIds, version)
+                .OrderBy(trackId => trackId)
+                .Skip(queued)
+                .Take(BatchSize)
+                .ToListAsync(cancellationToken);
+
+            if (trackIds.Count == 0)
+            {
+                break;
+            }
+
+            foreach (Guid trackId in trackIds)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                _dispatcher.Dispatch(new MusicAnalysisJob { TrackId = trackId });
+            }
+
+            queued += trackIds.Count;
+
+            if (trackIds.Count < BatchSize)
+            {
+                break;
+            }
+        }
+
+        if (queued > 0)
+        {
+            _logger.LogInformation(
+                "Audio analysis queued {Queued} track(s) across {Libraries} library(ies)",
+                [queued, libraryIds.Count]
+            );
+        }
+
+        return queued;
+    }
+}

--- a/src/NoMercy.Service/Jobs/AudioAnalysisSweepCronJob.cs
+++ b/src/NoMercy.Service/Jobs/AudioAnalysisSweepCronJob.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 //  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
 //
 //  This file is part of NoMercy MediaServer, source-available software (NOT open
@@ -11,54 +11,38 @@
 
 using Microsoft.EntityFrameworkCore;
 using NoMercy.Database;
-using NoMercy.Database.Models.Music;
 using NoMercy.MediaProcessing.AudioAnalysis;
-using NoMercy.MediaProcessing.Jobs.MediaJobs;
 using NoMercyQueue.Core;
 using NoMercyQueue.Core.Interfaces;
 
 namespace NoMercy.Service.Jobs;
 
 /// <summary>
-/// Queues audio analysis for tracks in libraries that asked for it.
+/// The safety net under the import hook: every hour it re-asks which tracks
+/// still lack a current verdict, across every music library that wants one.
 /// <para>
-/// A sweep rather than a hook on import, because it covers the library a user
-/// already had at the moment they turn the setting on, and it re-covers
-/// everything when the analyzer version changes. Both of those are the same
-/// question — "which tracks lack a current verdict" — and one mechanism answers
-/// it.
+/// Analysis is queued when a library scan finishes, but the sweep still earns
+/// its place — it covers the library a user already had at the moment they
+/// turn the setting on, and it re-covers everything when the analyzer version
+/// changes. That is the same question the scan hook asks, so both ask it
+/// through <see cref="IAudioAnalysisScheduler" />.
 /// </para>
 /// </summary>
 public class AudioAnalysisSweepCronJob : ICronJobExecutor
 {
-    /// <summary>
-    /// Queued per run. A large library must not put sixty thousand rows on the
-    /// queue in one pass and bury every other job behind them; the next run
-    /// picks up where this one stopped.
-    /// </summary>
-    private const int BatchSize = 500;
-
-    private const string MusicLibraryType = "music";
-
-    private readonly IJobDispatcher _dispatcher;
-    private readonly IAudioAnalyzer _analyzer;
+    private readonly IAudioAnalysisScheduler _scheduler;
     private readonly IDbContextFactory<MediaContext> _contextFactory;
-    private readonly ILogger<AudioAnalysisSweepCronJob> _logger;
 
     public string CronExpression => new CronExpressionBuilder().Hourly();
     public string JobName => "Audio Analysis Sweep";
 
     public AudioAnalysisSweepCronJob(
-        IJobDispatcher dispatcher,
-        IAudioAnalyzer analyzer,
-        IDbContextFactory<MediaContext> contextFactory,
-        ILogger<AudioAnalysisSweepCronJob> logger
+        IAudioAnalysisScheduler scheduler,
+        IDbContextFactory<MediaContext> contextFactory
     )
     {
-        _dispatcher = dispatcher;
-        _analyzer = analyzer;
+        _scheduler = scheduler;
         _contextFactory = contextFactory;
-        _logger = logger;
     }
 
     public async Task ExecuteAsync(string parameters, CancellationToken cancellationToken = default)
@@ -67,10 +51,8 @@ public class AudioAnalysisSweepCronJob : ICronJobExecutor
             cancellationToken
         );
 
-        List<Ulid> libraryIds = await mediaContext
-            .Libraries.AsNoTracking()
-            .Where(library => library.AnalyzeAudio && library.Type == MusicLibraryType)
-            .Select(library => library.Id)
+        List<Ulid> libraryIds = await AudioAnalysisQueries
+            .LibrariesToAnalyze(mediaContext)
             .ToListAsync(cancellationToken);
 
         if (libraryIds.Count == 0)
@@ -78,28 +60,6 @@ public class AudioAnalysisSweepCronJob : ICronJobExecutor
             return;
         }
 
-        int version = _analyzer.Version;
-
-        List<Guid> trackIds = await AudioAnalysisQueries
-            .TracksNeedingAnalysis(mediaContext, libraryIds, version)
-            .Take(BatchSize)
-            .ToListAsync(cancellationToken);
-
-        if (trackIds.Count == 0)
-        {
-            return;
-        }
-
-        foreach (Guid trackId in trackIds)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            _dispatcher.Dispatch(new MusicAnalysisJob { TrackId = trackId });
-        }
-
-        _logger.LogInformation(
-            "Audio analysis sweep queued {Queued} track(s) across {Libraries} library(ies)",
-            [trackIds.Count, libraryIds.Count]
-        );
+        await _scheduler.QueueAsync(libraryIds, cancellationToken);
     }
 }

--- a/src/NoMercy.Service/Jobs/AudioAnalysisSweepCronJob.cs
+++ b/src/NoMercy.Service/Jobs/AudioAnalysisSweepCronJob.cs
@@ -18,14 +18,18 @@ using NoMercyQueue.Core.Interfaces;
 namespace NoMercy.Service.Jobs;
 
 /// <summary>
-/// The safety net under the import hook: every hour it re-asks which tracks
-/// still lack a current verdict, across every music library that wants one.
+/// The last of the three layers that keep a music library analysed, and the
+/// only one that runs unprompted: every hour it re-asks which tracks still lack
+/// a current verdict, across every music library that wants one.
 /// <para>
-/// Analysis is queued when a library scan finishes, but the sweep still earns
-/// its place — it covers the library a user already had at the moment they
-/// turn the setting on, and it re-covers everything when the analyzer version
-/// changes. That is the same question the scan hook asks, so both ask it
-/// through <see cref="IAudioAnalysisScheduler" />.
+/// The import queues each track it stores
+/// (<see cref="NoMercy.MediaProcessing.AudioAnalysis.AudioAnalysisDispatch" />)
+/// and <see cref="Subscribers.AudioAnalysisSubscriber" /> queues the tracks that
+/// were already there when a scan finished. The sweep is what catches whatever
+/// those two missed — a queue that was drained before a worker got to a job, a
+/// library whose owner turned the setting on without rescanning, an analyzer
+/// version bump. It is the same question all three ask, through
+/// <see cref="IAudioAnalysisScheduler" />.
 /// </para>
 /// </summary>
 public class AudioAnalysisSweepCronJob : ICronJobExecutor

--- a/src/NoMercy.Service/Subscribers/AudioAnalysisSubscriber.cs
+++ b/src/NoMercy.Service/Subscribers/AudioAnalysisSubscriber.cs
@@ -18,14 +18,23 @@ using NoMercy.MediaProcessing.AudioAnalysis;
 namespace NoMercy.Service.Subscribers;
 
 /// <summary>
-/// Queues audio analysis for a music library the moment its scan finishes, so
-/// analysis is part of every import and rescan rather than something a user has
-/// to go and find.
+/// The middle of the three layers that keep a music library analysed: the one
+/// that covers the tracks a scan did not create.
+/// <para>
+/// The import queues each track it stores
+/// (<see cref="NoMercy.MediaProcessing.AudioAnalysis.AudioAnalysisDispatch" />),
+/// and that is what reaches a brand-new library — this hook cannot, because a
+/// music scan dispatches the import jobs and then announces itself, so no
+/// <c>Track</c> row exists yet when it runs. What it does reach is everything
+/// that was already there: a rescan that stored nothing new, a library whose
+/// owner has only just turned the setting on, an analyzer version bump. The
+/// hourly <see cref="Jobs.AudioAnalysisSweepCronJob" /> is the safety net under
+/// both.
+/// </para>
 /// <para>
 /// Only the trigger lives here. Which tracks still need a verdict is
-/// <see cref="IAudioAnalysisScheduler" />'s question, and the hourly
-/// <see cref="Jobs.AudioAnalysisSweepCronJob" /> asks the same one for the
-/// library a user already had.
+/// <see cref="IAudioAnalysisScheduler" />'s question, and every layer asks it
+/// the same way.
 /// </para>
 /// <para>
 /// The opt-out is <c>Library.AnalyzeAudio</c>, which is on by default for music

--- a/src/NoMercy.Service/Subscribers/AudioAnalysisSubscriber.cs
+++ b/src/NoMercy.Service/Subscribers/AudioAnalysisSubscriber.cs
@@ -1,0 +1,119 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Microsoft.EntityFrameworkCore;
+using NoMercy.Database;
+using NoMercy.Events;
+using NoMercy.Events.Library;
+using NoMercy.MediaProcessing.AudioAnalysis;
+
+namespace NoMercy.Service.Subscribers;
+
+/// <summary>
+/// Queues audio analysis for a music library the moment its scan finishes, so
+/// analysis is part of every import and rescan rather than something a user has
+/// to go and find.
+/// <para>
+/// Only the trigger lives here. Which tracks still need a verdict is
+/// <see cref="IAudioAnalysisScheduler" />'s question, and the hourly
+/// <see cref="Jobs.AudioAnalysisSweepCronJob" /> asks the same one for the
+/// library a user already had.
+/// </para>
+/// <para>
+/// The opt-out is <c>Library.AnalyzeAudio</c>, which is on by default for music
+/// libraries.
+/// </para>
+/// </summary>
+public class AudioAnalysisSubscriber(
+    IEventBus eventBus,
+    IAudioAnalysisScheduler scheduler,
+    IDbContextFactory<MediaContext> contextFactory,
+    ILogger<AudioAnalysisSubscriber> logger
+) : IHostedService
+{
+    private const string MusicLibraryType = "music";
+
+    private readonly List<IDisposable> _subscriptions = [];
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _subscriptions.Add(eventBus.Subscribe<LibraryScanCompletedEvent>(OnLibraryScanCompleted));
+
+        logger.LogInformation("Audio analysis subscriber active");
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        foreach (IDisposable subscription in _subscriptions)
+        {
+            try
+            {
+                subscription.Dispose();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Could not dispose the audio analysis subscription");
+            }
+        }
+
+        _subscriptions.Clear();
+
+        return Task.CompletedTask;
+    }
+
+    internal async Task OnLibraryScanCompleted(
+        LibraryScanCompletedEvent @event,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            await using MediaContext mediaContext = await contextFactory.CreateDbContextAsync(
+                cancellationToken
+            );
+
+            bool wantsAnalysis = await mediaContext
+                .Libraries.AsNoTracking()
+                .AnyAsync(
+                    library =>
+                        library.Id == @event.LibraryId
+                        && library.Type == MusicLibraryType
+                        && library.AnalyzeAudio,
+                    cancellationToken
+                );
+
+            if (!wantsAnalysis)
+            {
+                return;
+            }
+
+            int queued = await scheduler.QueueAsync([@event.LibraryId], cancellationToken);
+
+            logger.LogInformation(
+                "Audio analysis queued {Queued} track(s) after the scan of {LibraryName}",
+                [queued, @event.LibraryName]
+            );
+        }
+        catch (Exception ex)
+        {
+            // A scan that finished is a success the user can see. Losing the
+            // analysis that should follow it is a smaller failure than losing
+            // the scan, so it stays inside this handler.
+            logger.LogError(
+                ex,
+                "Audio analysis could not be queued after the scan of {LibraryName}",
+                @event.LibraryName
+            );
+        }
+    }
+}

--- a/tests/NoMercy.Tests.Api/Contracts/RouteContractSnapshotTests.cs
+++ b/tests/NoMercy.Tests.Api/Contracts/RouteContractSnapshotTests.cs
@@ -385,6 +385,7 @@ public class RouteContractSnapshotTests : IClassFixture<NoMercyApiFactory>
         "POST api/v{version:apiVersion}/dashboard/storage/mkdir [StorageBrowser.Mkdir]",
         "POST api/v{version:apiVersion}/dashboard/storage/probe [StorageBrowser.Probe]",
         "POST api/v{version:apiVersion}/dashboard/tasks [Tasks.Store]",
+        "POST api/v{version:apiVersion}/dashboard/tasks/audio-analysis/sweep [Tasks.AudioAnalysisSweep]",
         "POST api/v{version:apiVersion}/dashboard/tasks/failed/retry [Tasks.RetryFailedJobs]",
         "POST api/v{version:apiVersion}/dashboard/tasks/failed/retry/{id:long?} [Tasks.RetryFailedJobs]",
         "POST api/v{version:apiVersion}/dashboard/tasks/pause-queue [Tasks.PauseEncoderQueue]",

--- a/tests/NoMercy.Tests.Api/Music/TrackAudioAnalysisEndpointTests.cs
+++ b/tests/NoMercy.Tests.Api/Music/TrackAudioAnalysisEndpointTests.cs
@@ -12,6 +12,8 @@
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using NoMercy.Database;
 using NoMercy.Tests.Api.Infrastructure;
 using Xunit;
 
@@ -26,6 +28,7 @@ namespace NoMercy.Tests.Api.Music;
 public class TrackAudioAnalysisEndpointTests : IClassFixture<NoMercyApiFactory>
 {
     private const string AnalysisRoute = "/api/v1/music/tracks/analysis";
+    private const string SweepRoute = "/api/v1/dashboard/tasks/audio-analysis/sweep";
 
     private readonly HttpClient _owner;
     private readonly HttpClient _anonymous;
@@ -85,6 +88,40 @@ public class TrackAudioAnalysisEndpointTests : IClassFixture<NoMercyApiFactory>
         doc.RootElement.GetProperty("analyzed").GetInt32().Should().BeGreaterThanOrEqualTo(0);
         doc.RootElement.GetProperty("failed").GetInt32().Should().BeGreaterThanOrEqualTo(0);
         doc.RootElement.TryGetProperty("paused", out _).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The button that says "do it now". Analysis already happens on every
+    /// import and once an hour after that, so this is the extra, not the way
+    /// in — but it has to actually reach the queue, which is why the assertion
+    /// is on the tracks the seeded music library owns rather than on a 200.
+    /// </summary>
+    [Fact]
+    public async Task AudioAnalysisSweep_QueuesTheSeededMusicLibrary()
+    {
+        HttpResponseMessage response = await _owner.PostAsync(SweepRoute, JsonBody(new { }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("queued").GetInt32().Should().BeGreaterThanOrEqualTo(2);
+
+        await using QueueContext queueContext = new();
+        bool queuedAnAnalysisJob = await queueContext
+            .QueueJobs.AsNoTracking()
+            .AnyAsync(job => job.Payload.Contains("MusicAnalysisJob"));
+
+        queuedAnAnalysisJob.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AudioAnalysisSweep_RejectsAnonymousCallers()
+    {
+        HttpResponseMessage response = await _anonymous.PostAsync(SweepRoute, JsonBody(new { }));
+
+        response
+            .StatusCode.Should()
+            .BeOneOf([HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden]);
     }
 
     [Fact]

--- a/tests/NoMercy.Tests.Database/Migrations/AnalyzeAudioDefaultsOnMigrationTests.cs
+++ b/tests/NoMercy.Tests.Database/Migrations/AnalyzeAudioDefaultsOnMigrationTests.cs
@@ -1,0 +1,181 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NoMercy.Database;
+using NoMercy.Database.Models.Libraries;
+
+namespace NoMercy.Tests.Database.Migrations;
+
+/// <summary>
+/// Audio analysis being on by default is only half a promise if it reaches
+/// nobody who already installed the server. This replays the chain against a
+/// real file the way a self-hosted upgrade does: a database that predates the
+/// change, carrying libraries that were created with the column off, then the
+/// new migration on top of it.
+/// </summary>
+public class AnalyzeAudioDefaultsOnMigrationTests : IDisposable
+{
+    private const string PreviousMigration = "20260905191847_TrackAudioAnalysis";
+
+    private readonly string _databasePath;
+
+    public AnalyzeAudioDefaultsOnMigrationTests()
+    {
+        _databasePath = Path.Combine(
+            Path.GetTempPath(),
+            $"nm_analyzeaudio_migration_{Guid.NewGuid():N}.db"
+        );
+    }
+
+    public void Dispose()
+    {
+        // Microsoft.Data.Sqlite pools physical file handles across connections
+        // even after Dispose(); on Windows the OS-level lock outlives the
+        // `using` above, so the delete fails unless the pool is cleared first.
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(_databasePath))
+        {
+            File.Delete(_databasePath);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private MediaContext OpenContext()
+    {
+        DbContextOptionsBuilder<MediaContext> builder = new();
+        builder.UseSqlite($"Data Source={_databasePath}");
+
+        return new(builder.Options);
+    }
+
+    private static Library MusicLibrary(bool? analyzeAudio)
+    {
+        Library library = new()
+        {
+            Id = Ulid.NewUlid(),
+            Title = "A Library",
+            Type = "music",
+        };
+
+        if (analyzeAudio is not null)
+        {
+            library.AnalyzeAudio = analyzeAudio.Value;
+        }
+
+        return library;
+    }
+
+    /// <summary>
+    /// The store default is on, and EF must still write an explicit "off" for
+    /// a library that opted out — a default that swallows the opt-out would
+    /// analyse a library its owner said no to.
+    /// </summary>
+    [Fact]
+    public async Task ALibraryThatOptedOut_StaysOffAcrossASaveAndReload()
+    {
+        Ulid libraryId;
+
+        await using (MediaContext seedContext = OpenContext())
+        {
+            await seedContext.Database.MigrateAsync();
+
+            Library library = MusicLibrary(analyzeAudio: false);
+            libraryId = library.Id;
+
+            seedContext.Libraries.Add(library);
+            await seedContext.SaveChangesAsync();
+        }
+
+        await using MediaContext readContext = OpenContext();
+        Library reloaded = await readContext
+            .Libraries.AsNoTracking()
+            .SingleAsync(library => library.Id == libraryId);
+
+        Assert.False(reloaded.AnalyzeAudio);
+    }
+
+    [Fact]
+    public async Task ALibraryThatSaysNothing_IsStoredWithAnalysisOn()
+    {
+        Ulid libraryId;
+
+        await using (MediaContext seedContext = OpenContext())
+        {
+            await seedContext.Database.MigrateAsync();
+
+            Library library = MusicLibrary(analyzeAudio: null);
+            libraryId = library.Id;
+
+            seedContext.Libraries.Add(library);
+            await seedContext.SaveChangesAsync();
+        }
+
+        await using MediaContext readContext = OpenContext();
+        Library reloaded = await readContext
+            .Libraries.AsNoTracking()
+            .SingleAsync(library => library.Id == libraryId);
+
+        Assert.True(reloaded.AnalyzeAudio);
+    }
+
+    /// <summary>
+    /// The upgrade path: every music library that already existed when the
+    /// column could only be off is turned on, and nothing else is touched.
+    /// </summary>
+    [Fact]
+    public async Task ExistingMusicLibraries_AreTurnedOnByTheMigration()
+    {
+        Ulid musicLibraryId = Ulid.NewUlid();
+        Ulid movieLibraryId = Ulid.NewUlid();
+
+        await using (MediaContext oldContext = OpenContext())
+        {
+            IMigrator migrator = oldContext.GetService<IMigrator>();
+            await migrator.MigrateAsync(PreviousMigration);
+
+            oldContext.Libraries.AddRange(
+                new Library
+                {
+                    Id = musicLibraryId,
+                    Title = "A Library",
+                    Type = "music",
+                    AnalyzeAudio = false,
+                },
+                new Library
+                {
+                    Id = movieLibraryId,
+                    Title = "Another Library",
+                    Type = "movie",
+                    AnalyzeAudio = false,
+                }
+            );
+
+            await oldContext.SaveChangesAsync();
+        }
+
+        await using (MediaContext upgradeContext = OpenContext())
+        {
+            await upgradeContext.Database.MigrateAsync();
+        }
+
+        await using MediaContext readContext = OpenContext();
+        List<Library> libraries = await readContext.Libraries.AsNoTracking().ToListAsync();
+
+        Assert.True(libraries.Single(library => library.Id == musicLibraryId).AnalyzeAudio);
+        Assert.False(libraries.Single(library => library.Id == movieLibraryId).AnalyzeAudio);
+    }
+}

--- a/tests/NoMercy.Tests.Database/Models/LibraryTests.cs
+++ b/tests/NoMercy.Tests.Database/Models/LibraryTests.cs
@@ -33,4 +33,24 @@ public class LibraryTests
 
         library.AutoConfirmDiscMatches.Should().BeTrue();
     }
+
+    /// <summary>
+    /// Audio analysis is part of every music import, not a setting a user has
+    /// to go and find, so a library that says nothing about it wants it.
+    /// </summary>
+    [Fact]
+    public void AnalyzeAudio_DefaultsToOn()
+    {
+        Library library = new();
+
+        library.AnalyzeAudio.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AnalyzeAudio_CanBeSetOff()
+    {
+        Library library = new() { AnalyzeAudio = false };
+
+        library.AnalyzeAudio.Should().BeFalse();
+    }
 }

--- a/tests/NoMercy.Tests.MediaProcessing/AudioAnalysis/AudioAnalysisDispatchTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/AudioAnalysis/AudioAnalysisDispatchTests.cs
@@ -1,0 +1,103 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Moq;
+using NoMercy.Database.Models.Libraries;
+using NoMercy.MediaProcessing.AudioAnalysis;
+using NoMercy.MediaProcessing.Jobs.MediaJobs;
+using NoMercyQueue.Core.Interfaces;
+using Xunit;
+
+namespace NoMercy.Tests.MediaProcessing.AudioAnalysis;
+
+/// <summary>
+/// The gate an import passes through for every track it stores. It is the only
+/// layer that reaches a brand-new library at the moment its tracks appear —
+/// the scan-completed hook runs before the import jobs have written any Track
+/// row, so without this a first import waited for the hourly sweep.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class AudioAnalysisDispatchTests
+{
+    private static (Mock<IJobDispatcher> Dispatcher, List<IShouldQueue> Dispatched) Recorder()
+    {
+        List<IShouldQueue> dispatched = [];
+
+        Mock<IJobDispatcher> dispatcher = new();
+        dispatcher
+            .Setup(d => d.Dispatch(It.IsAny<IShouldQueue>()))
+            .Callback<IShouldQueue>(dispatched.Add);
+
+        return (dispatcher, dispatched);
+    }
+
+    private static Library Library(bool analyzeAudio) =>
+        new()
+        {
+            Id = Ulid.NewUlid(),
+            Title = "A Library",
+            Type = "music",
+            AnalyzeAudio = analyzeAudio,
+        };
+
+    [Fact]
+    public void AfterStore_WhenTheLibraryWantsAnalysis_QueuesThatTrack()
+    {
+        Guid trackId = Guid.NewGuid();
+        (Mock<IJobDispatcher> dispatcher, List<IShouldQueue> dispatched) = Recorder();
+
+        AudioAnalysisDispatch.AfterStore(dispatcher.Object, Library(analyzeAudio: true), trackId);
+
+        IShouldQueue only = Assert.Single(dispatched);
+        MusicAnalysisJob analysis = Assert.IsType<MusicAnalysisJob>(only);
+        Assert.Equal(trackId, analysis.TrackId);
+    }
+
+    /// <summary>
+    /// The column is the whole opt-out. A library that turned analysis off must
+    /// not have its tracks analyzed by the back door of an import.
+    /// </summary>
+    [Fact]
+    public void AfterStore_WhenTheLibraryOptedOut_QueuesNothing()
+    {
+        (Mock<IJobDispatcher> dispatcher, List<IShouldQueue> dispatched) = Recorder();
+
+        AudioAnalysisDispatch.AfterStore(
+            dispatcher.Object,
+            Library(analyzeAudio: false),
+            Guid.NewGuid()
+        );
+
+        Assert.Empty(dispatched);
+    }
+
+    /// <summary>
+    /// One track, one job. A release of twelve tracks must not cost the queue
+    /// twelve jobs per track.
+    /// </summary>
+    [Fact]
+    public void AfterStore_QueuesOneJobPerTrack()
+    {
+        List<Guid> trackIds = [Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()];
+        (Mock<IJobDispatcher> dispatcher, List<IShouldQueue> dispatched) = Recorder();
+        Library library = Library(analyzeAudio: true);
+
+        foreach (Guid trackId in trackIds)
+        {
+            AudioAnalysisDispatch.AfterStore(dispatcher.Object, library, trackId);
+        }
+
+        Assert.Equal(
+            trackIds.Order(),
+            dispatched.Cast<MusicAnalysisJob>().Select(job => job.TrackId).Order()
+        );
+    }
+}

--- a/tests/NoMercy.Tests.Service/Jobs/AudioAnalysisQueryPlanTests.cs
+++ b/tests/NoMercy.Tests.Service/Jobs/AudioAnalysisQueryPlanTests.cs
@@ -48,11 +48,35 @@ public class AudioAnalysisQueryPlanTests : IDisposable
     {
         using MediaContext context = new(_options);
 
-        string sql = AudioAnalysisQueries
-            .TracksNeedingAnalysis(context, [Ulid.NewUlid()], 1)
-            .Take(500)
-            .ToQueryString();
+        return Explain(
+            AudioAnalysisQueries
+                .TracksNeedingAnalysis(context, [Ulid.NewUlid()], 1)
+                .Take(500)
+                .ToQueryString()
+        );
+    }
 
+    /// <summary>
+    /// The query <see cref="NoMercy.Service.Jobs.AudioAnalysisScheduler" />
+    /// actually issues: the same filter, ordered so a page has a stable
+    /// meaning, one page at a time.
+    /// </summary>
+    private string ExplainPagedSweepQuery()
+    {
+        using MediaContext context = new(_options);
+
+        return Explain(
+            AudioAnalysisQueries
+                .TracksNeedingAnalysis(context, [Ulid.NewUlid()], 1)
+                .OrderBy(trackId => trackId)
+                .Skip(500)
+                .Take(500)
+                .ToQueryString()
+        );
+    }
+
+    private string Explain(string sql)
+    {
         // ToQueryString prefixes the statement with ".param set" lines; EXPLAIN
         // wants the statement alone.
         string statement = string.Join(
@@ -108,5 +132,23 @@ public class AudioAnalysisQueryPlanTests : IDisposable
         string plan = ExplainSweepQuery();
 
         Assert.DoesNotContain("SCAN l", plan);
+    }
+
+    /// <summary>
+    /// Paging wraps the filter in a derived table, so the plan gains a scan of
+    /// that table's own output plus a temp b-tree for the ORDER BY — the price
+    /// of a page that means the same thing twice in a row. What it must NOT
+    /// cost is either real table: both are still reached by index, which is
+    /// what makes a sweep over a large library affordable.
+    /// </summary>
+    [Fact]
+    public void PagedSweepQuery_StillReachesBothTablesByIndex()
+    {
+        string plan = ExplainPagedSweepQuery();
+
+        Assert.Contains("SEARCH l USING COVERING INDEX sqlite_autoindex_LibraryTrack_1", plan);
+        Assert.Contains("SEARCH t USING INDEX sqlite_autoindex_TrackAudioAnalysis_1", plan);
+        Assert.DoesNotContain("SCAN t", plan);
+        Assert.DoesNotContain("SCAN LibraryTrack", plan);
     }
 }

--- a/tests/NoMercy.Tests.Service/Jobs/AudioAnalysisSchedulerTests.cs
+++ b/tests/NoMercy.Tests.Service/Jobs/AudioAnalysisSchedulerTests.cs
@@ -1,0 +1,314 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NoMercy.Database;
+using NoMercy.Database.Models.Libraries;
+using NoMercy.Database.Models.Music;
+using NoMercy.MediaProcessing.AudioAnalysis;
+using NoMercy.MediaProcessing.Jobs.MediaJobs;
+using NoMercy.Service.Jobs;
+using NoMercyQueue.Core.Interfaces;
+
+namespace NoMercy.Tests.Service.Jobs;
+
+/// <summary>
+/// The scheduler is the one place that answers "which tracks still need a
+/// verdict" and puts them on the queue. Both the hourly sweep and the
+/// scan-completed hook go through it, so its behaviour is proven once here
+/// instead of twice at the call sites.
+/// </summary>
+public class AudioAnalysisSchedulerTests : IDisposable
+{
+    private const int AnalyzerVersion = 1;
+
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<MediaContext> _options;
+
+    public AudioAnalysisSchedulerTests()
+    {
+        _connection = new("Data Source=:memory:");
+        _connection.Open();
+
+        using (SqliteCommand fkOff = _connection.CreateCommand())
+        {
+            fkOff.CommandText = "PRAGMA foreign_keys = OFF;";
+            fkOff.ExecuteNonQuery();
+        }
+
+        _options = new DbContextOptionsBuilder<MediaContext>().UseSqlite(_connection).Options;
+
+        using MediaContext context = new(_options);
+        context.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private Ulid SeedLibrary(string type = "music")
+    {
+        Ulid libraryId = Ulid.NewUlid();
+
+        using MediaContext context = new(_options);
+        context.Libraries.Add(
+            new Library
+            {
+                Id = libraryId,
+                Title = "A Library",
+                Type = type,
+                AnalyzeAudio = true,
+            }
+        );
+        context.SaveChanges();
+
+        return libraryId;
+    }
+
+    private Guid SeedTrack(Ulid libraryId, AudioAnalysisState? state, int version = AnalyzerVersion)
+    {
+        Guid trackId = Guid.NewGuid();
+
+        using MediaContext context = new(_options);
+        context.Tracks.Add(new Track { Id = trackId, Name = "A Track" });
+        context.LibraryTrack.Add(new LibraryTrack { LibraryId = libraryId, TrackId = trackId });
+
+        if (state is not null)
+        {
+            context.TrackAudioAnalysis.Add(
+                new TrackAudioAnalysis
+                {
+                    TrackId = trackId,
+                    AnalyzerVersion = version,
+                    State = state.Value,
+                    AnalyzedAt = DateTime.UtcNow,
+                }
+            );
+        }
+
+        context.SaveChanges();
+
+        return trackId;
+    }
+
+    private List<Guid> SeedTracks(Ulid libraryId, int count)
+    {
+        List<Guid> trackIds = [];
+
+        using MediaContext context = new(_options);
+
+        for (int index = 0; index < count; index++)
+        {
+            Guid trackId = Guid.NewGuid();
+            trackIds.Add(trackId);
+
+            context.Tracks.Add(new Track { Id = trackId, Name = "A Track" });
+            context.LibraryTrack.Add(new LibraryTrack { LibraryId = libraryId, TrackId = trackId });
+        }
+
+        context.SaveChanges();
+
+        return trackIds;
+    }
+
+    private void RecordVerdicts(IEnumerable<Guid> trackIds)
+    {
+        using MediaContext context = new(_options);
+
+        foreach (Guid trackId in trackIds)
+        {
+            context.TrackAudioAnalysis.Add(
+                new TrackAudioAnalysis
+                {
+                    TrackId = trackId,
+                    AnalyzerVersion = AnalyzerVersion,
+                    State = AudioAnalysisState.Ok,
+                    AnalyzedAt = DateTime.UtcNow,
+                }
+            );
+        }
+
+        context.SaveChanges();
+    }
+
+    private (AudioAnalysisScheduler Scheduler, List<Guid> Queued) CreateScheduler()
+    {
+        List<Guid> queued = [];
+
+        Mock<IJobDispatcher> dispatcher = new();
+        dispatcher
+            .Setup(d => d.Dispatch(It.IsAny<IShouldQueue>()))
+            .Callback<IShouldQueue>(job =>
+            {
+                if (job is MusicAnalysisJob analysis)
+                {
+                    queued.Add(analysis.TrackId);
+                }
+            });
+
+        Mock<IAudioAnalyzer> analyzer = new();
+        analyzer.SetupGet(a => a.Version).Returns(AnalyzerVersion);
+
+        Mock<IDbContextFactory<MediaContext>> factory = new();
+        factory
+            .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new(_options));
+
+        AudioAnalysisScheduler scheduler = new(
+            dispatcher.Object,
+            analyzer.Object,
+            factory.Object,
+            NullLogger<AudioAnalysisScheduler>.Instance
+        );
+
+        return (scheduler, queued);
+    }
+
+    [Fact]
+    public async Task QueueAsync_QueuesTracksWithoutAVerdict_AndReturnsTheCount()
+    {
+        Ulid libraryId = SeedLibrary();
+        Guid trackId = SeedTrack(libraryId, state: null);
+
+        (AudioAnalysisScheduler scheduler, List<Guid> queued) = CreateScheduler();
+        int count = await scheduler.QueueAsync([libraryId]);
+
+        Assert.Equal([trackId], queued);
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task QueueAsync_SkipsTracksThisVersionAlreadyAnalyzed()
+    {
+        Ulid libraryId = SeedLibrary();
+        SeedTrack(libraryId, AudioAnalysisState.Ok);
+
+        (AudioAnalysisScheduler scheduler, List<Guid> queued) = CreateScheduler();
+        int count = await scheduler.QueueAsync([libraryId]);
+
+        Assert.Empty(queued);
+        Assert.Equal(0, count);
+    }
+
+    /// <summary>
+    /// A terminal failure at the current version is an answer. Re-queuing it
+    /// every hour would spend the queue on files that cannot succeed.
+    /// </summary>
+    [Fact]
+    public async Task QueueAsync_SkipsTracksThatFailedAtThisVersion()
+    {
+        Ulid libraryId = SeedLibrary();
+        SeedTrack(libraryId, AudioAnalysisState.Failed);
+
+        (AudioAnalysisScheduler scheduler, List<Guid> queued) = CreateScheduler();
+
+        Assert.Equal(0, await scheduler.QueueAsync([libraryId]));
+        Assert.Empty(queued);
+    }
+
+    [Fact]
+    public async Task QueueAsync_RequeuesTracksLeftPendingByAnUnfinishedRun()
+    {
+        Ulid libraryId = SeedLibrary();
+        Guid trackId = SeedTrack(libraryId, AudioAnalysisState.Pending);
+
+        (AudioAnalysisScheduler scheduler, List<Guid> queued) = CreateScheduler();
+
+        Assert.Equal(1, await scheduler.QueueAsync([libraryId]));
+        Assert.Equal([trackId], queued);
+    }
+
+    /// <summary>
+    /// The reason the version column exists: improving the analyzer re-queues
+    /// exactly the stale rows, without a full library rescan.
+    /// </summary>
+    [Fact]
+    public async Task QueueAsync_RequeuesTracksAnalyzedByAnOlderVersion()
+    {
+        Ulid libraryId = SeedLibrary();
+        Guid trackId = SeedTrack(libraryId, AudioAnalysisState.Ok, version: AnalyzerVersion - 1);
+
+        (AudioAnalysisScheduler scheduler, List<Guid> queued) = CreateScheduler();
+
+        Assert.Equal(1, await scheduler.QueueAsync([libraryId]));
+        Assert.Equal([trackId], queued);
+    }
+
+    [Fact]
+    public async Task QueueAsync_QueuesNothingForAnEmptyLibrarySet()
+    {
+        Ulid libraryId = SeedLibrary();
+        SeedTrack(libraryId, state: null);
+
+        (AudioAnalysisScheduler scheduler, List<Guid> queued) = CreateScheduler();
+        int count = await scheduler.QueueAsync([]);
+
+        Assert.Empty(queued);
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task QueueAsync_QueuesTracksFromEveryLibraryItIsGiven()
+    {
+        Ulid first = SeedLibrary();
+        Ulid second = SeedLibrary();
+        Guid firstTrack = SeedTrack(first, state: null);
+        Guid secondTrack = SeedTrack(second, state: null);
+
+        (AudioAnalysisScheduler scheduler, List<Guid> queued) = CreateScheduler();
+        int count = await scheduler.QueueAsync([first, second]);
+
+        Assert.Equal(2, count);
+        Assert.Equal(new List<Guid> { firstTrack, secondTrack }.Order(), queued.Order());
+    }
+
+    /// <summary>
+    /// A page is 500 and dispatching writes nothing back, so a scheduler that
+    /// re-asks the same question without moving forward would hand the queue
+    /// the same 500 tracks for ever and never reach the rest of the library.
+    /// </summary>
+    [Fact]
+    public async Task QueueAsync_PagesPastTheBatchSize()
+    {
+        Ulid libraryId = SeedLibrary();
+        List<Guid> trackIds = SeedTracks(libraryId, 1201);
+
+        (AudioAnalysisScheduler scheduler, List<Guid> queued) = CreateScheduler();
+        int count = await scheduler.QueueAsync([libraryId]);
+
+        Assert.Equal(1201, count);
+        Assert.Equal(trackIds.Order().ToList(), queued.Order().ToList());
+    }
+
+    /// <summary>
+    /// Both callers may run minutes apart on the same library. Once the tracks
+    /// carry a verdict there is nothing left to queue.
+    /// </summary>
+    [Fact]
+    public async Task QueueAsync_QueuesNothingOnceEveryTrackHasAVerdict()
+    {
+        Ulid libraryId = SeedLibrary();
+        List<Guid> trackIds = SeedTracks(libraryId, 3);
+
+        (AudioAnalysisScheduler scheduler, List<Guid> queued) = CreateScheduler();
+        Assert.Equal(3, await scheduler.QueueAsync([libraryId]));
+
+        RecordVerdicts(trackIds);
+        queued.Clear();
+
+        Assert.Equal(0, await scheduler.QueueAsync([libraryId]));
+        Assert.Empty(queued);
+    }
+}

--- a/tests/NoMercy.Tests.Service/Jobs/AudioAnalysisSubscriberTests.cs
+++ b/tests/NoMercy.Tests.Service/Jobs/AudioAnalysisSubscriberTests.cs
@@ -1,0 +1,268 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NoMercy.Database;
+using NoMercy.Database.Models.Libraries;
+using NoMercy.Events;
+using NoMercy.Events.Library;
+using NoMercy.MediaProcessing.AudioAnalysis;
+using NoMercy.Service.Subscribers;
+using NoMercy.Tests.Service.TestHelpers;
+
+namespace NoMercy.Tests.Service.Jobs;
+
+/// <summary>
+/// Analysis has to happen as part of an import or rescan, with no switch to
+/// find — so the moment a music library finishes scanning, its outstanding
+/// tracks go on the queue. These tests pin that, the two cases that must stay
+/// quiet, and the promise that a failure in here never takes the scan down
+/// with it.
+/// </summary>
+public class AudioAnalysisSubscriberTests
+{
+    private static async Task<Ulid> SeedLibrary(
+        IDbContextFactory<MediaContext> contextFactory,
+        bool analyzeAudio,
+        string type = "music"
+    )
+    {
+        Ulid libraryId = Ulid.NewUlid();
+
+        await using MediaContext context = await contextFactory.CreateDbContextAsync();
+        context.Libraries.Add(
+            new Library
+            {
+                Id = libraryId,
+                Title = "A Library",
+                Type = type,
+                AnalyzeAudio = analyzeAudio,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        return libraryId;
+    }
+
+    private static LibraryScanCompletedEvent ScanOf(Ulid libraryId) =>
+        new()
+        {
+            LibraryId = libraryId,
+            LibraryName = "A Library",
+            ItemsFound = 12,
+            Duration = TimeSpan.FromSeconds(3),
+        };
+
+    private static Mock<IAudioAnalysisScheduler> SchedulerReturning(
+        int queued,
+        List<Ulid> scheduled
+    )
+    {
+        Mock<IAudioAnalysisScheduler> scheduler = new();
+        scheduler
+            .Setup(s =>
+                s.QueueAsync(It.IsAny<IReadOnlyCollection<Ulid>>(), It.IsAny<CancellationToken>())
+            )
+            .Callback<IReadOnlyCollection<Ulid>, CancellationToken>(
+                (libraryIds, _) => scheduled.AddRange(libraryIds)
+            )
+            .ReturnsAsync(queued);
+
+        return scheduler;
+    }
+
+    [Fact]
+    public async Task ScanCompleted_ForAnOptedInMusicLibrary_QueuesThatLibrary()
+    {
+        await using SqliteMediaContextFactory contextFactory = new();
+        Ulid libraryId = await SeedLibrary(contextFactory, analyzeAudio: true);
+
+        List<Ulid> scheduled = [];
+        InMemoryEventBus bus = new();
+        AudioAnalysisSubscriber subscriber = new(
+            bus,
+            SchedulerReturning(7, scheduled).Object,
+            contextFactory,
+            NullLogger<AudioAnalysisSubscriber>.Instance
+        );
+
+        await subscriber.StartAsync(CancellationToken.None);
+        await bus.PublishAsync(ScanOf(libraryId));
+
+        Assert.Equal([libraryId], scheduled);
+    }
+
+    [Fact]
+    public async Task ScanCompleted_ForALibraryThatOptedOut_QueuesNothing()
+    {
+        await using SqliteMediaContextFactory contextFactory = new();
+        Ulid libraryId = await SeedLibrary(contextFactory, analyzeAudio: false);
+
+        List<Ulid> scheduled = [];
+        InMemoryEventBus bus = new();
+        AudioAnalysisSubscriber subscriber = new(
+            bus,
+            SchedulerReturning(0, scheduled).Object,
+            contextFactory,
+            NullLogger<AudioAnalysisSubscriber>.Instance
+        );
+
+        await subscriber.StartAsync(CancellationToken.None);
+        await bus.PublishAsync(ScanOf(libraryId));
+
+        Assert.Empty(scheduled);
+    }
+
+    [Fact]
+    public async Task ScanCompleted_ForAVideoLibrary_QueuesNothing()
+    {
+        await using SqliteMediaContextFactory contextFactory = new();
+        Ulid libraryId = await SeedLibrary(contextFactory, analyzeAudio: true, type: "movie");
+
+        List<Ulid> scheduled = [];
+        InMemoryEventBus bus = new();
+        AudioAnalysisSubscriber subscriber = new(
+            bus,
+            SchedulerReturning(0, scheduled).Object,
+            contextFactory,
+            NullLogger<AudioAnalysisSubscriber>.Instance
+        );
+
+        await subscriber.StartAsync(CancellationToken.None);
+        await bus.PublishAsync(ScanOf(libraryId));
+
+        Assert.Empty(scheduled);
+    }
+
+    [Fact]
+    public async Task ScanCompleted_ForALibraryThatIsGone_QueuesNothing()
+    {
+        await using SqliteMediaContextFactory contextFactory = new();
+
+        List<Ulid> scheduled = [];
+        InMemoryEventBus bus = new();
+        AudioAnalysisSubscriber subscriber = new(
+            bus,
+            SchedulerReturning(0, scheduled).Object,
+            contextFactory,
+            NullLogger<AudioAnalysisSubscriber>.Instance
+        );
+
+        await subscriber.StartAsync(CancellationToken.None);
+        await bus.PublishAsync(ScanOf(Ulid.NewUlid()));
+
+        Assert.Empty(scheduled);
+    }
+
+    /// <summary>
+    /// An event handler that throws takes the publisher with it. A queue that
+    /// cannot be reached must cost the user their analysis, never their scan —
+    /// so the handler itself is asserted directly, not through the bus, which
+    /// would swallow the exception on its own and prove nothing.
+    /// </summary>
+    [Fact]
+    public async Task ScanCompleted_WhenTheSchedulerThrows_IsLoggedAndNotPropagated()
+    {
+        await using SqliteMediaContextFactory contextFactory = new();
+        Ulid libraryId = await SeedLibrary(contextFactory, analyzeAudio: true);
+
+        Mock<IAudioAnalysisScheduler> scheduler = new();
+        scheduler
+            .Setup(s =>
+                s.QueueAsync(It.IsAny<IReadOnlyCollection<Ulid>>(), It.IsAny<CancellationToken>())
+            )
+            .ThrowsAsync(new InvalidOperationException("the queue is unreachable"));
+
+        RecordingLogger logger = new();
+        AudioAnalysisSubscriber subscriber = new(
+            new InMemoryEventBus(),
+            scheduler.Object,
+            contextFactory,
+            logger
+        );
+
+        await subscriber.OnLibraryScanCompleted(ScanOf(libraryId), CancellationToken.None);
+
+        Assert.Contains(LogLevel.Error, logger.Levels);
+    }
+
+    [Fact]
+    public async Task Stop_DisposesTheSubscription_SoALaterScanQueuesNothing()
+    {
+        await using SqliteMediaContextFactory contextFactory = new();
+        Ulid libraryId = await SeedLibrary(contextFactory, analyzeAudio: true);
+
+        List<Ulid> scheduled = [];
+        InMemoryEventBus bus = new();
+        AudioAnalysisSubscriber subscriber = new(
+            bus,
+            SchedulerReturning(1, scheduled).Object,
+            contextFactory,
+            NullLogger<AudioAnalysisSubscriber>.Instance
+        );
+
+        await subscriber.StartAsync(CancellationToken.None);
+        await subscriber.StopAsync(CancellationToken.None);
+        await bus.PublishAsync(ScanOf(libraryId));
+
+        Assert.Empty(scheduled);
+    }
+
+    [Fact]
+    public async Task MultipleStartStopCycles_DoNotQueueTheSameLibraryTwice()
+    {
+        await using SqliteMediaContextFactory contextFactory = new();
+        Ulid libraryId = await SeedLibrary(contextFactory, analyzeAudio: true);
+
+        List<Ulid> scheduled = [];
+        InMemoryEventBus bus = new();
+        AudioAnalysisSubscriber subscriber = new(
+            bus,
+            SchedulerReturning(1, scheduled).Object,
+            contextFactory,
+            NullLogger<AudioAnalysisSubscriber>.Instance
+        );
+
+        for (int cycle = 0; cycle < 3; cycle++)
+        {
+            await subscriber.StartAsync(CancellationToken.None);
+            await subscriber.StopAsync(CancellationToken.None);
+        }
+
+        await subscriber.StartAsync(CancellationToken.None);
+        await bus.PublishAsync(ScanOf(libraryId));
+
+        Assert.Equal([libraryId], scheduled);
+    }
+
+    private sealed class RecordingLogger : ILogger<AudioAnalysisSubscriber>
+    {
+        public List<LogLevel> Levels { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
+        )
+        {
+            Levels.Add(logLevel);
+        }
+    }
+}

--- a/tests/NoMercy.Tests.Service/Jobs/AudioAnalysisSweepCronJobTests.cs
+++ b/tests/NoMercy.Tests.Service/Jobs/AudioAnalysisSweepCronJobTests.cs
@@ -143,6 +143,10 @@ public class AudioAnalysisSweepCronJobTests : IDisposable
         (AudioAnalysisSweepCronJob job, List<Ulid> scheduled) = CreateSweep();
         await job.ExecuteAsync(string.Empty);
 
-        Assert.Equal<Ulid>([first, second], scheduled.Order().ToList());
+        // Both sides sorted. Two ULIDs minted in the same millisecond differ
+        // only in their random tail, so the order they were created in is not
+        // the order they sort in, and comparing a seed-ordered list against a
+        // sorted one passes or fails by luck.
+        Assert.Equal(new List<Ulid> { first, second }.Order(), scheduled.Order());
     }
 }

--- a/tests/NoMercy.Tests.Service/Jobs/AudioAnalysisSweepCronJobTests.cs
+++ b/tests/NoMercy.Tests.Service/Jobs/AudioAnalysisSweepCronJobTests.cs
@@ -11,22 +11,21 @@
 
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
 using NoMercy.Database;
 using NoMercy.Database.Models.Libraries;
-using NoMercy.Database.Models.Music;
 using NoMercy.MediaProcessing.AudioAnalysis;
-using NoMercy.MediaProcessing.Jobs.MediaJobs;
 using NoMercy.Service.Jobs;
-using NoMercyQueue.Core.Interfaces;
 
 namespace NoMercy.Tests.Service.Jobs;
 
+/// <summary>
+/// The sweep's own job is now the library question — which libraries want
+/// their audio analyzed — and handing that set to the scheduler. Which tracks
+/// inside those libraries still need a verdict is proven in
+/// <see cref="AudioAnalysisSchedulerTests" />.
+/// </summary>
 public class AudioAnalysisSweepCronJobTests : IDisposable
 {
-    private const int AnalyzerVersion = 1;
-
     private readonly SqliteConnection _connection;
     private readonly DbContextOptions<MediaContext> _options;
 
@@ -72,158 +71,78 @@ public class AudioAnalysisSweepCronJobTests : IDisposable
         return libraryId;
     }
 
-    private Guid SeedTrack(Ulid libraryId, AudioAnalysisState? state, int version = AnalyzerVersion)
+    private (AudioAnalysisSweepCronJob Job, List<Ulid> Scheduled) CreateSweep()
     {
-        Guid trackId = Guid.NewGuid();
+        List<Ulid> scheduled = [];
 
-        using MediaContext context = new(_options);
-        context.Tracks.Add(new Track { Id = trackId, Name = "A Track" });
-        context.LibraryTrack.Add(new LibraryTrack { LibraryId = libraryId, TrackId = trackId });
-
-        if (state is not null)
-        {
-            context.TrackAudioAnalysis.Add(
-                new TrackAudioAnalysis
-                {
-                    TrackId = trackId,
-                    AnalyzerVersion = version,
-                    State = state.Value,
-                    AnalyzedAt = DateTime.UtcNow,
-                }
-            );
-        }
-
-        context.SaveChanges();
-
-        return trackId;
-    }
-
-    private (AudioAnalysisSweepCronJob Job, List<Guid> Queued) CreateSweep()
-    {
-        List<Guid> queued = [];
-
-        Mock<IJobDispatcher> dispatcher = new();
-        dispatcher
-            .Setup(d => d.Dispatch(It.IsAny<IShouldQueue>()))
-            .Callback<IShouldQueue>(job =>
-            {
-                if (job is MusicAnalysisJob analysis)
-                {
-                    queued.Add(analysis.TrackId);
-                }
-            });
-
-        Mock<IAudioAnalyzer> analyzer = new();
-        analyzer.SetupGet(a => a.Version).Returns(AnalyzerVersion);
+        Mock<IAudioAnalysisScheduler> scheduler = new();
+        scheduler
+            .Setup(s =>
+                s.QueueAsync(It.IsAny<IReadOnlyCollection<Ulid>>(), It.IsAny<CancellationToken>())
+            )
+            .Callback<IReadOnlyCollection<Ulid>, CancellationToken>(
+                (libraryIds, _) => scheduled.AddRange(libraryIds)
+            )
+            .ReturnsAsync(0);
 
         Mock<IDbContextFactory<MediaContext>> factory = new();
         factory
             .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => new(_options));
 
-        AudioAnalysisSweepCronJob job = new(
-            dispatcher.Object,
-            analyzer.Object,
-            factory.Object,
-            NullLogger<AudioAnalysisSweepCronJob>.Instance
-        );
+        AudioAnalysisSweepCronJob job = new(scheduler.Object, factory.Object);
 
-        return (job, queued);
+        return (job, scheduled);
     }
 
     [Fact]
-    public async Task Execute_QueuesTracksThatHaveNoAnalysis()
+    public async Task Execute_SchedulesTheMusicLibrariesThatOptedIn()
     {
         Ulid libraryId = SeedLibrary(analyzeAudio: true);
-        Guid trackId = SeedTrack(libraryId, state: null);
 
-        (AudioAnalysisSweepCronJob job, List<Guid> queued) = CreateSweep();
+        (AudioAnalysisSweepCronJob job, List<Ulid> scheduled) = CreateSweep();
         await job.ExecuteAsync(string.Empty);
 
-        Assert.Equal([trackId], queued);
+        Assert.Equal([libraryId], scheduled);
     }
 
     /// <summary>
-    /// The opt-in is the whole consent model for this feature. A library that
-    /// never asked must never have its tracks analyzed.
+    /// The opt-out is the whole consent model for this feature. A library that
+    /// turned it off must never have its tracks analyzed.
     /// </summary>
     [Fact]
-    public async Task Execute_SkipsLibrariesThatDidNotOptIn()
+    public async Task Execute_SkipsLibrariesThatOptedOut()
     {
-        Ulid libraryId = SeedLibrary(analyzeAudio: false);
-        SeedTrack(libraryId, state: null);
+        SeedLibrary(analyzeAudio: false);
 
-        (AudioAnalysisSweepCronJob job, List<Guid> queued) = CreateSweep();
+        (AudioAnalysisSweepCronJob job, List<Ulid> scheduled) = CreateSweep();
         await job.ExecuteAsync(string.Empty);
 
-        Assert.Empty(queued);
+        Assert.Empty(scheduled);
     }
 
     [Fact]
     public async Task Execute_SkipsNonMusicLibraries()
     {
-        Ulid libraryId = SeedLibrary(analyzeAudio: true, type: "movie");
-        SeedTrack(libraryId, state: null);
+        SeedLibrary(analyzeAudio: true, type: "movie");
 
-        (AudioAnalysisSweepCronJob job, List<Guid> queued) = CreateSweep();
+        (AudioAnalysisSweepCronJob job, List<Ulid> scheduled) = CreateSweep();
         await job.ExecuteAsync(string.Empty);
 
-        Assert.Empty(queued);
+        Assert.Empty(scheduled);
     }
 
     [Fact]
-    public async Task Execute_SkipsTracksThisVersionAlreadyAnalyzed()
+    public async Task Execute_SchedulesEveryOptedInMusicLibraryTogether()
     {
-        Ulid libraryId = SeedLibrary(analyzeAudio: true);
-        SeedTrack(libraryId, AudioAnalysisState.Ok);
+        Ulid first = SeedLibrary(analyzeAudio: true);
+        Ulid second = SeedLibrary(analyzeAudio: true);
+        SeedLibrary(analyzeAudio: false);
+        SeedLibrary(analyzeAudio: true, type: "tv");
 
-        (AudioAnalysisSweepCronJob job, List<Guid> queued) = CreateSweep();
+        (AudioAnalysisSweepCronJob job, List<Ulid> scheduled) = CreateSweep();
         await job.ExecuteAsync(string.Empty);
 
-        Assert.Empty(queued);
-    }
-
-    /// <summary>
-    /// A terminal failure at the current version is an answer. Re-queuing it
-    /// every hour would spend the queue on files that cannot succeed.
-    /// </summary>
-    [Fact]
-    public async Task Execute_SkipsTracksThatFailedAtThisVersion()
-    {
-        Ulid libraryId = SeedLibrary(analyzeAudio: true);
-        SeedTrack(libraryId, AudioAnalysisState.Failed);
-
-        (AudioAnalysisSweepCronJob job, List<Guid> queued) = CreateSweep();
-        await job.ExecuteAsync(string.Empty);
-
-        Assert.Empty(queued);
-    }
-
-    [Fact]
-    public async Task Execute_RequeuesTracksLeftPendingByAnUnfinishedRun()
-    {
-        Ulid libraryId = SeedLibrary(analyzeAudio: true);
-        Guid trackId = SeedTrack(libraryId, AudioAnalysisState.Pending);
-
-        (AudioAnalysisSweepCronJob job, List<Guid> queued) = CreateSweep();
-        await job.ExecuteAsync(string.Empty);
-
-        Assert.Equal([trackId], queued);
-    }
-
-    /// <summary>
-    /// The reason the version column exists: improving the analyzer re-queues
-    /// exactly the stale rows, without a full library rescan.
-    /// </summary>
-    [Fact]
-    public async Task Execute_RequeuesTracksAnalyzedByAnOlderVersion()
-    {
-        Ulid libraryId = SeedLibrary(analyzeAudio: true);
-        Guid trackId = SeedTrack(libraryId, AudioAnalysisState.Ok, version: AnalyzerVersion - 1);
-
-        (AudioAnalysisSweepCronJob job, List<Guid> queued) = CreateSweep();
-        await job.ExecuteAsync(string.Empty);
-
-        Assert.Equal([trackId], queued);
+        Assert.Equal<Ulid>([first, second], scheduled.Order().ToList());
     }
 }


### PR DESCRIPTION
## Why

Audio analysis (tempo, key, loudness, energy; the `MusicAnalysisJob` / `TrackAudioAnalysis` pipeline from #39 and #40) only ran through the hourly sweep, and only for libraries whose `AnalyzeAudio` column was true, which nothing in the API or the UI could set. The rule is now: analysis is part of every music import or rescan, on by default, with the column as the opt-out. A run-now task exists as the extra, not as the way in.

## What

- **`IAudioAnalysisScheduler`** (contract in `NoMercy.MediaProcessing.AudioAnalysis`, implementation in `NoMercy.Service/Jobs`): one place that queues every track of the given libraries lacking a verdict at the current analyzer version, 500 per page until the query runs dry. `AudioAnalysisQueries.LibrariesToAnalyze` is the shared "music libraries that want analysis" set. The hourly sweep calls the scheduler instead of carrying its own copy.
- **`AudioAnalysisDispatch.AfterStore`** in `AudioImportJob`: every track an import stores is queued right away (both the release and the singles path). A rescan is cheap: the queue drops identical payloads and the job returns early for a track with a current verdict.
- **`AudioAnalysisSubscriber`** (hosted service, same shape as `AutoEncodeSubscriber`) on `LibraryScanCompletedEvent`: covers the tracks that existed before the scan (a rescan that stored nothing new, an analyzer version bump). Exceptions stay inside the handler.
- **Migration `AnalyzeAudioDefaultsOn`**: store default `true`, EF sentinel set so an explicit `false` is still written, and `UPDATE Libraries SET AnalyzeAudio = 1 WHERE Type = 'music'` for installs that predate this.
- **`POST dashboard/tasks/audio-analysis/sweep`** → `{ "queued": n }`, Moderator policy like its neighbours; route contract snapshot updated.

Three layers, one question: the import reaches a brand-new library, the scan hook reaches what existed before, the hourly sweep is the safety net.

## Tests

`AudioAnalysisSchedulerTests` (pages past 500, counts, re-run queues nothing), `AudioAnalysisSubscriberTests` (music + opted in queues; video, opted out or missing library queue nothing; a throwing scheduler is logged, not propagated; stop/start cycles), `AudioAnalysisDispatchTests`, `AnalyzeAudioDefaultsOnMigrationTests` (replays the migration chain against a real SQLite file: existing music libraries turned on, movie libraries untouched, explicit opt-out survives a save), `LibraryTests`, endpoint tests (auth rejected, happy path reaches the queue), query plan test for the paged query.

Build 0 warnings; MediaProcessing 1035, Service 194, Api 2320, Database 256 passed locally. `Tests.Encoder` not run here (17 ffmpeg integration cases need the NoMercy build).

## Follow-ups, not in this PR

- No UI or API sets `AnalyzeAudio` to false yet; the opt-out is a database column for now.
- Offset paging adds a temp b-tree per 500-track page; a keyset cursor if it ever bites.
