### PR TITLE
feat(music): the DJ analysis record, the derived-audio store and the plugin contracts that write them

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# Docs index
+
+- [`distributed-encoding.md`](distributed-encoding.md) — running encode jobs
+  across a coordinator and remote workers.
+- [`encoder-errors.md`](encoder-errors.md) — the catalog of every
+  `EncoderRuleId` / `EncoderRuntimeErrorId` constant the encoder pipeline can
+  emit.
+- [`plugins/music-analysis.md`](plugins/music-analysis.md) — how a plugin
+  computes and stores the DJ analysis of a track.
+- [`refactor/wave2-runbook.md`](refactor/wave2-runbook.md) — the wave-2
+  autonomous refactor execution runbook.

--- a/docs/plugins/music-analysis.md
+++ b/docs/plugins/music-analysis.md
@@ -410,11 +410,23 @@ _subscription = context.EventBus.Subscribe<TrackAudioAnalysisCompletedEvent>(
 ```
 
 The event carries `TrackId`, `AnalyzerVersion` (the base analyzer's version
-the row was computed at) and `State` (the string `"Ok"` or `"Failed"` — the
-events package carries no reference to the database enum it came from). It
-does not yet carry a library id — a follow-up on this branch adds
-`LibraryIds`; until then, keep your own per-track state or run the
-per-library needs query instead.
+the row was computed at), `State` (the string `"Ok"` or `"Failed"` — the
+events package carries no reference to the database enum it came from) and
+`LibraryIds`.
+
+`LibraryIds` is every library the track belonged to when the verdict landed,
+read at publish time rather than carried from the moment the job was queued.
+It is a list because a track can belong to several libraries at once, and it
+is empty when the track is in none. Retention — how long a derived file for
+this track is worth keeping — is a per-library decision, so pick the policy
+per id rather than assuming one:
+
+```csharp
+foreach (Ulid libraryId in evt.LibraryIds)
+{
+    ApplyRetentionPolicyFor(libraryId, evt.TrackId);
+}
+```
 
 ## The dashboard cap setting
 

--- a/docs/plugins/music-analysis.md
+++ b/docs/plugins/music-analysis.md
@@ -1,0 +1,434 @@
+# Writing a DJ analysis plugin
+
+How a plugin computes and stores the DJ analysis of a track: the beat grid's
+downbeat and phrases, vocal activity, per-bar energy, candidate cue points and
+chords, plus the separated stems a transition is rendered from. The server
+owns the storage (`TrackDjAnalysis`, `TrackStem`, the derived-audio store) and
+the base measurements (`TrackAudioAnalysis` — tempo, key, loudness); a plugin
+that declares the right hooks computes the DJ-specific layer on top and writes
+it back through the contracts below. None of this needs the plugin to know
+where a file lives on disk, where ffmpeg is installed, or how to shell out to
+it safely — the host mediates all three.
+
+Every type mentioned here lives in `NoMercy.Plugins.Abstractions` (ABI 10.2 or
+later; see `PluginAbi.Current`).
+
+## Declaring the hooks
+
+Four hooks go in `plugin.json`, three of them elevated — the owner has to
+grant each one explicitly before the matching member on `IPluginContext`
+stops being `null`:
+
+```json
+{
+  "capabilities": {
+    "hooks": ["scheduledTask", "audioTools", "derivedAudio", "musicAnalysisWrite"]
+  }
+}
+```
+
+- `scheduledTask` — baseline. Lets the plugin implement `IScheduledTaskPlugin`
+  and run its analysis sweep on a cron.
+- `audioTools` — elevated. Unlocks `IPluginContext.AudioTools`
+  (`IPluginAudioTools`): running the server's own ffmpeg build over a track or
+  a derived file.
+- `derivedAudio` — elevated. Unlocks `IPluginContext.DerivedAudio`
+  (`IPluginDerivedAudio`): the content-addressed store for stems and other
+  files nothing in a library owns.
+- `musicAnalysisWrite` — elevated. Unlocks `IPluginContext.MusicAnalysisWriter`
+  (`IPluginMusicAnalysisWriter`): writing the `TrackDjAnalysis` row and the
+  stem register.
+
+Read-only access to what analysis has already measured —
+`IPluginContext.Music` (`IPluginMusicQuery`) — needs no hook and no grant; it
+is always present.
+
+Until the owner grants an elevated hook, its member on `IPluginContext` is
+`null`. Check for that rather than assuming the grant landed:
+
+```csharp
+if (context.AudioTools is not { } audioTools)
+{
+    context.Logger.LogInformation("audioTools not granted yet; skipping this sweep tick");
+    return;
+}
+```
+
+## `IPluginAudioTools` — running ffmpeg
+
+Two members: `RunFilterGraphAsync` for a measurement pass that produces no
+file, and `SplitStemsAsync` for a stem split that does.
+
+### `RunFilterGraphAsync` and the complex-graph rule
+
+`IPluginAudioTools` takes a track id as a `string` (`PluginAudioInput.Track`
+and `SplitStemsAsync` both do) while everything else here — the query
+contract, the analysis writer, the completion event — uses `Guid`. Call
+`.ToString()` on the `Guid` you already have; there is no other conversion.
+
+```csharp
+PluginAudioRunResult result = await audioTools.RunFilterGraphAsync(
+    PluginAudioInput.Track(trackId.ToString()),
+    new PluginFilterGraph(
+        "[0:a]stemsplit=model={stemsModel}[voc][acc];"
+            + "[voc]ebur128=metadata=1[voclevel];[voclevel]anullsink;"
+            + "[acc]ebur128=metadata=1[acclevel];[acclevel]anullsink",
+        Complex: true
+    ),
+    onStdOut: null,
+    onStdErr: line => context.Logger.LogTrace("{Line}", line),
+    ct: ct
+);
+
+if (!result.Ran)
+{
+    context.Logger.LogWarning("filter graph refused: {Reason}", result.Refusal);
+    return;
+}
+```
+
+- The literal token `{stemsModel}` is replaced by the host with the
+  stemsplit model's file name before the graph runs — a plugin never learns
+  the path, and the process runs with the ffmpeg folder as its working
+  directory so a bare file name resolves.
+- `Complex: false` runs the text as `-af <text> -f null -`, a single input to
+  a single output — fine for a one-filter measurement such as
+  `"ebur128=metadata=1"`.
+- `Complex: true` runs it as `-filter_complex <text> -map 0:a -f null -`. The
+  host only ever maps the **untouched** input stream to the null muxer; it
+  never maps anything the plugin's own graph produced. That means every
+  branch the plugin's text forks off — one per stem, one per measurement —
+  has to be consumed inside the plugin's own text or ffmpeg refuses to run at
+  all. The pattern above shows it: `stemsplit` forks into `[voc]` and `[acc]`,
+  each is measured and re-labelled, and each measured label ends in
+  `anullsink`, a filter that consumes audio and produces nothing. Nothing in
+  this graph is written to disk — the point of a measurement pass is what the
+  filters print, not a file — and `RunFilterGraphAsync` never returns any
+  audio; it returns only the exit code and whatever `onStdOut` / `onStdErr`
+  read live.
+- Reading a stem already written to the derived store as input, instead of a
+  library track: `PluginAudioInput.Derived(storageKey)`.
+- One ffmpeg run at a time per plugin; a second call while one is running is
+  refused rather than queued. A 10-minute timeout applies on top of your own
+  cancellation token.
+
+### `SplitStemsAsync`
+
+```csharp
+PluginStemSplitResult split = await audioTools.SplitStemsAsync(
+    trackId.ToString(),
+    PluginStemCoverage.MixIn,
+    PluginStemSet.Two,
+    ct
+);
+
+if (!split.Accepted)
+{
+    context.Logger.LogWarning("stem split refused for {TrackId}: {Reason}", trackId, split.Refusal);
+    return;
+}
+
+foreach (PluginStemFile stem in split.Stems)
+{
+    context.Logger.LogInformation("{Kind}: {Bytes} bytes at key {Key}", stem.Kind, stem.Bytes, stem.StorageKey);
+}
+```
+
+`coverage` picks how much of the track gets split:
+
+| value | what it covers |
+|---|---|
+| `PluginStemCoverage.Full` | the whole track, start to end |
+| `PluginStemCoverage.MixIn` | the first 20 % — the window a mix *into* the next track draws from |
+| `PluginStemCoverage.MixOut` | the last 25 % — the window a mix *out of* the track draws from |
+
+The exact bound is computed by the host from the track's duration, never by
+the caller. Both stems land in the derived store and are registered in the
+stem register automatically — a successful `SplitStemsAsync` call is enough;
+there is no separate `RegisterStemAsync` call to make for it (that member
+exists for `IPluginMusicAnalysisWriter`'s own callers, described below).
+`stemSet` is `PluginStemSet.Two` today (vocals + accompaniment);
+`PluginStemSet.Four` is reserved and currently refused.
+
+## `IPluginDerivedAudio` — the derived-audio store
+
+A content-addressed store for files nothing in a library owns — stems,
+later rendered transitions. Addressed by a key `PutAsync` returns, never by
+path: `IDerivedAudioStore.RelativePath` (the thing that turns a key into an
+on-disk path) is deliberately not exposed here, so a plugin always goes
+through this facade to read or write.
+
+```csharp
+await using FileStream localFile = File.OpenRead(renderedSegmentPath);
+string key = await context.DerivedAudio!.PutAsync(localFile, "audio/opus", ct);
+
+// later, on a different pass:
+if (await context.DerivedAudio.ExistsAsync(key, ct))
+{
+    await context.DerivedAudio.TouchAsync(key, ct); // keep it out of the next eviction sweep
+    await using Stream? content = await context.DerivedAudio.OpenReadAsync(key, ct);
+}
+
+await context.DerivedAudio.DeleteAsync(key, ct);
+```
+
+`SplitStemsAsync` already writes into this store on your behalf; call
+`PutAsync` yourself only for a file your own code produced (a render, an
+intermediate you want to keep across runs). Two plugins that derive the same
+bytes from the same track share one copy rather than each staging its own.
+
+## `IPluginMusicAnalysisWriter` — writing the DJ record
+
+### `UpsertDjAnalysisAsync`
+
+```csharp
+IReadOnlyList<PluginTrackAudioAnalysis> baseRows = await context.Music!.GetAnalysisAsync([trackId], ct);
+PluginTrackAudioAnalysis baseAnalysis = baseRows.Single();
+
+PluginWriteResult result = await context.MusicAnalysisWriter!.UpsertDjAnalysisAsync(
+    new PluginTrackDjAnalysis(
+        TrackId: trackId,
+        DjAnalyzerVersion: CurrentDjAnalyzerVersion,
+        BaseAnalyzerVersion: baseAnalysis.AnalyzerVersion,
+        DownbeatIndex: 0,
+        BeatsPerBar: 4,
+        PhraseLengthBars: 8,
+        PhraseStartsMs: [0, 15_000, 30_000, 45_000],
+        VocalRegionsMs: [[4_200, 18_900], [22_000, 40_500]],
+        BarEnergy: [-18.2, -17.9, -16.4, -15.8],
+        CuePoints: [new PluginCuePoint(28_600, "drop", "mixIn", 0.92)],
+        Chords: [new PluginChord(0, "Am"), new PluginChord(4_000, "F")]
+    ),
+    ct
+);
+
+if (!result.Ok)
+{
+    context.Logger.LogWarning("DJ analysis refused for {TrackId}: {Reason}", trackId, result.Refusal);
+}
+```
+
+`BaseAnalyzerVersion` has to match the version on a **current, Ok** base row —
+read it back from `IPluginMusicQuery.GetAnalysisAsync` rather than hard-coding
+it, since the server can bump its own analyzer independently of yours. See
+[Refusals](#refusals-what-they-mean-and-what-to-do) for every way this call
+can be turned down.
+
+### `RegisterStemAsync`, `MarkFailedAsync`, `DeleteDjAnalysisAsync`
+
+`RegisterStemAsync` is what `SplitStemsAsync` calls internally; call it
+yourself only if you produced a stem file some other way (through your own
+`RunFilterGraphAsync` graph, say) and already hold its derived-store key.
+
+```csharp
+await context.MusicAnalysisWriter!.RegisterStemAsync(
+    new PluginTrackStem(
+        trackId,
+        Kind: "vocals",
+        Coverage: PluginStemCoverage.MixIn,
+        WindowStartMs: 0,
+        WindowEndMs: 60_000,
+        Format: "opus",
+        SampleRate: 48_000,
+        StorageKey: key,
+        ProducerVersion: "spleeter-2stems-f16@9.0-NoMercy-MediaServer"
+    ),
+    ct
+);
+```
+
+`MarkFailedAsync(trackId, djAnalyzerVersion, baseAnalyzerVersion, reason, ct)`
+records that analysis was attempted and did not produce a row — so the sweep
+can tell "not analysed yet" from "analysed and failed" instead of retrying
+the same broken file forever. It clears every measurement column on the row
+(a `Failed` row must never go on carrying a previous `Ok` row's numbers).
+`DeleteDjAnalysisAsync(trackId, ct)` removes the row outright and never
+refuses, even for a track that never had one.
+
+## The two "needs" queries, and how to page them
+
+Both live on `IPluginMusicQuery` (`context.Music`, always present, no hook
+needed) and both are capped server-side: `take` is clamped to 1–1000
+regardless of what you pass, and a `libraryId` that does not parse comes back
+as an empty page rather than a throw.
+
+`GetTracksNeedingDjAnalysisAsync(libraryId, djAnalyzerVersion, skip, take, ct)`
+is the sweep's worklist: track ids in the library whose base analysis is `Ok`
+but that have no DJ row, or have one from an older `DjAnalyzerVersion`, or
+have one computed against a `BaseAnalyzerVersion` the base row has since moved
+past, or have one left `Pending`. A `Failed` row at the current versions is
+**not** returned — a version bump or an explicit retry re-queues it, nothing
+else does.
+
+`GetTracksMissingStemsAsync(libraryId, producerVersion, policy, skip, take, ct)`
+is the same idea for stems: track ids whose DJ row is `Ok` but whose
+`TrackStem` rows at `producerVersion` do not yet satisfy `policy` (see
+[retention](#stem-retention-policy) below). Passing
+`PluginStemPolicy.OnDemand` always returns an empty page without touching the
+database — under that policy there is no sweep to drive.
+
+Page either one with `skip`, advancing it by how many rows actually came
+back (not by the page size you asked for — the last page is usually short):
+
+```csharp
+const int PageSize = 500;
+int skip = 0;
+
+while (true)
+{
+    IReadOnlyList<Guid> page = await context.Music!.GetTracksNeedingDjAnalysisAsync(
+        libraryId,
+        CurrentDjAnalyzerVersion,
+        skip,
+        PageSize,
+        ct
+    );
+
+    if (page.Count == 0)
+    {
+        break;
+    }
+
+    foreach (Guid trackId in page)
+    {
+        await AnalyzeOneTrackAsync(trackId, ct);
+    }
+
+    skip += page.Count;
+}
+```
+
+## Stem retention policy
+
+`PluginStemPolicy` (an enum on the abstractions package, not a setting the
+server stores — the setting itself belongs to the plugin's own
+`IPluginConfiguration`, per library, and lands in a later plugin release) has
+three values:
+
+| value | at analysis time | at plan time |
+|---|---|---|
+| `Windows` (0, default) | run the measurement pass in-stream (nothing stored), then `SplitStemsAsync` for `MixIn` and `MixOut` | use the stored windows |
+| `Full` (1) | `SplitStemsAsync` with `Full` coverage first, then run the measurement pass reading the stored stems back through `PluginAudioInput.Derived` | use the stored full stems |
+| `OnDemand` (2) | run the measurement pass in-stream, store nothing | `SplitStemsAsync` for whichever window is needed, kept only for the render |
+
+Changing the setting later is never destructive. `Windows → Full` just means
+`GetTracksMissingStemsAsync` starts returning tracks again — the sweep fills
+in the missing full stems on its own. `Full → Windows` leaves the existing
+full-coverage rows in place until the server's own eviction sweep reclaims
+them; nothing has to be deleted by hand. Either way the dashboard's
+size cap (below) is the hard limit regardless of what the policy asks for.
+
+## Versions, and what a bump means
+
+Three independent version numbers, each owned by a different thing:
+
+| version | owner | lives in | a bump means |
+|---|---|---|---|
+| base analyzer | the server | `TrackAudioAnalysis.AnalyzerVersion` | the server's own sweep redoes base rows; any `TrackDjAnalysis` row whose `BaseAnalyzerVersion` no longer matches becomes stale and `GetTracksNeedingDjAnalysisAsync` starts returning that track again |
+| DJ analyzer | your plugin | `TrackDjAnalysis.DjAnalyzerVersion` (`PluginTrackDjAnalysis.DjAnalyzerVersion` on the wire) | every row from an older version is stale; the needs-query returns every one of them, so raising this constant is how you redo your whole library after changing a stage |
+| stems producer | your plugin (model + ffmpeg build) | `TrackStem.ProducerVersion` (`PluginTrackStem.ProducerVersion`) | new stem rows are written at the new value; old rows at the old value are left alone until the derived-audio store evicts them — a model or ffmpeg upgrade never has to delete anything itself |
+
+`ProducerVersion` is a free-form string you choose; `SplitStemsAsync` builds
+its own as `"{model name}@{ffmpeg version token}"` (for example
+`spleeter-2stems-f16@9.0-NoMercy-MediaServer`) when it writes stems through
+the built-in path, so use the same shape if you register stems yourself.
+
+## Refusals: what they mean and what to do
+
+Every method here fails by returning a refusal in words, never by throwing —
+a sweep runs unattended, and a stack trace nobody reads is worth nothing next
+to a reason the owner can act on. Check `Ran` / `Accepted` / `Ok` before
+touching the rest of the result.
+
+### `IPluginAudioTools`
+
+| refusal | what it means | what to do |
+|---|---|---|
+| `"ffmpeg is not installed"` | no ffmpeg path is configured on this server, or the configured path does not exist | tell the owner to point the server at its ffmpeg build; nothing a plugin can fix at runtime |
+| `"the stemsplit model is not installed"` | the Spleeter GGUF is missing (checked whenever the filter text contains `"stemsplit"`, or always for `SplitStemsAsync`) | tell the owner to install the model; retry later, the capability probe re-checks periodically |
+| `"another ffmpeg run of this plugin is still in progress"` | one ffmpeg process at a time per plugin; a second call arrived while the first was still running | do not retry immediately — queue the work and wait for the current run to finish |
+| `"four-stem splitting is not available yet"` | `PluginStemSet.Four` was requested | use `PluginStemSet.Two`; four-stem support is a later ffmpeg release |
+| `"track {id} has no file"` | the id did not parse as a `Guid`, the track is unknown, or the library scan never recorded a file for it | skip the track, or mark it failed — there is nothing to run ffmpeg against |
+| `"track {id} has no duration"` | `SplitStemsAsync` was asked for `MixIn` or `MixOut` on a track the library never timed | fall back to `PluginStemCoverage.Full`, or wait for a rescan to record a duration |
+| `"storage key {key} is not in the derived store"` | `PluginAudioInput.Derived(key)` named a key nothing wrote, or the key is empty | double-check the key came from a `PutAsync` or `SplitStemsAsync` call that actually succeeded |
+| `"the input names neither a track nor a derived file"` | a `PluginAudioInput` was built with neither field set | always build inputs through `PluginAudioInput.Track(...)` or `PluginAudioInput.Derived(...)`, never the constructor directly |
+| `"stemsplit timed out after 600 seconds"` | ffmpeg did not finish inside the host's 10-minute timeout (a stalled mount is the usual cause) | mark the track failed and retry on a later sweep; this is not something to retry immediately |
+| `"stemsplit exited with {code}"` | ffmpeg ran and returned non-zero | read the `onStdErr` lines you captured for the real reason before deciding whether to retry |
+
+### `IPluginMusicAnalysisWriter.UpsertDjAnalysisAsync`
+
+Checked in this order — the first failing check is the one you get back:
+
+| refusal | what it means | what to do |
+|---|---|---|
+| `"track {id} does not exist"` | the `TrackId` is not one the library knows | drop the row you were about to write |
+| `"no base analysis at version {version} for track {id}"` | no `TrackAudioAnalysis` row is `Ok` at exactly `BaseAnalyzerVersion` | re-read `IPluginMusicQuery.GetAnalysisAsync` for the current `AnalyzerVersion` and recompute against that, rather than a version you cached earlier |
+| `"beats_per_bar must be at least 1, got {value}"` | `BeatsPerBar` was 0 or negative | a plugin bug — this is normally 4 |
+| `"downbeat_index value {value} lies outside the beat grid (0..{max})"` | `DownbeatIndex` was outside `0 .. BeatsPerBar − 1` | clamp it, or leave it `null` when the detector could not place the bar |
+| `"{field} value {value} lies outside the track (0..{durationMs} ms)"` | a millisecond value in `phrase_starts_ms`, `vocal_regions_ms`, `cue_points` or `chords` (checked in that order) falls before 0 or after the track's own duration | the detector measured past the end of the file, or against the wrong track's duration — re-check the source of the timestamp |
+| `"phrase_starts_ms must be ascending"` | the phrase boundaries were not strictly increasing | sort them before writing; two phrases cannot share a millisecond |
+| `"{field} exceeds 64 kB"` | one JSON column (`phrase_starts_ms`, `vocal_regions_ms`, `bar_energy`, `cue_points` or `chords`, checked in that order) serialized past the 64 kB column limit | this record is meant to hold bars and phrases, not a sample-accurate trace — keep arrays proportionate to track length |
+
+Skipped entirely, rather than refused, when the track's duration is unknown:
+the millisecond-range check. A partial base row is normal, not a defect.
+
+### `IPluginMusicAnalysisWriter.RegisterStemAsync`
+
+| refusal | what it means | what to do |
+|---|---|---|
+| `"track {id} does not exist"` | unknown `TrackId` | drop the row |
+| `"storage key {key} is not in the derived store"` | the stem was never actually written, or the key is wrong | write it through `IPluginDerivedAudio.PutAsync` (or `SplitStemsAsync`) first |
+| `"full coverage stems must not specify a window"` | `Coverage.Full` was combined with a non-null `WindowStartMs` or `WindowEndMs` | leave both null for `Full` |
+| `"windowed stems must specify both window_start_ms and window_end_ms"` | `MixIn` / `MixOut` was combined with a null window bound | set both, in milliseconds from the start of the track |
+| `"window_start_ms must be less than window_end_ms"` | the window was empty or backwards | fix the bounds — a windowed stem always covers a positive span |
+
+### `IPluginMusicAnalysisWriter.MarkFailedAsync`
+
+| refusal | what it means | what to do |
+|---|---|---|
+| `"track {id} does not exist"` | unknown `TrackId` | nothing to mark |
+
+`DeleteDjAnalysisAsync` never refuses; deleting a row that is not there is a
+no-op.
+
+## The event to subscribe to
+
+`TrackAudioAnalysisCompletedEvent` (`NoMercy.Events.Music`) is published by
+the server's own base-analysis job the moment a `TrackAudioAnalysis` row lands
+— `Ok` or `Failed` — so the plugin can react per track instead of waiting for
+its next sweep tick:
+
+```csharp
+using NoMercy.Events.Music;
+
+_subscription = context.EventBus.Subscribe<TrackAudioAnalysisCompletedEvent>(
+    async (evt, ct) =>
+    {
+        if (evt.State != "Ok")
+        {
+            return; // nothing to build the DJ row from yet
+        }
+
+        await AnalyzeOneTrackAsync(evt.TrackId, ct);
+    }
+);
+```
+
+The event carries `TrackId`, `AnalyzerVersion` (the base analyzer's version
+the row was computed at) and `State` (the string `"Ok"` or `"Failed"` — the
+events package carries no reference to the database enum it came from). It
+does not carry a library id; if the sweep needs one, look the track up
+through `IPluginMusicQuery.GetTracksAsync` or keep your own per-track state.
+
+## The dashboard cap setting
+
+The derived-audio store (stems, and later rendered transitions) is capped by
+a dashboard setting, `derived_audio_cap_gb` (50 GB by default, at least 1).
+An hourly job evicts the least-recently-used entries — by `LastUsedAt`, never
+one touched inside the last 24 hours — until the store is back under the cap.
+Eviction cascades: the file goes, its `DerivedAudio` register row goes, and
+every `TrackStem` row pointing at it goes with it. A plugin does not manage
+this itself; `IPluginDerivedAudio.TouchAsync` is the one lever available to
+keep a specific file out of the next sweep, and a missing stem at plan time
+(R2, not this slice) simply falls back to a plain crossfade rather than
+failing the transition — never truncate a track, never fail closed.

--- a/docs/plugins/music-analysis.md
+++ b/docs/plugins/music-analysis.md
@@ -27,17 +27,12 @@ stops being `null`:
 }
 ```
 
-- `scheduledTask` — baseline. Lets the plugin implement `IScheduledTaskPlugin`
-  and run its analysis sweep on a cron.
-- `audioTools` — elevated. Unlocks `IPluginContext.AudioTools`
-  (`IPluginAudioTools`): running the server's own ffmpeg build over a track or
-  a derived file.
-- `derivedAudio` — elevated. Unlocks `IPluginContext.DerivedAudio`
-  (`IPluginDerivedAudio`): the content-addressed store for stems and other
-  files nothing in a library owns.
-- `musicAnalysisWrite` — elevated. Unlocks `IPluginContext.MusicAnalysisWriter`
-  (`IPluginMusicAnalysisWriter`): writing the `TrackDjAnalysis` row and the
-  stem register.
+| hook | elevated | unlocks | for |
+|---|---|---|---|
+| `scheduledTask` | no | `IScheduledTaskPlugin` | running the analysis sweep on a cron |
+| `audioTools` | yes | `IPluginContext.AudioTools` (`IPluginAudioTools`) | running the server's own ffmpeg build over a track or a derived file |
+| `derivedAudio` | yes | `IPluginContext.DerivedAudio` (`IPluginDerivedAudio`) | the content-addressed store for stems and other files nothing in a library owns |
+| `musicAnalysisWrite` | yes | `IPluginContext.MusicAnalysisWriter` (`IPluginMusicAnalysisWriter`) | writing the `TrackDjAnalysis` row and the stem register |
 
 Read-only access to what analysis has already measured —
 `IPluginContext.Music` (`IPluginMusicQuery`) — needs no hook and no grant; it
@@ -417,8 +412,9 @@ _subscription = context.EventBus.Subscribe<TrackAudioAnalysisCompletedEvent>(
 The event carries `TrackId`, `AnalyzerVersion` (the base analyzer's version
 the row was computed at) and `State` (the string `"Ok"` or `"Failed"` — the
 events package carries no reference to the database enum it came from). It
-does not carry a library id; if the sweep needs one, look the track up
-through `IPluginMusicQuery.GetTracksAsync` or keep your own per-track state.
+does not yet carry a library id — a follow-up on this branch adds
+`LibraryIds`; until then, keep your own per-track state or run the
+per-library needs query instead.
 
 ## The dashboard cap setting
 

--- a/src/NoMercy.Api/Controllers/V1/Dashboard/Admin/ConfigurationController.cs
+++ b/src/NoMercy.Api/Controllers/V1/Dashboard/Admin/ConfigurationController.cs
@@ -67,6 +67,9 @@ public class ConfigurationController(
                     Swagger = runtimeSettings.Swagger,
                     AllowAdultContent = runtimeSettings.ShowAdultContent,
                     UseSynthesizedDns = runtimeSettings.UseSynthesizedDns,
+                    DerivedAudioCapGb = (int)(
+                        runtimeSettings.DerivedAudioCapBytes / (1024L * 1024 * 1024)
+                    ),
                 },
             }
         );
@@ -129,6 +132,11 @@ public class ConfigurationController(
         Guid userId = User.UserId();
         List<(string key, object? oldVal, object? newVal)> changes = [];
         bool restartRequired = false;
+
+        if (request.DerivedAudioCapGb is < 1)
+        {
+            return BadRequestResponse("derived_audio_cap_gb must be at least 1");
+        }
 
         if (request.InternalServerPort != 0)
         {
@@ -322,6 +330,30 @@ public class ConfigurationController(
                 )
                 .RunAsync();
             changes.Add(("allowAdultContent", oldAllowAdult, (bool)request.AllowAdultContent));
+        }
+
+        if (request.DerivedAudioCapGb is not null)
+        {
+            int newCapGb = (int)request.DerivedAudioCapGb;
+            long oldCapBytes = runtimeSettings.DerivedAudioCapBytes;
+            long newCapBytes = newCapGb * 1024L * 1024 * 1024;
+            runtimeSettings.DerivedAudioCapBytes = newCapBytes;
+            await appContext
+                .Configuration.Upsert(
+                    new()
+                    {
+                        Key = "derivedAudioCapGb",
+                        Value = newCapGb.ToString(),
+                        ModifiedBy = userId,
+                    }
+                )
+                .On(configuration => configuration.Key)
+                .WhenMatched(
+                    (o, configuration) =>
+                        new() { Value = configuration.Value, ModifiedBy = configuration.ModifiedBy }
+                )
+                .RunAsync();
+            changes.Add(("derivedAudioCapGb", oldCapBytes, newCapBytes));
         }
 
         if (request.ServerName is not null)

--- a/src/NoMercy.Api/Controllers/V1/Dashboard/Admin/TasksController.cs
+++ b/src/NoMercy.Api/Controllers/V1/Dashboard/Admin/TasksController.cs
@@ -1144,6 +1144,16 @@ public class TasksController(
             analysis.State == AudioAnalysisState.Failed
         );
 
+        int djAnalyzed = await analysisContext.TrackDjAnalysis.CountAsync(dj =>
+            dj.State == AudioAnalysisState.Ok
+        );
+
+        int djFailed = await analysisContext.TrackDjAnalysis.CountAsync(dj =>
+            dj.State == AudioAnalysisState.Failed
+        );
+
+        long stemsBytes = await analysisContext.DerivedAudio.SumAsync(derived => derived.Bytes);
+
         return Ok(
             new AudioAnalysisStatusDto
             {
@@ -1151,6 +1161,9 @@ public class TasksController(
                 Queued = queued,
                 Analyzed = analyzed,
                 Failed = failed,
+                DjAnalyzed = djAnalyzed,
+                DjFailed = djFailed,
+                StemsBytes = stemsBytes,
             }
         );
     }

--- a/src/NoMercy.Api/Controllers/V1/Music/TracksController.cs
+++ b/src/NoMercy.Api/Controllers/V1/Music/TracksController.cs
@@ -97,16 +97,25 @@ public class TracksController : BaseController
                 $"At most {TrackAudioAnalysisRequestDto.MaxTrackIds} track ids per request"
             );
 
-        List<TrackAudioAnalysis> analysis = await _musicRepository.GetTrackAudioAnalysisAsync(
-            request.TrackIds.Distinct().ToArray()
-        );
+        Guid[] trackIds = request.TrackIds.Distinct().ToArray();
 
-        return Ok(
-            new TrackAudioAnalysisResponseDto
+        TrackAnalysisBundle bundle = await _musicRepository.GetTrackAnalysisBundleAsync(trackIds);
+
+        Dictionary<Guid, TrackDjAnalysis> djByTrackId = bundle.Dj.ToDictionary(row => row.TrackId);
+        ILookup<Guid, TrackStem> stemsByTrackId = bundle.Stems.ToLookup(row => row.TrackId);
+
+        List<TrackAudioAnalysisDto> data =
+        [
+            .. bundle.Analysis.Select(row => new TrackAudioAnalysisDto(row)
             {
-                Data = analysis.Select(row => new TrackAudioAnalysisDto(row)).ToList(),
-            }
-        );
+                Dj = djByTrackId.TryGetValue(row.TrackId, out TrackDjAnalysis? dj)
+                    ? new TrackDjAnalysisDto(dj, row.KeyName)
+                    : null,
+                Stems = [.. stemsByTrackId[row.TrackId].Select(stem => new TrackStemDto(stem))],
+            }),
+        ];
+
+        return Ok(new TrackAudioAnalysisResponseDto { Data = data });
     }
 
     [HttpPost]

--- a/src/NoMercy.Api/DTOs/Dashboard/ConfigDto.cs
+++ b/src/NoMercy.Api/DTOs/Dashboard/ConfigDto.cs
@@ -62,4 +62,7 @@ public class ConfigDtoData
 
     [JsonProperty("use_synthesized_dns")]
     public bool? UseSynthesizedDns { get; set; }
+
+    [JsonProperty("derived_audio_cap_gb")]
+    public int? DerivedAudioCapGb { get; set; }
 }

--- a/src/NoMercy.Api/DTOs/Music/AudioAnalysisStatusDto.cs
+++ b/src/NoMercy.Api/DTOs/Music/AudioAnalysisStatusDto.cs
@@ -35,4 +35,16 @@ public record AudioAnalysisStatusDto
     /// </summary>
     [JsonProperty("failed")]
     public int Failed { get; set; }
+
+    /// <summary>Tracks with an Ok DJ record from the automix plugin.</summary>
+    [JsonProperty("dj_analyzed")]
+    public int DjAnalyzed { get; set; }
+
+    /// <summary>DJ rows that will not be retried until the DJ analyzer version changes.</summary>
+    [JsonProperty("dj_failed")]
+    public int DjFailed { get; set; }
+
+    /// <summary>Total bytes the derived-audio store holds, across every stem file.</summary>
+    [JsonProperty("stems_bytes")]
+    public long StemsBytes { get; set; }
 }

--- a/src/NoMercy.Api/DTOs/Music/ChordDto.cs
+++ b/src/NoMercy.Api/DTOs/Music/ChordDto.cs
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+
+namespace NoMercy.Api.DTOs.Music;
+
+/// <summary>One chord change, as ffmpeg's keydetect filter timed it.</summary>
+public record ChordDto
+{
+    [JsonProperty("ms")]
+    public int Ms { get; set; }
+
+    /// <summary>As the detector named it, for example "Am" or "F#maj".</summary>
+    [JsonProperty("chord")]
+    public string Chord { get; set; } = string.Empty;
+}

--- a/src/NoMercy.Api/DTOs/Music/CuePointDto.cs
+++ b/src/NoMercy.Api/DTOs/Music/CuePointDto.cs
@@ -1,0 +1,36 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+
+namespace NoMercy.Api.DTOs.Music;
+
+/// <summary>
+/// One place in a track a transition could sensibly start or land, as the
+/// automix plugin's DJ analysis found it.
+/// </summary>
+public record CuePointDto
+{
+    [JsonProperty("ms")]
+    public int Ms { get; set; }
+
+    /// <summary>One of "intro", "drop", "breakdown" or "outro".</summary>
+    [JsonProperty("type")]
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>One of "mixIn" or "mixOut".</summary>
+    [JsonProperty("direction")]
+    public string Direction { get; set; } = string.Empty;
+
+    /// <summary>0..1, how strong a candidate this is relative to the track's other cue points.</summary>
+    [JsonProperty("score")]
+    public double Score { get; set; }
+}

--- a/src/NoMercy.Api/DTOs/Music/TrackAudioAnalysisDto.cs
+++ b/src/NoMercy.Api/DTOs/Music/TrackAudioAnalysisDto.cs
@@ -77,6 +77,18 @@ public record TrackAudioAnalysisDto
     [JsonProperty("analyzer_version")]
     public int AnalyzerVersion { get; set; }
 
+    /// <summary>
+    /// The automix plugin's DJ record for this track. Null whenever there is
+    /// no Ok DJ row — most tracks, for most of a library's life, same as every
+    /// other analysis measurement here.
+    /// </summary>
+    [JsonProperty("dj")]
+    public TrackDjAnalysisDto? Dj { get; set; }
+
+    /// <summary>The stem files available for this track. Empty, never null.</summary>
+    [JsonProperty("stems")]
+    public List<TrackStemDto> Stems { get; set; } = [];
+
     public TrackAudioAnalysisDto() { }
 
     public TrackAudioAnalysisDto(TrackAudioAnalysis analysis)

--- a/src/NoMercy.Api/DTOs/Music/TrackDjAnalysisDto.cs
+++ b/src/NoMercy.Api/DTOs/Music/TrackDjAnalysisDto.cs
@@ -92,19 +92,19 @@ public record TrackDjAnalysisDto
         BarEnergy = DjAnalysisJson.TryDeserialize<double>(dj.BarEnergy) ?? [];
         CuePoints =
         [
-            .. (
-                DjAnalysisJson.TryDeserialize<DjAnalysisJson.CuePointRow>(dj.CuePoints) ?? []
-            ).Select(cue => new CuePointDto
-            {
-                Ms = cue.Ms,
-                Type = cue.Type ?? string.Empty,
-                Direction = cue.Direction ?? string.Empty,
-                Score = cue.Score,
-            }),
+            .. (DjAnalysisJson.TryDeserialize<CuePointRow>(dj.CuePoints) ?? []).Select(
+                cue => new CuePointDto
+                {
+                    Ms = cue.Ms,
+                    Type = cue.Type ?? string.Empty,
+                    Direction = cue.Direction ?? string.Empty,
+                    Score = cue.Score,
+                }
+            ),
         ];
         Chords =
         [
-            .. (DjAnalysisJson.TryDeserialize<DjAnalysisJson.ChordRow>(dj.Chords) ?? []).Select(
+            .. (DjAnalysisJson.TryDeserialize<ChordRow>(dj.Chords) ?? []).Select(
                 chord => new ChordDto { Ms = chord.Ms, Chord = chord.Chord ?? string.Empty }
             ),
         ];

--- a/src/NoMercy.Api/DTOs/Music/TrackDjAnalysisDto.cs
+++ b/src/NoMercy.Api/DTOs/Music/TrackDjAnalysisDto.cs
@@ -1,0 +1,113 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+using NoMercy.Data.Music;
+using NoMercy.Database.Models.Music;
+using NoMercy.MediaProcessing.AudioAnalysis;
+
+namespace NoMercy.Api.DTOs.Music;
+
+/// <summary>
+/// The DJ half of a track's analysis: downbeat, phrases, vocal activity,
+/// per-bar energy, cue points and chords — written by the automix plugin,
+/// never by the server. Absent from <see cref="TrackAudioAnalysisDto.Dj" />
+/// whenever there is no Ok row, same as every other analysis measurement.
+/// </summary>
+public record TrackDjAnalysisDto
+{
+    [JsonProperty("dj_analyzer_version")]
+    public int DjAnalyzerVersion { get; set; }
+
+    /// <summary>
+    /// The base <see cref="TrackAudioAnalysisDto.AnalyzerVersion" /> this row
+    /// was computed against. A consumer holding a newer base analysis than
+    /// this can tell the DJ row is stale without re-deriving anything.
+    /// </summary>
+    [JsonProperty("base_analyzer_version")]
+    public int BaseAnalyzerVersion { get; set; }
+
+    /// <summary>Which beat of the base grid is beat 1. Null when undetected.</summary>
+    [JsonProperty("downbeat_index")]
+    public int? DownbeatIndex { get; set; }
+
+    [JsonProperty("beats_per_bar")]
+    public int BeatsPerBar { get; set; }
+
+    [JsonProperty("phrase_length_bars")]
+    public int PhraseLengthBars { get; set; }
+
+    /// <summary>Where each phrase begins, in track time.</summary>
+    [JsonProperty("phrase_starts_ms")]
+    public List<int> PhraseStartsMs { get; set; } = [];
+
+    /// <summary>Where a vocal is present, as [startMs, endMs] pairs.</summary>
+    [JsonProperty("vocal_regions_ms")]
+    public List<int[]> VocalRegionsMs { get; set; } = [];
+
+    /// <summary>Short-term loudness in LUFS per bar, index = bar.</summary>
+    [JsonProperty("bar_energy")]
+    public List<double> BarEnergy { get; set; } = [];
+
+    /// <summary>Candidate transition points, ranked by score descending.</summary>
+    [JsonProperty("cue_points")]
+    public List<CuePointDto> CuePoints { get; set; } = [];
+
+    /// <summary>The chord timeline.</summary>
+    [JsonProperty("chords")]
+    public List<ChordDto> Chords { get; set; } = [];
+
+    /// <summary>
+    /// 0 (C) .. 11 (B), derived from the base row's key name — a minor key's
+    /// tonic, e.g. "Am" reads as 9. Null when the base analysis has no key or
+    /// the detector named one <see cref="CamelotKey" /> does not recognise.
+    /// </summary>
+    [JsonProperty("pitch_class")]
+    public int? PitchClass { get; set; }
+
+    public TrackDjAnalysisDto() { }
+
+    /// <param name="dj">An Ok <see cref="TrackDjAnalysis" /> row.</param>
+    /// <param name="baseKeyName">
+    /// The matching <see cref="TrackAudioAnalysis.KeyName" />, if any — the DJ
+    /// row itself carries no key of its own.
+    /// </param>
+    public TrackDjAnalysisDto(TrackDjAnalysis dj, string? baseKeyName)
+    {
+        DjAnalyzerVersion = dj.DjAnalyzerVersion;
+        BaseAnalyzerVersion = dj.BaseAnalyzerVersion;
+        DownbeatIndex = dj.DownbeatIndex;
+        BeatsPerBar = dj.BeatsPerBar;
+        PhraseLengthBars = dj.PhraseLengthBars;
+        PhraseStartsMs = DjAnalysisJson.TryDeserialize<int>(dj.PhraseStartsMs) ?? [];
+        VocalRegionsMs = DjAnalysisJson.TryDeserialize<int[]>(dj.VocalRegionsMs) ?? [];
+        BarEnergy = DjAnalysisJson.TryDeserialize<double>(dj.BarEnergy) ?? [];
+        CuePoints =
+        [
+            .. (
+                DjAnalysisJson.TryDeserialize<DjAnalysisJson.CuePointRow>(dj.CuePoints) ?? []
+            ).Select(cue => new CuePointDto
+            {
+                Ms = cue.Ms,
+                Type = cue.Type ?? string.Empty,
+                Direction = cue.Direction ?? string.Empty,
+                Score = cue.Score,
+            }),
+        ];
+        Chords =
+        [
+            .. (DjAnalysisJson.TryDeserialize<DjAnalysisJson.ChordRow>(dj.Chords) ?? []).Select(
+                chord => new ChordDto { Ms = chord.Ms, Chord = chord.Chord ?? string.Empty }
+            ),
+        ];
+        PitchClass = CamelotKey.PitchClassFromKeyName(baseKeyName);
+    }
+}

--- a/src/NoMercy.Api/DTOs/Music/TrackStemDto.cs
+++ b/src/NoMercy.Api/DTOs/Music/TrackStemDto.cs
@@ -1,0 +1,72 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+using NoMercy.Database.Models.Music;
+
+namespace NoMercy.Api.DTOs.Music;
+
+/// <summary>One stem file available for a track, as the automix plugin registered it.</summary>
+public record TrackStemDto
+{
+    /// <summary>"vocals", "accompaniment"; later "drums", "bass", "other".</summary>
+    [JsonProperty("kind")]
+    public string Kind { get; set; } = string.Empty;
+
+    /// <summary>"full", "mixIn" or "mixOut" — which part of the track this stem covers.</summary>
+    [JsonProperty("coverage")]
+    public string Coverage { get; set; } = string.Empty;
+
+    /// <summary>Null when <see cref="Coverage" /> is "full".</summary>
+    [JsonProperty("window_start_ms")]
+    public int? WindowStartMs { get; set; }
+
+    [JsonProperty("window_end_ms")]
+    public int? WindowEndMs { get; set; }
+
+    [JsonProperty("format")]
+    public string Format { get; set; } = string.Empty;
+
+    [JsonProperty("sample_rate")]
+    public int SampleRate { get; set; }
+
+    [JsonProperty("storage_key")]
+    public string StorageKey { get; set; } = string.Empty;
+
+    /// <summary>Model and ffmpeg, e.g. "spleeter-2stems-f16@v1.0.41".</summary>
+    [JsonProperty("producer_version")]
+    public string ProducerVersion { get; set; } = string.Empty;
+
+    public TrackStemDto() { }
+
+    public TrackStemDto(TrackStem stem)
+    {
+        Kind = stem.Kind;
+        Coverage = CoverageToken(stem.Coverage);
+        WindowStartMs = stem.WindowStartMs;
+        WindowEndMs = stem.WindowEndMs;
+        Format = stem.Format;
+        SampleRate = stem.SampleRate;
+        StorageKey = stem.StorageKey;
+        ProducerVersion = stem.ProducerVersion;
+    }
+
+    /// <summary>
+    /// "Full" -> "full", "MixIn" -> "mixIn": the enum name with its first
+    /// letter lower-cased, rather than a switch that could fall out of step
+    /// with a new <see cref="StemCoverage" /> member.
+    /// </summary>
+    private static string CoverageToken(StemCoverage coverage)
+    {
+        string name = coverage.ToString();
+        return char.ToLowerInvariant(name[0]) + name[1..];
+    }
+}

--- a/src/NoMercy.Data/Music/ChordRow.cs
+++ b/src/NoMercy.Data/Music/ChordRow.cs
@@ -1,0 +1,20 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Data.Music;
+
+/// <summary>
+/// The shape one entry of <c>TrackDjAnalysis.Chords</c> takes on disk:
+/// <c>{ ms, chord }</c>. What <see cref="DjAnalysisJson" /> parses that
+/// column into — the one shape the plugin reader and the API's DJ analysis
+/// DTO both build their own chord type from.
+/// </summary>
+public sealed record ChordRow(int Ms, string? Chord);

--- a/src/NoMercy.Data/Music/CuePointRow.cs
+++ b/src/NoMercy.Data/Music/CuePointRow.cs
@@ -1,0 +1,20 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Data.Music;
+
+/// <summary>
+/// The shape one entry of <c>TrackDjAnalysis.CuePoints</c> takes on disk:
+/// <c>{ ms, type, direction, score }</c>. What <see cref="DjAnalysisJson" />
+/// parses that column into — the one shape the plugin reader and the API's
+/// DJ analysis DTO both build their own cue-point type from.
+/// </summary>
+public sealed record CuePointRow(int Ms, string? Type, string? Direction, double Score);

--- a/src/NoMercy.Data/Music/DjAnalysisJson.cs
+++ b/src/NoMercy.Data/Music/DjAnalysisJson.cs
@@ -17,14 +17,18 @@ namespace NoMercy.Data.Music;
 /// Parses the JSON text columns on <c>TrackDjAnalysis</c> — <c>phrase_starts_ms</c>,
 /// <c>vocal_regions_ms</c>, <c>bar_energy</c>, <c>cue_points</c>, <c>chords</c>.
 /// <para>
-/// The one place that knows the on-disk shape of those columns.
-/// <c>NoMercy.Data.Plugins.PluginMusicQuery</c> (what a plugin reads) and
-/// <c>NoMercy.Api.DTOs.Music.TrackDjAnalysisDto</c> (what the API returns) both
-/// call this instead of deserializing the text themselves, so the two surfaces
-/// can never quietly drift onto different shapes.
+/// The one parser for those columns' on-disk shape, shared by the two
+/// surfaces that read them: <c>NoMercy.Data.Plugins.PluginMusicQuery</c>
+/// (what a plugin reads) and <c>NoMercy.Api.DTOs.Music.TrackDjAnalysisDto</c>
+/// (what the API returns) both call this instead of deserializing the text
+/// themselves, so the two can never quietly drift onto different shapes.
+/// Public rather than a friend-assembly internal: <c>NoMercy.Api</c> already
+/// references <c>NoMercy.Data</c> for its repositories and entities, and a
+/// project-wide <c>InternalsVisibleTo</c> would open every other internal in
+/// this assembly to it just to reach this one helper.
 /// </para>
 /// </summary>
-internal static class DjAnalysisJson
+public static class DjAnalysisJson
 {
     private static readonly JsonSerializerOptions Options = new()
     {
@@ -35,10 +39,24 @@ internal static class DjAnalysisJson
     /// Null when <paramref name="json" /> is null, blank, or fails to parse —
     /// the caller decides what an absent or malformed column means to it (log
     /// it, default to empty, or something else). A valid but empty array still
-    /// comes back as an empty, non-null list.
+    /// comes back as an empty, non-null list. Discards the parse error; a
+    /// caller that wants it calls the <see cref="TryDeserialize{T}(string?, out Exception?)" />
+    /// overload instead.
     /// </summary>
-    public static List<T>? TryDeserialize<T>(string? json)
+    public static List<T>? TryDeserialize<T>(string? json) => TryDeserialize<T>(json, out _);
+
+    /// <summary>
+    /// Same contract as <see cref="TryDeserialize{T}(string?)" />, plus the
+    /// parse failure: <paramref name="error" /> is null when
+    /// <paramref name="json" /> was null/blank (nothing was ever parsed) and
+    /// the caught <see cref="JsonException" /> when it was present but
+    /// malformed — the two absence reasons a caller like
+    /// <c>PluginMusicQuery</c> logs differently.
+    /// </summary>
+    public static List<T>? TryDeserialize<T>(string? json, out Exception? error)
     {
+        error = null;
+
         if (string.IsNullOrWhiteSpace(json))
         {
             return null;
@@ -48,15 +66,10 @@ internal static class DjAnalysisJson
         {
             return JsonSerializer.Deserialize<List<T>>(json, Options) ?? [];
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
+            error = ex;
             return null;
         }
     }
-
-    /// <summary>The shape one entry of <c>cue_points</c> takes on disk: <c>{ ms, type, direction, score }</c>.</summary>
-    internal sealed record CuePointRow(int Ms, string? Type, string? Direction, double Score);
-
-    /// <summary>The shape one entry of <c>chords</c> takes on disk: <c>{ ms, chord }</c>.</summary>
-    internal sealed record ChordRow(int Ms, string? Chord);
 }

--- a/src/NoMercy.Data/Music/DjAnalysisJson.cs
+++ b/src/NoMercy.Data/Music/DjAnalysisJson.cs
@@ -1,0 +1,62 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using System.Text.Json;
+
+namespace NoMercy.Data.Music;
+
+/// <summary>
+/// Parses the JSON text columns on <c>TrackDjAnalysis</c> — <c>phrase_starts_ms</c>,
+/// <c>vocal_regions_ms</c>, <c>bar_energy</c>, <c>cue_points</c>, <c>chords</c>.
+/// <para>
+/// The one place that knows the on-disk shape of those columns.
+/// <c>NoMercy.Data.Plugins.PluginMusicQuery</c> (what a plugin reads) and
+/// <c>NoMercy.Api.DTOs.Music.TrackDjAnalysisDto</c> (what the API returns) both
+/// call this instead of deserializing the text themselves, so the two surfaces
+/// can never quietly drift onto different shapes.
+/// </para>
+/// </summary>
+internal static class DjAnalysisJson
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>
+    /// Null when <paramref name="json" /> is null, blank, or fails to parse —
+    /// the caller decides what an absent or malformed column means to it (log
+    /// it, default to empty, or something else). A valid but empty array still
+    /// comes back as an empty, non-null list.
+    /// </summary>
+    public static List<T>? TryDeserialize<T>(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<T>>(json, Options) ?? [];
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>The shape one entry of <c>cue_points</c> takes on disk: <c>{ ms, type, direction, score }</c>.</summary>
+    internal sealed record CuePointRow(int Ms, string? Type, string? Direction, double Score);
+
+    /// <summary>The shape one entry of <c>chords</c> takes on disk: <c>{ ms, chord }</c>.</summary>
+    internal sealed record ChordRow(int Ms, string? Chord);
+}

--- a/src/NoMercy.Data/NoMercy.Data.csproj
+++ b/src/NoMercy.Data/NoMercy.Data.csproj
@@ -10,6 +10,10 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="NoMercy.Tests.Repositories" />
+    <!-- TrackDjAnalysisDto (NoMercy.Api) parses the same JSON columns
+         DjAnalysisJson.TryDeserialize already parses for PluginMusicQuery, so
+         the API and the automix plugin never disagree on the shape. -->
+    <InternalsVisibleTo Include="NoMercy.Api" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NoMercy.Data/NoMercy.Data.csproj
+++ b/src/NoMercy.Data/NoMercy.Data.csproj
@@ -10,10 +10,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="NoMercy.Tests.Repositories" />
-    <!-- TrackDjAnalysisDto (NoMercy.Api) parses the same JSON columns
-         DjAnalysisJson.TryDeserialize already parses for PluginMusicQuery, so
-         the API and the automix plugin never disagree on the shape. -->
-    <InternalsVisibleTo Include="NoMercy.Api" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NoMercy.Data/Plugins/IPluginAudioToolsFactory.cs
+++ b/src/NoMercy.Data/Plugins/IPluginAudioToolsFactory.cs
@@ -1,0 +1,30 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using NoMercy.Plugins.Abstractions;
+
+namespace NoMercy.Data.Plugins;
+
+/// <summary>
+/// Hands out the host's <see cref="IPluginAudioTools" /> for one plugin.
+/// <para>
+/// The same instance every time for the same plugin, deliberately: the
+/// one-ffmpeg-at-a-time guard lives inside the instance, so a fresh one per
+/// call would let a plugin start as many ffmpeg processes as it has call
+/// sites. Whether a plugin may have these tools at all is the
+/// <c>PluginHookCapability.AudioTools</c> question the plugin host answers
+/// before asking for them, not something this factory re-checks.
+/// </para>
+/// </summary>
+public interface IPluginAudioToolsFactory
+{
+    IPluginAudioTools CreateFor(Ulid pluginId);
+}

--- a/src/NoMercy.Data/Plugins/IPluginMusicAnalysisWriterFactory.cs
+++ b/src/NoMercy.Data/Plugins/IPluginMusicAnalysisWriterFactory.cs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using NoMercy.Plugins.Abstractions;
+
+namespace NoMercy.Data.Plugins;
+
+/// <summary>
+/// Builds the host's <see cref="IPluginMusicAnalysisWriter" /> for one plugin.
+/// <para>
+/// Unlike <c>IPluginLibraryWriterFactory</c>, this never returns null: the
+/// grant question here is whether a plugin declared
+/// <c>PluginHookCapability.MusicAnalysisWrite</c>, which the plugin host
+/// checks before handing the writer out at all, not something this factory
+/// re-checks per call.
+/// </para>
+/// </summary>
+public interface IPluginMusicAnalysisWriterFactory
+{
+    IPluginMusicAnalysisWriter CreateFor(Ulid pluginId);
+}

--- a/src/NoMercy.Data/Plugins/PluginAudioArguments.cs
+++ b/src/NoMercy.Data/Plugins/PluginAudioArguments.cs
@@ -72,7 +72,19 @@ internal static class PluginAudioArguments
     /// because a stem is an intermediate a transition is rendered from, not
     /// something a listener ever hears on its own.
     /// </summary>
-    /// <param name="windowArguments">Empty for full coverage; otherwise the <c>-t</c> or <c>-ss</c> pair.</param>
+    /// <param name="windowArguments">
+    /// Empty for full coverage; otherwise the <c>-t</c> or <c>-ss</c> pair.
+    /// They go BEFORE <c>-i</c>, as input options. In ffmpeg's grammar an
+    /// option binds to the next file named after it, so a window placed after
+    /// the input would apply to the first output alone: the vocals stem would
+    /// be the window and the accompaniment stem the whole track, while both
+    /// were registered with the same window milliseconds. As an input option
+    /// it trims the decoded stream instead, so both output pads see the same
+    /// audio and stemsplit never separates seconds that are thrown away
+    /// afterwards. Input <c>-ss</c> still decodes up to the exact point
+    /// (accurate seek is the default), so the registered window milliseconds
+    /// stay true to the samples.
+    /// </param>
     internal static string[] StemSplit(
         string inputPath,
         IReadOnlyList<string> windowArguments,
@@ -81,9 +93,9 @@ internal static class PluginAudioArguments
     ) =>
         [
             "-nostdin",
+            .. windowArguments,
             "-i",
             inputPath,
-            .. windowArguments,
             "-vn",
             "-sn",
             "-dn",

--- a/src/NoMercy.Data/Plugins/PluginAudioArguments.cs
+++ b/src/NoMercy.Data/Plugins/PluginAudioArguments.cs
@@ -1,0 +1,131 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using NoMercy.NmSystem.Information;
+
+namespace NoMercy.Data.Plugins;
+
+/// <summary>
+/// The exact ffmpeg command lines <see cref="PluginAudioTools" /> runs, kept
+/// apart from the decisions around them. Every argument here is asserted on
+/// in the tests: a plugin's filter graph is the one thing the host cannot
+/// re-derive from the outcome, so the command has to be readable on its own
+/// rather than assembled in the middle of a method that also resolves paths,
+/// takes a lock and talks to the database.
+/// </summary>
+internal static class PluginAudioArguments
+{
+    /// <summary>What a plugin writes in its filter text where the model file's name belongs.</summary>
+    private const string ModelToken = "{stemsModel}";
+
+    /// <summary>
+    /// The model file's own name, not its path: ffmpeg runs with
+    /// <see cref="AppFiles.FfmpegFolder" /> as its working directory, so a
+    /// bare name resolves there on every machine.
+    /// </summary>
+    internal static string ModelFileName => AppFiles.StemsplitModel + ".gguf";
+
+    /// <summary>Substitutes the model file's name for <c>{stemsModel}</c>.</summary>
+    internal static string ApplyModelToken(string text) =>
+        text.Replace(ModelToken, ModelFileName, StringComparison.Ordinal);
+
+    /// <summary>
+    /// One filter chain over one input, decoded and thrown away: the plugin
+    /// is after what the filters print, not after a file.
+    /// <para>
+    /// A complex graph also maps the input to the null muxer, because a
+    /// <c>-filter_complex</c> whose output pads nothing consumes makes ffmpeg
+    /// refuse to run at all.
+    /// </para>
+    /// </summary>
+    internal static string[] FilterGraph(string inputPath, string text, bool complex) =>
+        complex
+            ?
+            [
+                "-nostdin",
+                "-i",
+                inputPath,
+                "-vn",
+                "-sn",
+                "-dn",
+                "-filter_complex",
+                text,
+                "-map",
+                "0:a",
+                "-f",
+                "null",
+                "-",
+            ]
+            : ["-nostdin", "-i", inputPath, "-vn", "-sn", "-dn", "-af", text, "-f", "null", "-"];
+
+    /// <summary>
+    /// Spleeter 2 stems in one pass: the filter has two output pads, vocals
+    /// first, and each is encoded to its own Opus file. 160 kbit/s at 48 kHz
+    /// because a stem is an intermediate a transition is rendered from, not
+    /// something a listener ever hears on its own.
+    /// </summary>
+    /// <param name="windowArguments">Empty for full coverage; otherwise the <c>-t</c> or <c>-ss</c> pair.</param>
+    internal static string[] StemSplit(
+        string inputPath,
+        IReadOnlyList<string> windowArguments,
+        string vocalsPath,
+        string accompanimentPath
+    ) =>
+        [
+            "-nostdin",
+            "-i",
+            inputPath,
+            .. windowArguments,
+            "-vn",
+            "-sn",
+            "-dn",
+            "-filter_complex",
+            $"[0:a]stemsplit=model={ModelFileName}[voc][acc]",
+            "-map",
+            "[voc]",
+            "-c:a",
+            "libopus",
+            "-b:a",
+            "160k",
+            "-ar",
+            "48000",
+            vocalsPath,
+            "-map",
+            "[acc]",
+            "-c:a",
+            "libopus",
+            "-b:a",
+            "160k",
+            "-ar",
+            "48000",
+            accompanimentPath,
+        ];
+
+    /// <summary>
+    /// The build token out of ffmpeg's own banner - the first line it writes
+    /// to stderr, <c>ffmpeg version 9.0-NoMercy-MediaServer …</c>. It goes
+    /// into every stem's producer version, so a model or binary upgrade can
+    /// be spotted the way an analyzer upgrade is; "unknown" when the banner
+    /// was not what it usually is, which is still better than no marker.
+    /// </summary>
+    internal static string FfmpegVersion(string? bannerLine)
+    {
+        const string prefix = "ffmpeg version ";
+
+        if (bannerLine is null || !bannerLine.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return "unknown";
+        }
+
+        string token = bannerLine[prefix.Length..].Split(' ')[0].Trim();
+        return token.Length == 0 ? "unknown" : token;
+    }
+}

--- a/src/NoMercy.Data/Plugins/PluginAudioTools.cs
+++ b/src/NoMercy.Data/Plugins/PluginAudioTools.cs
@@ -20,6 +20,7 @@ using NoMercy.Encoder.Infrastructure;
 using NoMercy.Encoder.Startup;
 using NoMercy.MediaProcessing.DerivedAudio;
 using NoMercy.NmSystem.Information;
+using NoMercy.Plugins;
 using NoMercy.Plugins.Abstractions;
 using NoMercy.Storage;
 

--- a/src/NoMercy.Data/Plugins/PluginAudioTools.cs
+++ b/src/NoMercy.Data/Plugins/PluginAudioTools.cs
@@ -504,8 +504,10 @@ public sealed class PluginAudioTools(
     {
         if (input.StorageKey is not null)
         {
+            // Checked before the store is asked anything: answering about a key
+            // means slicing it into a path, and this key came from a plugin.
             if (
-                string.IsNullOrWhiteSpace(input.StorageKey)
+                !DerivedAudioKey.IsValid(input.StorageKey)
                 || !await store.ExistsAsync(input.StorageKey, ct)
             )
             {

--- a/src/NoMercy.Data/Plugins/PluginAudioTools.cs
+++ b/src/NoMercy.Data/Plugins/PluginAudioTools.cs
@@ -1,0 +1,576 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using System.Globalization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NoMercy.Database;
+using NoMercy.Database.Models.Music;
+using NoMercy.Encoder.Composition;
+using NoMercy.Encoder.Infrastructure;
+using NoMercy.Encoder.Startup;
+using NoMercy.MediaProcessing.DerivedAudio;
+using NoMercy.NmSystem.Information;
+using NoMercy.Plugins.Abstractions;
+using NoMercy.Storage;
+
+namespace NoMercy.Data.Plugins;
+
+/// <summary>
+/// Runs the server's own ffmpeg build on behalf of one plugin - the host side
+/// of <see cref="IPluginAudioTools" />.
+/// <para>
+/// Every rejection comes back as a refusal in words rather than as an
+/// exception, for the same reason the analysis writer does it: a plugin's
+/// sweep runs unattended, and a stack trace nobody reads is worth nothing
+/// next to a reason the owner can act on.
+/// </para>
+/// <para>
+/// One instance per plugin, and one ffmpeg at a time inside it. A plugin that
+/// fans out a library sweep would otherwise start one ffmpeg per track and
+/// take the owner's machine down with work it is not even watching; the
+/// second call is refused rather than queued, so the plugin decides what to
+/// do about it instead of accumulating an invisible backlog.
+/// </para>
+/// </summary>
+public sealed class PluginAudioTools(
+    Ulid pluginId,
+    EncoderOptions options,
+    IProcessRunner processRunner,
+    IStorage storage,
+    IStorageDriver storageDriver,
+    IStorage derivedStorage,
+    IDerivedAudioStore store,
+    IPluginMusicAnalysisWriterFactory writerFactory,
+    IDbContextFactory<MediaContext> contextFactory,
+    IFfmpegCapabilityProbe capabilityProbe,
+    ILogger<PluginAudioTools>? logger = null
+) : IPluginAudioTools
+{
+    /// <summary>Matches the analysis pass: ffmpeg on a stalled mount never returns on its own.</summary>
+    private static readonly TimeSpan RunTimeout = TimeSpan.FromMinutes(10);
+
+    /// <summary>The derived store's own scratch folder; its eviction sweep also cleans it.</summary>
+    private const string TempFolder = "tmp";
+
+    private const string OpusContentType = "audio/ogg";
+    private const string OpusFormat = "opus";
+    private const int OpusSampleRate = 48000;
+
+    /// <summary>The share of a track a mix into it draws from.</summary>
+    private const double MixInShare = 0.20;
+
+    /// <summary>Where the window a mix out of a track draws from starts.</summary>
+    private const double MixOutStart = 0.75;
+
+    private const string FfmpegMissing = "ffmpeg is not installed";
+    private const string StemsplitModelMissing = "the stemsplit model is not installed";
+    private const string RunInProgress = "another ffmpeg run of this plugin is still in progress";
+
+    private readonly SemaphoreSlim _oneRunAtATime = new(1, 1);
+
+    private readonly ILogger<PluginAudioTools> _logger =
+        logger ?? NullLogger<PluginAudioTools>.Instance;
+
+    public async Task<PluginAudioRunResult> RunFilterGraphAsync(
+        PluginAudioInput input,
+        PluginFilterGraph graph,
+        Action<string>? onStdOut,
+        Action<string>? onStdErr,
+        CancellationToken ct = default
+    )
+    {
+        string? ffmpegPath = ResolveFfmpegPath();
+        if (ffmpegPath is null)
+        {
+            return PluginAudioRunResult.Refused(FfmpegMissing);
+        }
+
+        string text = PluginAudioArguments.ApplyModelToken(graph.Text);
+
+        // The filter exists in the build whether or not the model was ever
+        // downloaded, so ffmpeg would start, read the whole input and only
+        // then fail. Cheaper, and far clearer, to say so up front.
+        if (text.Contains("stemsplit", StringComparison.Ordinal) && !StemsplitModelPresent())
+        {
+            return PluginAudioRunResult.Refused(StemsplitModelMissing);
+        }
+
+        if (!await _oneRunAtATime.WaitAsync(0, ct))
+        {
+            return PluginAudioRunResult.Refused(RunInProgress);
+        }
+
+        try
+        {
+            InputResolution resolved = await ResolveInputAsync(input, ct);
+            if (resolved.Refusal is not null)
+            {
+                return PluginAudioRunResult.Refused(resolved.Refusal);
+            }
+
+            await using LocalPathLease lease = resolved.Lease!;
+
+            string[] arguments = PluginAudioArguments.FilterGraph(lease.Path, text, graph.Complex);
+
+            ProcessResult? result = await RunFfmpegAsync(
+                ffmpegPath,
+                arguments,
+                onStdOut,
+                onStdErr,
+                ct
+            );
+
+            // Null is the timeout: -2 rather than a refusal, because the run
+            // did start - the plugin's graph was accepted and its callbacks
+            // saw whatever ffmpeg managed to print before the clock ran out.
+            return result is null
+                ? new PluginAudioRunResult(-2, null)
+                : new PluginAudioRunResult(result.ExitCode, null);
+        }
+        finally
+        {
+            _oneRunAtATime.Release();
+        }
+    }
+
+    public async Task<PluginStemSplitResult> SplitStemsAsync(
+        string trackId,
+        PluginStemCoverage coverage,
+        PluginStemSet stemSet,
+        CancellationToken ct = default
+    )
+    {
+        // The 4stems model is not in the ffmpeg build yet. Saying so beats
+        // silently handing back two stems a caller asked four of.
+        if (stemSet == PluginStemSet.Four)
+        {
+            return PluginStemSplitResult.Refused("four-stem splitting is not available yet");
+        }
+
+        string? ffmpegPath = ResolveFfmpegPath();
+        if (ffmpegPath is null)
+        {
+            return PluginStemSplitResult.Refused(FfmpegMissing);
+        }
+
+        if (!StemsplitModelPresent())
+        {
+            return PluginStemSplitResult.Refused(StemsplitModelMissing);
+        }
+
+        if (!Guid.TryParse(trackId, out Guid id))
+        {
+            return PluginStemSplitResult.Refused($"track {trackId} has no file");
+        }
+
+        TrackFile? file = await LoadTrackFileAsync(id, ct);
+        if (file is null)
+        {
+            return PluginStemSplitResult.Refused($"track {trackId} has no file");
+        }
+
+        // Only a windowed split needs the duration. A full split of a track
+        // the scan never timed is still a perfectly good split, so it is not
+        // refused for a value it does not use.
+        StemWindow? window = BuildWindow(coverage, file.DurationSeconds);
+        if (window is null)
+        {
+            return PluginStemSplitResult.Refused($"track {trackId} has no duration");
+        }
+
+        if (!await _oneRunAtATime.WaitAsync(0, ct))
+        {
+            return PluginStemSplitResult.Refused(RunInProgress);
+        }
+
+        try
+        {
+            return await SplitInsideTheLockAsync(ffmpegPath, id, file, coverage, window, ct);
+        }
+        finally
+        {
+            _oneRunAtATime.Release();
+        }
+    }
+
+    /// <summary>
+    /// The split itself, with the one-ffmpeg-per-plugin lock already held.
+    /// Split out so the lock's <c>finally</c> stays next to its
+    /// <c>WaitAsync</c> instead of a hundred lines away from it.
+    /// </summary>
+    private async Task<PluginStemSplitResult> SplitInsideTheLockAsync(
+        string ffmpegPath,
+        Guid trackId,
+        TrackFile file,
+        PluginStemCoverage coverage,
+        StemWindow window,
+        CancellationToken ct
+    )
+    {
+        await derivedStorage.CreateDirectoryAsync(TempFolder, ct);
+
+        // ffmpeg writes the two stems as plain files first; only content that
+        // finished being written gets a content-addressed key.
+        Ulid batch = Ulid.NewUlid();
+        string vocalsTemp = $"{TempFolder}/{batch}-vocals.opus";
+        string accompanimentTemp = $"{TempFolder}/{batch}-accompaniment.opus";
+
+        await using LocalPathLease inputLease = await storage.AcquireLocalPathAsync(file.Path, ct);
+        await using LocalPathLease vocalsLease = await derivedStorage.AcquireLocalPathAsync(
+            vocalsTemp,
+            ct
+        );
+        await using LocalPathLease accompanimentLease = await derivedStorage.AcquireLocalPathAsync(
+            accompanimentTemp,
+            ct
+        );
+
+        string[] arguments = PluginAudioArguments.StemSplit(
+            inputLease.Path,
+            window.Arguments,
+            vocalsLease.Path,
+            accompanimentLease.Path
+        );
+
+        string? bannerLine = null;
+        Queue<string> stdErrTail = new();
+
+        void CaptureStdErr(string line)
+        {
+            bannerLine ??= line;
+            stdErrTail.Enqueue(line);
+            if (stdErrTail.Count > 5)
+            {
+                stdErrTail.Dequeue();
+            }
+        }
+
+        ProcessResult? result = await RunFfmpegAsync(
+            ffmpegPath,
+            arguments,
+            null,
+            CaptureStdErr,
+            ct
+        );
+
+        if (result is null)
+        {
+            await DeleteTempAsync(vocalsTemp, ct);
+            await DeleteTempAsync(accompanimentTemp, ct);
+            return PluginStemSplitResult.Refused(
+                $"stemsplit timed out after {RunTimeout.TotalSeconds:0} seconds"
+            );
+        }
+
+        if (result.ExitCode != 0)
+        {
+            _logger.LogWarning(
+                "plugin {PluginId}: stemsplit exited with {Exit} for track {TrackId}: {StdErr}",
+                pluginId,
+                result.ExitCode,
+                trackId,
+                string.Join(" | ", stdErrTail)
+            );
+
+            await DeleteTempAsync(vocalsTemp, ct);
+            await DeleteTempAsync(accompanimentTemp, ct);
+            return PluginStemSplitResult.Refused($"stemsplit exited with {result.ExitCode}");
+        }
+
+        // Both files land in the store, and both temps go, before anything is
+        // registered: a registration that refuses halfway must not leave a
+        // scratch file behind for the eviction sweep to find hours later.
+        DerivedAudioEntry vocals = await StoreTempAsync(vocalsTemp, ct);
+        DerivedAudioEntry accompaniment = await StoreTempAsync(accompanimentTemp, ct);
+
+        string producerVersion =
+            $"{AppFiles.StemsplitModel}@{PluginAudioArguments.FfmpegVersion(bannerLine)}";
+
+        IPluginMusicAnalysisWriter writer = writerFactory.CreateFor(pluginId);
+
+        List<PluginStemFile> stems = [];
+        foreach (
+            (string kind, DerivedAudioEntry entry) in new[]
+            {
+                ("vocals", vocals),
+                ("accompaniment", accompaniment),
+            }
+        )
+        {
+            PluginWriteResult write = await writer.RegisterStemAsync(
+                new PluginTrackStem(
+                    trackId,
+                    kind,
+                    coverage,
+                    window.StartMs,
+                    window.EndMs,
+                    OpusFormat,
+                    OpusSampleRate,
+                    entry.Key,
+                    producerVersion
+                ),
+                ct
+            );
+
+            if (!write.Ok)
+            {
+                return PluginStemSplitResult.Refused(write.Refusal!);
+            }
+
+            stems.Add(new PluginStemFile(kind, coverage, entry.Key, entry.Bytes));
+        }
+
+        return new PluginStemSplitResult(stems, null);
+    }
+
+    /// <summary>Moves one finished temp file into the content-addressed store and drops the temp.</summary>
+    private async Task<DerivedAudioEntry> StoreTempAsync(string tempPath, CancellationToken ct)
+    {
+        DerivedAudioEntry entry;
+        await using (Stream content = await derivedStorage.OpenReadAsync(tempPath, ct))
+        {
+            entry = await store.PutAsync(content, OpusContentType, ct);
+        }
+
+        await DeleteTempAsync(tempPath, ct);
+        return entry;
+    }
+
+    /// <summary>
+    /// Best-effort: a temp file that will not go is a wasted megabyte the
+    /// derived store's own sweep clears later, never a reason to fail a split
+    /// whose stems are already safely stored.
+    /// </summary>
+    private async Task DeleteTempAsync(string tempPath, CancellationToken ct)
+    {
+        try
+        {
+            if (await derivedStorage.ExistsAsync(tempPath, ct))
+            {
+                await derivedStorage.DeleteAsync(tempPath, ct);
+            }
+        }
+        catch (IOException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "plugin {PluginId}: could not remove the stem scratch file",
+                pluginId
+            );
+        }
+    }
+
+    /// <summary>
+    /// One ffmpeg run with the host's own timeout on top of the caller's
+    /// token. Null means the timeout fired; the caller decides what that is
+    /// worth to it.
+    /// </summary>
+    private async Task<ProcessResult?> RunFfmpegAsync(
+        string ffmpegPath,
+        string[] arguments,
+        Action<string>? onStdOut,
+        Action<string>? onStdErr,
+        CancellationToken ct
+    )
+    {
+        using CancellationTokenSource runCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        runCts.CancelAfter(RunTimeout);
+
+        try
+        {
+            return await processRunner.RunAsync(
+                ffmpegPath,
+                arguments,
+                onStdOut,
+                onStdErr,
+                AppFiles.FfmpegFolder,
+                runCts.Token
+            );
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                "plugin {PluginId}: ffmpeg run timed out after {Seconds}s",
+                pluginId,
+                RunTimeout.TotalSeconds
+            );
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// The configured ffmpeg, or null when there is none. Read from the
+    /// override rather than from <see cref="EncoderOptions.FfmpegPath" />,
+    /// which throws when nothing was configured - an unconfigured server is a
+    /// refusal here, not a crash inside a plugin's sweep.
+    /// </summary>
+    private string? ResolveFfmpegPath()
+    {
+        string? path = options.FfmpegPathOverride;
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return storage.Exists(path) ? path : null;
+        }
+        catch (Exception)
+        {
+            // The capability probe treats an unreadable path the same way:
+            // whatever the reason, this server cannot run ffmpeg from here.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Whether the Spleeter GGUF is on this machine. The capability probe is
+    /// the authority, but it runs deferred, so before its first report the
+    /// same file check it makes stands in - better than refusing every split
+    /// during the minutes after a restart.
+    /// </summary>
+    private bool StemsplitModelPresent()
+    {
+        CapabilityReport? report = capabilityProbe.GetCachedReport();
+        if (report is not null)
+        {
+            return report.StemsplitModelPresent;
+        }
+
+        try
+        {
+            return storage.Exists(AppFiles.StemsplitModelPath);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Turns the plugin's input into a local path ffmpeg can open, or a reason it cannot.</summary>
+    private async Task<InputResolution> ResolveInputAsync(
+        PluginAudioInput input,
+        CancellationToken ct
+    )
+    {
+        if (input.StorageKey is not null)
+        {
+            if (
+                string.IsNullOrWhiteSpace(input.StorageKey)
+                || !await store.ExistsAsync(input.StorageKey, ct)
+            )
+            {
+                return new(null, $"storage key {input.StorageKey} is not in the derived store");
+            }
+
+            return new(
+                await derivedStorage.AcquireLocalPathAsync(
+                    store.RelativePath(input.StorageKey),
+                    ct
+                ),
+                null
+            );
+        }
+
+        if (input.TrackId is null)
+        {
+            return new(null, "the input names neither a track nor a derived file");
+        }
+
+        if (!Guid.TryParse(input.TrackId, out Guid trackId))
+        {
+            return new(null, $"track {input.TrackId} has no file");
+        }
+
+        TrackFile? file = await LoadTrackFileAsync(trackId, ct);
+        if (file is null)
+        {
+            return new(null, $"track {input.TrackId} has no file");
+        }
+
+        return new(await storage.AcquireLocalPathAsync(file.Path, ct), null);
+    }
+
+    /// <summary>
+    /// A track's file and duration, or null when the library has no file for
+    /// it - an unknown id and a track the scan never found a file for are the
+    /// same absence to a caller that wanted to run ffmpeg over it.
+    /// </summary>
+    private async Task<TrackFile?> LoadTrackFileAsync(Guid trackId, CancellationToken ct)
+    {
+        await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
+
+        Track? track = await context
+            .Tracks.AsNoTracking()
+            .FirstOrDefaultAsync(row => row.Id == trackId, ct);
+
+        if (
+            track is null
+            || string.IsNullOrWhiteSpace(track.HostFolder)
+            || string.IsNullOrWhiteSpace(track.Filename)
+        )
+        {
+            return null;
+        }
+
+        return new(
+            storageDriver.CombinePath(track.HostFolder, track.Filename),
+            PluginMusicQuery.ParseDurationSeconds(track.Duration)
+        );
+    }
+
+    /// <summary>
+    /// The seek arguments for a coverage, and the same window in milliseconds
+    /// for the register row. Null when a window was asked for and the track's
+    /// duration is unknown, which is the one case that cannot be computed.
+    /// </summary>
+    private static StemWindow? BuildWindow(PluginStemCoverage coverage, double? durationSeconds)
+    {
+        if (coverage == PluginStemCoverage.Full)
+        {
+            return new([], null, null);
+        }
+
+        if (durationSeconds is not > 0)
+        {
+            return null;
+        }
+
+        double duration = durationSeconds.Value;
+
+        if (coverage == PluginStemCoverage.MixIn)
+        {
+            double end = duration * MixInShare;
+            return new(["-t", Seconds(end)], 0, Milliseconds(end));
+        }
+
+        double start = duration * MixOutStart;
+        return new(["-ss", Seconds(start)], Milliseconds(start), Milliseconds(duration));
+    }
+
+    /// <summary>Seconds as ffmpeg reads them: invariant, and no decimal tail when there is none.</summary>
+    private static string Seconds(double value) =>
+        value.ToString("0.###", CultureInfo.InvariantCulture);
+
+    private static int Milliseconds(double seconds) => (int)Math.Round(seconds * 1000);
+
+    /// <summary>A resolved input, or the reason there is none. Exactly one of the two is set.</summary>
+    private sealed record InputResolution(LocalPathLease? Lease, string? Refusal);
+
+    /// <summary>Where a track's audio is, and how long it runs when the library knows.</summary>
+    private sealed record TrackFile(string Path, double? DurationSeconds);
+
+    /// <summary>What a coverage means to ffmpeg, and what it means to the stem register.</summary>
+    private sealed record StemWindow(string[] Arguments, int? StartMs, int? EndMs);
+}

--- a/src/NoMercy.Data/Plugins/PluginAudioTools.cs
+++ b/src/NoMercy.Data/Plugins/PluginAudioTools.cs
@@ -225,115 +225,140 @@ public sealed class PluginAudioTools(
         string vocalsTemp = $"{TempFolder}/{batch}-vocals.opus";
         string accompanimentTemp = $"{TempFolder}/{batch}-accompaniment.opus";
 
-        await using LocalPathLease inputLease = await storage.AcquireLocalPathAsync(file.Path, ct);
-        await using LocalPathLease vocalsLease = await derivedStorage.AcquireLocalPathAsync(
-            vocalsTemp,
-            ct
-        );
-        await using LocalPathLease accompanimentLease = await derivedStorage.AcquireLocalPathAsync(
-            accompanimentTemp,
-            ct
-        );
-
-        string[] arguments = PluginAudioArguments.StemSplit(
-            inputLease.Path,
-            window.Arguments,
-            vocalsLease.Path,
-            accompanimentLease.Path
-        );
-
-        string? bannerLine = null;
-        Queue<string> stdErrTail = new();
-
-        void CaptureStdErr(string line)
+        try
         {
-            bannerLine ??= line;
-            stdErrTail.Enqueue(line);
-            if (stdErrTail.Count > 5)
-            {
-                stdErrTail.Dequeue();
-            }
-        }
-
-        ProcessResult? result = await RunFfmpegAsync(
-            ffmpegPath,
-            arguments,
-            null,
-            CaptureStdErr,
-            ct
-        );
-
-        if (result is null)
-        {
-            await DeleteTempAsync(vocalsTemp, ct);
-            await DeleteTempAsync(accompanimentTemp, ct);
-            return PluginStemSplitResult.Refused(
-                $"stemsplit timed out after {RunTimeout.TotalSeconds:0} seconds"
-            );
-        }
-
-        if (result.ExitCode != 0)
-        {
-            _logger.LogWarning(
-                "plugin {PluginId}: stemsplit exited with {Exit} for track {TrackId}: {StdErr}",
-                pluginId,
-                result.ExitCode,
-                trackId,
-                string.Join(" | ", stdErrTail)
-            );
-
-            await DeleteTempAsync(vocalsTemp, ct);
-            await DeleteTempAsync(accompanimentTemp, ct);
-            return PluginStemSplitResult.Refused($"stemsplit exited with {result.ExitCode}");
-        }
-
-        // Both files land in the store, and both temps go, before anything is
-        // registered: a registration that refuses halfway must not leave a
-        // scratch file behind for the eviction sweep to find hours later.
-        DerivedAudioEntry vocals = await StoreTempAsync(vocalsTemp, ct);
-        DerivedAudioEntry accompaniment = await StoreTempAsync(accompanimentTemp, ct);
-
-        string producerVersion =
-            $"{AppFiles.StemsplitModel}@{PluginAudioArguments.FfmpegVersion(bannerLine)}";
-
-        IPluginMusicAnalysisWriter writer = writerFactory.CreateFor(pluginId);
-
-        List<PluginStemFile> stems = [];
-        foreach (
-            (string kind, DerivedAudioEntry entry) in new[]
-            {
-                ("vocals", vocals),
-                ("accompaniment", accompaniment),
-            }
-        )
-        {
-            PluginWriteResult write = await writer.RegisterStemAsync(
-                new PluginTrackStem(
-                    trackId,
-                    kind,
-                    coverage,
-                    window.StartMs,
-                    window.EndMs,
-                    OpusFormat,
-                    OpusSampleRate,
-                    entry.Key,
-                    producerVersion
-                ),
+            await using LocalPathLease inputLease = await storage.AcquireLocalPathAsync(
+                file.Path,
                 ct
             );
 
-            if (!write.Ok)
+            // A lease on a path ffmpeg WRITES to. LocalPathLease documents a
+            // read-only staging contract - a future remote driver would stage
+            // the object into a temp file and drop it on dispose, which is the
+            // wrong direction for an output. It holds here because the derived
+            // store is always local storage (a LocalStorage scoped to
+            // AppFiles.DerivedAudioPath, see ServiceConfiguration.Core), so the
+            // lease hands back the real path unchanged. The day the derived
+            // store can live on a remote driver, this needs a
+            // put-from-lease helper on IStorage rather than a plain lease.
+            await using LocalPathLease vocalsLease = await derivedStorage.AcquireLocalPathAsync(
+                vocalsTemp,
+                ct
+            );
+            await using LocalPathLease accompanimentLease =
+                await derivedStorage.AcquireLocalPathAsync(accompanimentTemp, ct);
+
+            string[] arguments = PluginAudioArguments.StemSplit(
+                inputLease.Path,
+                window.Arguments,
+                vocalsLease.Path,
+                accompanimentLease.Path
+            );
+
+            string? bannerLine = null;
+            Queue<string> stdErrTail = new();
+
+            void CaptureStdErr(string line)
             {
-                return PluginStemSplitResult.Refused(write.Refusal!);
+                bannerLine ??= line;
+                stdErrTail.Enqueue(line);
+                if (stdErrTail.Count > 5)
+                {
+                    stdErrTail.Dequeue();
+                }
             }
 
-            stems.Add(new PluginStemFile(kind, coverage, entry.Key, entry.Bytes));
-        }
+            ProcessResult? result = await RunFfmpegAsync(
+                ffmpegPath,
+                arguments,
+                null,
+                CaptureStdErr,
+                ct
+            );
 
-        return new PluginStemSplitResult(stems, null);
+            if (result is null)
+            {
+                return PluginStemSplitResult.Refused(
+                    $"stemsplit timed out after {RunTimeout.TotalSeconds:0} seconds"
+                );
+            }
+
+            if (result.ExitCode != 0)
+            {
+                _logger.LogWarning(
+                    "plugin {PluginId}: stemsplit exited with {Exit} for track {TrackId}: {StdErr}",
+                    pluginId,
+                    result.ExitCode,
+                    trackId,
+                    string.Join(" | ", stdErrTail)
+                );
+
+                return PluginStemSplitResult.Refused($"stemsplit exited with {result.ExitCode}");
+            }
+
+            // Both files land in the store before anything is registered, so a
+            // registration that refuses halfway leaves no stem stored without
+            // its twin.
+            DerivedAudioEntry vocals = await StoreTempAsync(vocalsTemp, ct);
+            DerivedAudioEntry accompaniment = await StoreTempAsync(accompanimentTemp, ct);
+
+            string producerVersion =
+                $"{AppFiles.StemsplitModel}@{PluginAudioArguments.FfmpegVersion(bannerLine)}";
+
+            IPluginMusicAnalysisWriter writer = writerFactory.CreateFor(pluginId);
+
+            List<PluginStemFile> stems = [];
+            foreach (
+                (string kind, DerivedAudioEntry entry) in new[]
+                {
+                    ("vocals", vocals),
+                    ("accompaniment", accompaniment),
+                }
+            )
+            {
+                PluginWriteResult write = await writer.RegisterStemAsync(
+                    new PluginTrackStem(
+                        trackId,
+                        kind,
+                        coverage,
+                        window.StartMs,
+                        window.EndMs,
+                        OpusFormat,
+                        OpusSampleRate,
+                        entry.Key,
+                        producerVersion
+                    ),
+                    ct
+                );
+
+                if (!write.Ok)
+                {
+                    return PluginStemSplitResult.Refused(write.Refusal!);
+                }
+
+                stems.Add(new PluginStemFile(kind, coverage, entry.Key, entry.Bytes));
+            }
+
+            return new PluginStemSplitResult(stems, null);
+        }
+        finally
+        {
+            // Every way out of the block above - a refusal, a cancelled token,
+            // a throw from the store - would otherwise leave two scratch files
+            // for the derived store's eviction sweep to find hours later.
+            // CancellationToken.None deliberately: cleanup after a cancellation
+            // is exactly when it matters, and deleting a file the caller no
+            // longer wants is not work that should itself be cancellable.
+            await DeleteTempAsync(vocalsTemp, CancellationToken.None);
+            await DeleteTempAsync(accompanimentTemp, CancellationToken.None);
+        }
     }
 
-    /// <summary>Moves one finished temp file into the content-addressed store and drops the temp.</summary>
+    /// <summary>
+    /// Copies one finished temp file into the content-addressed store. The
+    /// temp itself is dropped by the caller's <c>finally</c>, so a throw in
+    /// here cannot strand it.
+    /// </summary>
     private async Task<DerivedAudioEntry> StoreTempAsync(string tempPath, CancellationToken ct)
     {
         DerivedAudioEntry entry;
@@ -342,7 +367,6 @@ public sealed class PluginAudioTools(
             entry = await store.PutAsync(content, OpusContentType, ct);
         }
 
-        await DeleteTempAsync(tempPath, ct);
         return entry;
     }
 
@@ -439,6 +463,13 @@ public sealed class PluginAudioTools(
     /// the authority, but it runs deferred, so before its first report the
     /// same file check it makes stands in - better than refusing every split
     /// during the minutes after a restart.
+    /// <para>
+    /// "The same check" means the same path, too: the probe reads
+    /// <see cref="EncoderOptions.StemsplitModelPath" />, which the host sets
+    /// from <see cref="AppFiles.StemsplitModelPath" /> but can point anywhere.
+    /// Reading <c>AppFiles</c> directly here would answer about a different
+    /// file than the probe does on a server that configured an override.
+    /// </para>
     /// </summary>
     private bool StemsplitModelPresent()
     {
@@ -448,9 +479,15 @@ public sealed class PluginAudioTools(
             return report.StemsplitModelPresent;
         }
 
+        string? modelPath = options.StemsplitModelPath;
+        if (string.IsNullOrWhiteSpace(modelPath))
+        {
+            modelPath = AppFiles.StemsplitModelPath;
+        }
+
         try
         {
-            return storage.Exists(AppFiles.StemsplitModelPath);
+            return storage.Exists(modelPath);
         }
         catch (Exception)
         {

--- a/src/NoMercy.Data/Plugins/PluginAudioTools.cs
+++ b/src/NoMercy.Data/Plugins/PluginAudioTools.cs
@@ -33,7 +33,10 @@ namespace NoMercy.Data.Plugins;
 /// Every rejection comes back as a refusal in words rather than as an
 /// exception, for the same reason the analysis writer does it: a plugin's
 /// sweep runs unattended, and a stack trace nobody reads is worth nothing
-/// next to a reason the owner can act on.
+/// next to a reason the owner can act on. That holds for failures nobody
+/// planned for too - both public members catch what they did not expect, log
+/// it at Warning and refuse with the exception's type name. Cancellation the
+/// caller asked for is the one thing that still propagates.
 /// </para>
 /// <para>
 /// One instance per plugin, and one ffmpeg at a time inside it. A plugin that
@@ -57,8 +60,17 @@ public sealed class PluginAudioTools(
     ILogger<PluginAudioTools>? logger = null
 ) : IPluginAudioTools
 {
-    /// <summary>Matches the analysis pass: ffmpeg on a stalled mount never returns on its own.</summary>
-    private static readonly TimeSpan RunTimeout = TimeSpan.FromMinutes(10);
+    /// <summary>
+    /// Matches the analysis pass: ffmpeg on a stalled mount never returns on
+    /// its own.
+    /// <para>
+    /// Init-only and internal rather than a constant so the tests can prove
+    /// the timeout path without waiting ten minutes for it. Every production
+    /// call site takes the default; nothing can change it after construction,
+    /// so no two instances ever disagree about their own timeout mid-run.
+    /// </para>
+    /// </summary>
+    internal TimeSpan RunTimeout { get; init; } = TimeSpan.FromMinutes(10);
 
     /// <summary>The derived store's own scratch folder; its eviction sweep also cleans it.</summary>
     private const string TempFolder = "tmp";
@@ -76,6 +88,7 @@ public sealed class PluginAudioTools(
     private const string FfmpegMissing = "ffmpeg is not installed";
     private const string StemsplitModelMissing = "the stemsplit model is not installed";
     private const string RunInProgress = "another ffmpeg run of this plugin is still in progress";
+    private const string NoStemOutput = "stemsplit produced no output";
 
     private readonly SemaphoreSlim _oneRunAtATime = new(1, 1);
 
@@ -88,6 +101,24 @@ public sealed class PluginAudioTools(
         Action<string>? onStdOut,
         Action<string>? onStdErr,
         CancellationToken ct = default
+    )
+    {
+        try
+        {
+            return await RunFilterGraphCoreAsync(input, graph, onStdOut, onStdErr, ct);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            return PluginAudioRunResult.Refused(Unexpected(exception, nameof(RunFilterGraphAsync)));
+        }
+    }
+
+    private async Task<PluginAudioRunResult> RunFilterGraphCoreAsync(
+        PluginAudioInput input,
+        PluginFilterGraph graph,
+        Action<string>? onStdOut,
+        Action<string>? onStdErr,
+        CancellationToken ct
     )
     {
         string? ffmpegPath = ResolveFfmpegPath();
@@ -149,6 +180,23 @@ public sealed class PluginAudioTools(
         PluginStemCoverage coverage,
         PluginStemSet stemSet,
         CancellationToken ct = default
+    )
+    {
+        try
+        {
+            return await SplitStemsCoreAsync(trackId, coverage, stemSet, ct);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            return PluginStemSplitResult.Refused(Unexpected(exception, nameof(SplitStemsAsync)));
+        }
+    }
+
+    private async Task<PluginStemSplitResult> SplitStemsCoreAsync(
+        string trackId,
+        PluginStemCoverage coverage,
+        PluginStemSet stemSet,
+        CancellationToken ct
     )
     {
         // The 4stems model is not in the ffmpeg build yet. Saying so beats
@@ -295,6 +343,24 @@ public sealed class PluginAudioTools(
                 );
 
                 return PluginStemSplitResult.Refused($"stemsplit exited with {result.ExitCode}");
+            }
+
+            // Exit code 0 is ffmpeg's word, not proof: a filter that produced
+            // no frames still exits clean, and reading a file that is not
+            // there would surface as an IOException from inside the store
+            // rather than as something a plugin can act on.
+            if (
+                !await derivedStorage.ExistsAsync(vocalsTemp, ct)
+                || !await derivedStorage.ExistsAsync(accompanimentTemp, ct)
+            )
+            {
+                _logger.LogWarning(
+                    "plugin {PluginId}: stemsplit exited 0 but wrote no output for track {TrackId}",
+                    pluginId,
+                    trackId
+                );
+
+                return PluginStemSplitResult.Refused(NoStemOutput);
             }
 
             // Both files land in the store before anything is registered, so a
@@ -465,11 +531,13 @@ public sealed class PluginAudioTools(
     /// same file check it makes stands in - better than refusing every split
     /// during the minutes after a restart.
     /// <para>
-    /// "The same check" means the same path, too: the probe reads
-    /// <see cref="EncoderOptions.StemsplitModelPath" />, which the host sets
-    /// from <see cref="AppFiles.StemsplitModelPath" /> but can point anywhere.
-    /// Reading <c>AppFiles</c> directly here would answer about a different
-    /// file than the probe does on a server that configured an override.
+    /// The fallback reads <see cref="EncoderOptions.StemsplitModelPath" />
+    /// first, which is the path the probe itself reads, so on a server that
+    /// configured an override both answer about the same file. Only when that
+    /// option is blank does this fall back to
+    /// <see cref="AppFiles.StemsplitModelPath" /> - the probe never does, but
+    /// it also never runs with a blank option, since the host sets the option
+    /// from exactly that constant.
     /// </para>
     /// </summary>
     private bool StemsplitModelPresent()
@@ -597,6 +665,25 @@ public sealed class PluginAudioTools(
 
         double start = duration * MixOutStart;
         return new(["-ss", Seconds(start)], Milliseconds(start), Milliseconds(duration));
+    }
+
+    /// <summary>
+    /// Turns a failure nobody planned for - a mount that went away, a locked
+    /// database file - into a refusal the caller can read, and puts the real
+    /// exception on the server's own record. A plugin sweeping a library
+    /// unattended loses one track this way instead of the whole sweep.
+    /// Cancellation the caller asked for never comes through here.
+    /// </summary>
+    private string Unexpected(Exception exception, string member)
+    {
+        _logger.LogWarning(
+            exception,
+            "plugin {PluginId}: {Member} failed inside the server",
+            pluginId,
+            member
+        );
+
+        return $"the server could not complete this call: {exception.GetType().Name}";
     }
 
     /// <summary>Seconds as ffmpeg reads them: invariant, and no decimal tail when there is none.</summary>

--- a/src/NoMercy.Data/Plugins/PluginAudioToolsFactory.cs
+++ b/src/NoMercy.Data/Plugins/PluginAudioToolsFactory.cs
@@ -18,6 +18,7 @@ using NoMercy.Encoder.Composition;
 using NoMercy.Encoder.Infrastructure;
 using NoMercy.Encoder.Startup;
 using NoMercy.MediaProcessing.DerivedAudio;
+using NoMercy.Plugins;
 using NoMercy.Plugins.Abstractions;
 using NoMercy.Storage;
 

--- a/src/NoMercy.Data/Plugins/PluginAudioToolsFactory.cs
+++ b/src/NoMercy.Data/Plugins/PluginAudioToolsFactory.cs
@@ -1,0 +1,70 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NoMercy.Database;
+using NoMercy.Encoder.Composition;
+using NoMercy.Encoder.Infrastructure;
+using NoMercy.Encoder.Startup;
+using NoMercy.MediaProcessing.DerivedAudio;
+using NoMercy.Plugins.Abstractions;
+using NoMercy.Storage;
+
+namespace NoMercy.Data.Plugins;
+
+/// <summary>
+/// Builds a <see cref="PluginAudioTools" /> bound to one plugin's id. A
+/// singleton holding the collaborators every instance needs.
+/// <para>
+/// Unlike <see cref="PluginMusicAnalysisWriterFactory" />, the instances are
+/// cached per plugin rather than created per call: the one-ffmpeg-at-a-time
+/// guard is a field on the instance, and a guard a caller can get a fresh
+/// copy of guards nothing.
+/// </para>
+/// </summary>
+/// <param name="storage">The default, library-scoped storage: track files, and the ffmpeg binary's own presence.</param>
+/// <param name="derivedStorage">Scoped to the derived-audio root, for stem scratch files and derived inputs.</param>
+public class PluginAudioToolsFactory(
+    EncoderOptions options,
+    IProcessRunner processRunner,
+    IStorage storage,
+    IStorageDriver storageDriver,
+    [FromKeyedServices("derived-audio")] IStorage derivedStorage,
+    IDerivedAudioStore store,
+    IPluginMusicAnalysisWriterFactory writerFactory,
+    IDbContextFactory<MediaContext> contextFactory,
+    IFfmpegCapabilityProbe capabilityProbe,
+    ILogger<PluginAudioTools> logger
+) : IPluginAudioToolsFactory
+{
+    private readonly ConcurrentDictionary<Ulid, PluginAudioTools> _perPlugin = new();
+
+    public IPluginAudioTools CreateFor(Ulid pluginId) =>
+        _perPlugin.GetOrAdd(
+            pluginId,
+            id => new PluginAudioTools(
+                id,
+                options,
+                processRunner,
+                storage,
+                storageDriver,
+                derivedStorage,
+                store,
+                writerFactory,
+                contextFactory,
+                capabilityProbe,
+                logger
+            )
+        );
+}

--- a/src/NoMercy.Data/Plugins/PluginDerivedAudio.cs
+++ b/src/NoMercy.Data/Plugins/PluginDerivedAudio.cs
@@ -9,6 +9,8 @@
 //  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
 // -----------------------------------------------------------------------------
 
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NoMercy.MediaProcessing.DerivedAudio;
 using NoMercy.Plugins.Abstractions;
 
@@ -31,44 +33,122 @@ namespace NoMercy.Data.Plugins;
 /// caller it has.
 /// </para>
 /// <para>
-/// None of these members has a refusal channel, so a refusal reads as an
-/// absence: <see cref="ExistsAsync" /> is false, <see cref="OpenReadAsync" />
-/// is null, and <see cref="TouchAsync" /> and <see cref="DeleteAsync" /> do
-/// nothing. <see cref="PutAsync" /> is the exception - it has to return a key,
-/// so a failure there is rethrown.
+/// None of these members has a refusal channel, so both a refused key and a
+/// failure inside the server read as an absence: <see cref="ExistsAsync" />
+/// answers false, <see cref="OpenReadAsync" /> answers null, and
+/// <see cref="TouchAsync" /> and <see cref="DeleteAsync" /> do nothing. Every
+/// one of those is logged at Warning first, so the owner still has the reason.
+/// <see cref="PutAsync" /> is the exception - it has to return the key of the
+/// content it was handed, and there is no key when the store would not take
+/// it, so that failure is logged and rethrown. Cancellation is never
+/// swallowed anywhere here: a caller that cancelled is owed its
+/// <see cref="OperationCanceledException" />.
 /// </para>
 /// </summary>
-public sealed class PluginDerivedAudio(IDerivedAudioStore store) : IPluginDerivedAudio
+public sealed class PluginDerivedAudio(
+    IDerivedAudioStore store,
+    ILogger<PluginDerivedAudio>? logger = null
+) : IPluginDerivedAudio
 {
+    private readonly ILogger<PluginDerivedAudio> _logger =
+        logger ?? NullLogger<PluginDerivedAudio>.Instance;
+
     public async Task<string> PutAsync(
         Stream content,
         string contentType,
         CancellationToken ct = default
     )
     {
-        DerivedAudioEntry entry = await store.PutAsync(content, contentType, ct);
-        return entry.Key;
+        // The one member with nothing sensible to hand back on failure: a
+        // caller asked for the key of content it just produced, and there is
+        // no key. Logged here so the reason is on the server's own record
+        // whichever way the plugin handles the throw.
+        try
+        {
+            DerivedAudioEntry entry = await store.PutAsync(content, contentType, ct);
+            return entry.Key;
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            _logger.LogWarning(exception, "the derived store could not accept a plugin's content");
+            throw;
+        }
     }
 
-    public Task<bool> ExistsAsync(string key, CancellationToken ct = default)
+    public async Task<bool> ExistsAsync(string key, CancellationToken ct = default)
     {
-        return DerivedAudioKey.IsValid(key) ? store.ExistsAsync(key, ct) : Task.FromResult(false);
+        if (!DerivedAudioKey.IsValid(key))
+        {
+            return false;
+        }
+
+        try
+        {
+            return await store.ExistsAsync(key, ct);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            Warn(exception, nameof(ExistsAsync));
+            return false;
+        }
     }
 
-    public Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default)
+    public async Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default)
     {
-        return DerivedAudioKey.IsValid(key)
-            ? store.OpenReadAsync(key, ct)
-            : Task.FromResult<Stream?>(null);
+        if (!DerivedAudioKey.IsValid(key))
+        {
+            return null;
+        }
+
+        try
+        {
+            return await store.OpenReadAsync(key, ct);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            Warn(exception, nameof(OpenReadAsync));
+            return null;
+        }
     }
 
-    public Task TouchAsync(string key, CancellationToken ct = default)
+    public async Task TouchAsync(string key, CancellationToken ct = default)
     {
-        return DerivedAudioKey.IsValid(key) ? store.TouchAsync(key, ct) : Task.CompletedTask;
+        if (!DerivedAudioKey.IsValid(key))
+        {
+            return;
+        }
+
+        try
+        {
+            await store.TouchAsync(key, ct);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            Warn(exception, nameof(TouchAsync));
+        }
     }
 
-    public Task DeleteAsync(string key, CancellationToken ct = default)
+    public async Task DeleteAsync(string key, CancellationToken ct = default)
     {
-        return DerivedAudioKey.IsValid(key) ? store.DeleteAsync(key, ct) : Task.CompletedTask;
+        if (!DerivedAudioKey.IsValid(key))
+        {
+            return;
+        }
+
+        try
+        {
+            await store.DeleteAsync(key, ct);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            Warn(exception, nameof(DeleteAsync));
+        }
     }
+
+    private void Warn(Exception exception, string member) =>
+        _logger.LogWarning(
+            exception,
+            "the server could not complete a plugin's {Member} call on the derived store",
+            member
+        );
 }

--- a/src/NoMercy.Data/Plugins/PluginDerivedAudio.cs
+++ b/src/NoMercy.Data/Plugins/PluginDerivedAudio.cs
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using NoMercy.MediaProcessing.DerivedAudio;
+using NoMercy.Plugins.Abstractions;
+
+namespace NoMercy.Data.Plugins;
+
+/// <summary>
+/// The server side of <see cref="IPluginDerivedAudio" />: a thin forwarder to
+/// the server's own <see cref="IDerivedAudioStore" />.
+///
+/// <para>
+/// Deliberately not exposed here: <see cref="IDerivedAudioStore.EvictAsync" />
+/// (the cache-cap sweep is the server's policy, not a plugin's to trigger) and
+/// <see cref="IDerivedAudioStore.RelativePath" /> (a plugin never learns where
+/// a file actually lives - it holds the key, and reads or writes through this
+/// facade). A null or empty key is refused here, before it reaches the store,
+/// since <c>RelativePath</c> slices the key apart to build a path.
+/// </para>
+/// </summary>
+public sealed class PluginDerivedAudio(IDerivedAudioStore store) : IPluginDerivedAudio
+{
+    public async Task<string> PutAsync(
+        Stream content,
+        string contentType,
+        CancellationToken ct = default
+    )
+    {
+        DerivedAudioEntry entry = await store.PutAsync(content, contentType, ct);
+        return entry.Key;
+    }
+
+    public Task<bool> ExistsAsync(string key, CancellationToken ct = default)
+    {
+        return string.IsNullOrEmpty(key) ? Task.FromResult(false) : store.ExistsAsync(key, ct);
+    }
+
+    public Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default)
+    {
+        return string.IsNullOrEmpty(key)
+            ? Task.FromResult<Stream?>(null)
+            : store.OpenReadAsync(key, ct);
+    }
+
+    public Task TouchAsync(string key, CancellationToken ct = default)
+    {
+        return string.IsNullOrEmpty(key) ? Task.CompletedTask : store.TouchAsync(key, ct);
+    }
+
+    public Task DeleteAsync(string key, CancellationToken ct = default)
+    {
+        return string.IsNullOrEmpty(key) ? Task.CompletedTask : store.DeleteAsync(key, ct);
+    }
+}

--- a/src/NoMercy.Data/Plugins/PluginDerivedAudio.cs
+++ b/src/NoMercy.Data/Plugins/PluginDerivedAudio.cs
@@ -23,9 +23,19 @@ namespace NoMercy.Data.Plugins;
 /// (the cache-cap sweep is the server's policy, not a plugin's to trigger) and
 /// <see cref="IDerivedAudioStore.RelativePath" /> (a plugin never learns where
 /// a file actually lives - it holds the key, and reads or writes through this
-/// facade). A null, empty or whitespace-only key is refused here, before it
-/// reaches the store, since <c>RelativePath</c> slices the key apart to
-/// build a path.
+/// facade). A key that <see cref="IPluginDerivedAudio.PutAsync" /> could not
+/// have minted - null, blank, the wrong length, the wrong characters, or the
+/// right hex in the wrong case - is refused here, before it reaches the
+/// store, since <c>RelativePath</c> slices the key apart to build a path. The
+/// store applies the same rule again on its own: this facade is not the only
+/// caller it has.
+/// </para>
+/// <para>
+/// None of these members has a refusal channel, so a refusal reads as an
+/// absence: <see cref="ExistsAsync" /> is false, <see cref="OpenReadAsync" />
+/// is null, and <see cref="TouchAsync" /> and <see cref="DeleteAsync" /> do
+/// nothing. <see cref="PutAsync" /> is the exception - it has to return a key,
+/// so a failure there is rethrown.
 /// </para>
 /// </summary>
 public sealed class PluginDerivedAudio(IDerivedAudioStore store) : IPluginDerivedAudio
@@ -42,23 +52,23 @@ public sealed class PluginDerivedAudio(IDerivedAudioStore store) : IPluginDerive
 
     public Task<bool> ExistsAsync(string key, CancellationToken ct = default)
     {
-        return string.IsNullOrWhiteSpace(key) ? Task.FromResult(false) : store.ExistsAsync(key, ct);
+        return DerivedAudioKey.IsValid(key) ? store.ExistsAsync(key, ct) : Task.FromResult(false);
     }
 
     public Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default)
     {
-        return string.IsNullOrWhiteSpace(key)
-            ? Task.FromResult<Stream?>(null)
-            : store.OpenReadAsync(key, ct);
+        return DerivedAudioKey.IsValid(key)
+            ? store.OpenReadAsync(key, ct)
+            : Task.FromResult<Stream?>(null);
     }
 
     public Task TouchAsync(string key, CancellationToken ct = default)
     {
-        return string.IsNullOrWhiteSpace(key) ? Task.CompletedTask : store.TouchAsync(key, ct);
+        return DerivedAudioKey.IsValid(key) ? store.TouchAsync(key, ct) : Task.CompletedTask;
     }
 
     public Task DeleteAsync(string key, CancellationToken ct = default)
     {
-        return string.IsNullOrWhiteSpace(key) ? Task.CompletedTask : store.DeleteAsync(key, ct);
+        return DerivedAudioKey.IsValid(key) ? store.DeleteAsync(key, ct) : Task.CompletedTask;
     }
 }

--- a/src/NoMercy.Data/Plugins/PluginDerivedAudio.cs
+++ b/src/NoMercy.Data/Plugins/PluginDerivedAudio.cs
@@ -23,8 +23,9 @@ namespace NoMercy.Data.Plugins;
 /// (the cache-cap sweep is the server's policy, not a plugin's to trigger) and
 /// <see cref="IDerivedAudioStore.RelativePath" /> (a plugin never learns where
 /// a file actually lives - it holds the key, and reads or writes through this
-/// facade). A null or empty key is refused here, before it reaches the store,
-/// since <c>RelativePath</c> slices the key apart to build a path.
+/// facade). A null, empty or whitespace-only key is refused here, before it
+/// reaches the store, since <c>RelativePath</c> slices the key apart to
+/// build a path.
 /// </para>
 /// </summary>
 public sealed class PluginDerivedAudio(IDerivedAudioStore store) : IPluginDerivedAudio
@@ -41,23 +42,23 @@ public sealed class PluginDerivedAudio(IDerivedAudioStore store) : IPluginDerive
 
     public Task<bool> ExistsAsync(string key, CancellationToken ct = default)
     {
-        return string.IsNullOrEmpty(key) ? Task.FromResult(false) : store.ExistsAsync(key, ct);
+        return string.IsNullOrWhiteSpace(key) ? Task.FromResult(false) : store.ExistsAsync(key, ct);
     }
 
     public Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default)
     {
-        return string.IsNullOrEmpty(key)
+        return string.IsNullOrWhiteSpace(key)
             ? Task.FromResult<Stream?>(null)
             : store.OpenReadAsync(key, ct);
     }
 
     public Task TouchAsync(string key, CancellationToken ct = default)
     {
-        return string.IsNullOrEmpty(key) ? Task.CompletedTask : store.TouchAsync(key, ct);
+        return string.IsNullOrWhiteSpace(key) ? Task.CompletedTask : store.TouchAsync(key, ct);
     }
 
     public Task DeleteAsync(string key, CancellationToken ct = default)
     {
-        return string.IsNullOrEmpty(key) ? Task.CompletedTask : store.DeleteAsync(key, ct);
+        return string.IsNullOrWhiteSpace(key) ? Task.CompletedTask : store.DeleteAsync(key, ct);
     }
 }

--- a/src/NoMercy.Data/Plugins/PluginLibraryServiceCollectionExtensions.cs
+++ b/src/NoMercy.Data/Plugins/PluginLibraryServiceCollectionExtensions.cs
@@ -46,6 +46,17 @@ public static class PluginLibraryServiceCollectionExtensions
         services.AddSingleton<IPluginJobs, PluginJobs>();
         services.AddSingleton<IPluginStorage, PluginStorage>();
 
+        // The three analysis facades: audio tools, the derived-audio store and
+        // the DJ analysis writer. Same story as the three above them - without
+        // this, a plugin doing DJ-grade analysis has no host-mediated route to
+        // ffmpeg, the derived store or the analysis record at all.
+        services.AddSingleton<IPluginAudioToolsFactory, PluginAudioToolsFactory>();
+        services.AddSingleton<IPluginDerivedAudio, PluginDerivedAudio>();
+        services.AddSingleton<
+            IPluginMusicAnalysisWriterFactory,
+            PluginMusicAnalysisWriterFactory
+        >();
+
         return services;
     }
 }

--- a/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
@@ -30,6 +30,13 @@ namespace NoMercy.Data.Plugins;
 /// stack trace nobody reads is worth nothing next to a reason the owner can
 /// act on.
 /// </para>
+/// <para>
+/// That holds for failures nobody planned for too - a locked database file, a
+/// disk that went away mid-write. Every member here catches what it did not
+/// expect, logs it at Warning and refuses with the exception's type name, so
+/// one bad track costs a plugin one refusal rather than its whole sweep.
+/// Cancellation the caller asked for is the one thing that still propagates.
+/// </para>
 /// </summary>
 public class PluginMusicAnalysisWriter(
     Ulid pluginId,
@@ -47,11 +54,55 @@ public class PluginMusicAnalysisWriter(
     private readonly ILogger<PluginMusicAnalysisWriter> _logger =
         logger ?? NullLogger<PluginMusicAnalysisWriter>.Instance;
 
-    public async Task<PluginWriteResult> UpsertDjAnalysisAsync(
+    public Task<PluginWriteResult> UpsertDjAnalysisAsync(
         PluginTrackDjAnalysis record,
         CancellationToken ct = default
+    ) => GuardAsync(nameof(UpsertDjAnalysisAsync), () => UpsertDjAnalysisCoreAsync(record, ct));
+
+    public Task<PluginWriteResult> RegisterStemAsync(
+        PluginTrackStem stem,
+        CancellationToken ct = default
+    ) => GuardAsync(nameof(RegisterStemAsync), () => RegisterStemCoreAsync(stem, ct));
+
+    public Task<PluginWriteResult> MarkFailedAsync(
+        Guid trackId,
+        int djAnalyzerVersion,
+        int baseAnalyzerVersion,
+        string reason,
+        CancellationToken ct = default
+    ) =>
+        GuardAsync(
+            nameof(MarkFailedAsync),
+            () => MarkFailedCoreAsync(trackId, djAnalyzerVersion, baseAnalyzerVersion, reason, ct)
+        );
+
+    /// <summary>
+    /// The one member with no refusal channel, so a failure has nowhere to go
+    /// but the log: deleting a row that is not there is already a no-op, and a
+    /// caller that asked for a row to be gone is no worse off being told
+    /// nothing than being handed a driver exception.
+    /// </summary>
+    public async Task DeleteDjAnalysisAsync(Guid trackId, CancellationToken ct = default)
+    {
+        try
+        {
+            await DeleteDjAnalysisCoreAsync(trackId, ct);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            LogUnexpected(exception, nameof(DeleteDjAnalysisAsync));
+        }
+    }
+
+    private async Task<PluginWriteResult> UpsertDjAnalysisCoreAsync(
+        PluginTrackDjAnalysis record,
+        CancellationToken ct
     )
     {
+        PluginWriteResult? missingList = CheckListsPresent(record);
+        if (missingList is not null)
+            return missingList;
+
         await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
 
         Track? track = await context
@@ -160,13 +211,27 @@ public class PluginMusicAnalysisWriter(
         existing.Chords = chordsJson;
         existing.AnalyzedAt = DateTime.UtcNow;
 
-        await context.SaveChangesAsync(ct);
+        try
+        {
+            await context.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException)
+        {
+            // Two sweeps upserting the same track at once: both read "no row"
+            // and both tried to insert. Nothing is lost - the winner wrote the
+            // same kind of record - so the loser is told to run again rather
+            // than handed a driver exception.
+            return PluginWriteResult.Refused(
+                $"the DJ record for track {record.TrackId} was written concurrently; retry"
+            );
+        }
+
         return PluginWriteResult.Accepted();
     }
 
-    public async Task<PluginWriteResult> RegisterStemAsync(
+    private async Task<PluginWriteResult> RegisterStemCoreAsync(
         PluginTrackStem stem,
-        CancellationToken ct = default
+        CancellationToken ct
     )
     {
         await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
@@ -237,12 +302,12 @@ public class PluginMusicAnalysisWriter(
         return PluginWriteResult.Accepted();
     }
 
-    public async Task<PluginWriteResult> MarkFailedAsync(
+    private async Task<PluginWriteResult> MarkFailedCoreAsync(
         Guid trackId,
         int djAnalyzerVersion,
         int baseAnalyzerVersion,
         string reason,
-        CancellationToken ct = default
+        CancellationToken ct
     )
     {
         await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
@@ -291,7 +356,7 @@ public class PluginMusicAnalysisWriter(
         return PluginWriteResult.Accepted();
     }
 
-    public async Task DeleteDjAnalysisAsync(Guid trackId, CancellationToken ct = default)
+    private async Task DeleteDjAnalysisCoreAsync(Guid trackId, CancellationToken ct)
     {
         await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
 
@@ -370,6 +435,66 @@ public class PluginMusicAnalysisWriter(
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Runs one contract call and turns anything it throws into a refusal:
+    /// every caller here is a plugin sweeping unattended, and an exception
+    /// crossing the host boundary takes that whole sweep down instead of one
+    /// track. The exception type is named in the refusal so the owner can match
+    /// it against the Warning line this also writes; cancellation the caller
+    /// asked for is passed through untouched.
+    /// </summary>
+    private async Task<PluginWriteResult> GuardAsync(
+        string member,
+        Func<Task<PluginWriteResult>> call
+    )
+    {
+        try
+        {
+            return await call();
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            LogUnexpected(exception, member);
+            return PluginWriteResult.Refused(
+                $"the server could not complete this call: {exception.GetType().Name}"
+            );
+        }
+    }
+
+    private void LogUnexpected(Exception exception, string member) =>
+        _logger.LogWarning(
+            exception,
+            "plugin {PluginId}: {Member} failed inside the server",
+            pluginId,
+            member
+        );
+
+    /// <summary>
+    /// Every list on the record is required. A null one is a caller bug that
+    /// would otherwise serialise to the JSON literal <c>null</c> and land in a
+    /// column the reader reads as "the plugin stored nothing here" - which is
+    /// a different claim from the <c>[]</c> an empty measurement writes.
+    /// </summary>
+    private static PluginWriteResult? CheckListsPresent(PluginTrackDjAnalysis record)
+    {
+        if (record.PhraseStartsMs is null)
+            return PluginWriteResult.Refused("phrase_starts_ms must not be null");
+
+        if (record.VocalRegionsMs is null)
+            return PluginWriteResult.Refused("vocal_regions_ms must not be null");
+
+        if (record.BarEnergy is null)
+            return PluginWriteResult.Refused("bar_energy must not be null");
+
+        if (record.CuePoints is null)
+            return PluginWriteResult.Refused("cue_points must not be null");
+
+        if (record.Chords is null)
+            return PluginWriteResult.Refused("chords must not be null");
+
+        return null;
     }
 
     private static PluginWriteResult? CheckJsonSize(params (string Field, string Json)[] columns)

--- a/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
@@ -93,7 +93,7 @@ public class PluginMusicAnalysisWriter(
 
         if (durationSeconds is null)
         {
-            _logger.LogDebug(
+            _logger.LogInformation(
                 "Track {TrackId}: duration is unknown; skipping the millisecond-range check on its DJ analysis",
                 record.TrackId
             );
@@ -265,6 +265,20 @@ public class PluginMusicAnalysisWriter(
         existing.State = AudioAnalysisState.Failed;
         existing.FailureReason = truncatedReason;
         existing.AnalyzedAt = DateTime.UtcNow;
+
+        // A Failed row must not go on carrying a previous Ok row's
+        // measurements: a caller reading DjAnalyzerVersion = 4 has to be able
+        // to trust that either the row is Ok and current, or it has nothing.
+        // Null is the right value here - the one place it is, since the
+        // reader only ever surfaces Ok rows.
+        existing.DownbeatIndex = null;
+        existing.BeatsPerBar = 4;
+        existing.PhraseLengthBars = 8;
+        existing.PhraseStartsMs = null;
+        existing.VocalRegionsMs = null;
+        existing.BarEnergy = null;
+        existing.CuePoints = null;
+        existing.Chords = null;
 
         await context.SaveChangesAsync(ct);
         return PluginWriteResult.Accepted();

--- a/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
@@ -1,0 +1,383 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NoMercy.Database;
+using NoMercy.Database.Models.Music;
+using NoMercy.MediaProcessing.DerivedAudio;
+using NoMercy.Plugins.Abstractions;
+
+namespace NoMercy.Data.Plugins;
+
+/// <summary>
+/// Writes the DJ analysis record and the stem register on behalf of one
+/// plugin - <see cref="PluginMusicQuery" />'s write side.
+/// <para>
+/// Every write is validated before it touches the database, and every
+/// rejection comes back as a <see cref="PluginWriteResult" /> refusal in
+/// words rather than an exception: a plugin's sweep runs unattended, so a
+/// stack trace nobody reads is worth nothing next to a reason the owner can
+/// act on.
+/// </para>
+/// </summary>
+public class PluginMusicAnalysisWriter(
+    Ulid pluginId,
+    IDbContextFactory<MediaContext> contextFactory,
+    IDerivedAudioStore store,
+    ILogger<PluginMusicAnalysisWriter>? logger = null
+) : IPluginMusicAnalysisWriter
+{
+    /// <summary>Mirrors the <c>[MaxLength(65536)]</c> on every JSON text column.</summary>
+    private const int MaxJsonColumnLength = 65536;
+
+    /// <summary>Mirrors the <c>[MaxLength(1024)]</c> on <c>FailureReason</c>.</summary>
+    private const int MaxFailureReasonLength = 1024;
+
+    private readonly ILogger<PluginMusicAnalysisWriter> _logger =
+        logger ?? NullLogger<PluginMusicAnalysisWriter>.Instance;
+
+    public async Task<PluginWriteResult> UpsertDjAnalysisAsync(
+        PluginTrackDjAnalysis record,
+        CancellationToken ct = default
+    )
+    {
+        await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
+
+        Track? track = await context
+            .Tracks.AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == record.TrackId, ct);
+
+        if (track is null)
+            return PluginWriteResult.Refused($"track {record.TrackId} does not exist");
+
+        bool hasCurrentBaseRow = await context
+            .TrackAudioAnalysis.AsNoTracking()
+            .AnyAsync(
+                analysis =>
+                    analysis.TrackId == record.TrackId
+                    && analysis.State == AudioAnalysisState.Ok
+                    && analysis.AnalyzerVersion == record.BaseAnalyzerVersion,
+                ct
+            );
+
+        if (!hasCurrentBaseRow)
+            return PluginWriteResult.Refused(
+                $"no base analysis at version {record.BaseAnalyzerVersion} for track {record.TrackId}"
+            );
+
+        if (record.BeatsPerBar < 1)
+            return PluginWriteResult.Refused(
+                $"beats_per_bar must be at least 1, got {record.BeatsPerBar}"
+            );
+
+        if (
+            record.DownbeatIndex is int downbeatIndex
+            && (downbeatIndex < 0 || downbeatIndex > record.BeatsPerBar - 1)
+        )
+            return PluginWriteResult.Refused(
+                $"downbeat_index value {downbeatIndex} lies outside the beat grid (0..{record.BeatsPerBar - 1})"
+            );
+
+        double? durationSeconds = PluginMusicQuery.ParseDurationSeconds(track.Duration);
+
+        if (durationSeconds is null)
+        {
+            _logger.LogDebug(
+                "Track {TrackId}: duration is unknown; skipping the millisecond-range check on its DJ analysis",
+                record.TrackId
+            );
+        }
+        else
+        {
+            PluginWriteResult? outOfRange = CheckMsRange(record, durationSeconds.Value * 1000);
+            if (outOfRange is not null)
+                return outOfRange;
+        }
+
+        if (!IsAscending(record.PhraseStartsMs))
+            return PluginWriteResult.Refused("phrase_starts_ms must be ascending");
+
+        string phraseStartsMsJson = JsonSerializer.Serialize(record.PhraseStartsMs);
+        string vocalRegionsMsJson = JsonSerializer.Serialize(record.VocalRegionsMs);
+        string barEnergyJson = JsonSerializer.Serialize(record.BarEnergy);
+        string cuePointsJson = JsonSerializer.Serialize(
+            record.CuePoints.Select(cue => new
+            {
+                ms = cue.Ms,
+                type = cue.Type,
+                direction = cue.Direction,
+                score = cue.Score,
+            })
+        );
+        string chordsJson = JsonSerializer.Serialize(
+            record.Chords.Select(chord => new { ms = chord.Ms, chord = chord.Chord })
+        );
+
+        PluginWriteResult? tooLarge = CheckJsonSize(
+            ("phrase_starts_ms", phraseStartsMsJson),
+            ("vocal_regions_ms", vocalRegionsMsJson),
+            ("bar_energy", barEnergyJson),
+            ("cue_points", cuePointsJson),
+            ("chords", chordsJson)
+        );
+        if (tooLarge is not null)
+            return tooLarge;
+
+        TrackDjAnalysis? existing = await context.TrackDjAnalysis.FirstOrDefaultAsync(
+            analysis => analysis.TrackId == record.TrackId,
+            ct
+        );
+
+        if (existing is null)
+        {
+            existing = new TrackDjAnalysis { TrackId = record.TrackId };
+            context.TrackDjAnalysis.Add(existing);
+        }
+
+        existing.ProducerPluginId = pluginId;
+        existing.DjAnalyzerVersion = record.DjAnalyzerVersion;
+        existing.BaseAnalyzerVersion = record.BaseAnalyzerVersion;
+        existing.State = AudioAnalysisState.Ok;
+        existing.FailureReason = null;
+        existing.DownbeatIndex = record.DownbeatIndex;
+        existing.BeatsPerBar = record.BeatsPerBar;
+        existing.PhraseLengthBars = record.PhraseLengthBars;
+        existing.PhraseStartsMs = phraseStartsMsJson;
+        existing.VocalRegionsMs = vocalRegionsMsJson;
+        existing.BarEnergy = barEnergyJson;
+        existing.CuePoints = cuePointsJson;
+        existing.Chords = chordsJson;
+        existing.AnalyzedAt = DateTime.UtcNow;
+
+        await context.SaveChangesAsync(ct);
+        return PluginWriteResult.Accepted();
+    }
+
+    public async Task<PluginWriteResult> RegisterStemAsync(
+        PluginTrackStem stem,
+        CancellationToken ct = default
+    )
+    {
+        await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
+
+        bool trackExists = await context
+            .Tracks.AsNoTracking()
+            .AnyAsync(t => t.Id == stem.TrackId, ct);
+
+        if (!trackExists)
+            return PluginWriteResult.Refused($"track {stem.TrackId} does not exist");
+
+        if (!await store.ExistsAsync(stem.StorageKey, ct))
+            return PluginWriteResult.Refused(
+                $"storage key {stem.StorageKey} is not in the derived store"
+            );
+
+        if (stem.Coverage == PluginStemCoverage.Full)
+        {
+            if (stem.WindowStartMs is not null || stem.WindowEndMs is not null)
+                return PluginWriteResult.Refused("full coverage stems must not specify a window");
+        }
+        else
+        {
+            if (stem.WindowStartMs is null || stem.WindowEndMs is null)
+                return PluginWriteResult.Refused(
+                    "windowed stems must specify both window_start_ms and window_end_ms"
+                );
+
+            if (stem.WindowStartMs.Value >= stem.WindowEndMs.Value)
+                return PluginWriteResult.Refused("window_start_ms must be less than window_end_ms");
+        }
+
+        StemCoverage coverage = ToDbCoverage(stem.Coverage);
+
+        TrackStem? existing = await context.TrackStems.FirstOrDefaultAsync(
+            row =>
+                row.TrackId == stem.TrackId
+                && row.Kind == stem.Kind
+                && row.Coverage == coverage
+                && row.ProducerVersion == stem.ProducerVersion,
+            ct
+        );
+
+        if (existing is null)
+        {
+            existing = new TrackStem { Id = Ulid.NewUlid(), TrackId = stem.TrackId };
+            context.TrackStems.Add(existing);
+        }
+
+        existing.Kind = stem.Kind;
+        existing.Coverage = coverage;
+        existing.WindowStartMs = stem.WindowStartMs;
+        existing.WindowEndMs = stem.WindowEndMs;
+        existing.Format = stem.Format;
+        existing.SampleRate = stem.SampleRate;
+        existing.StorageKey = stem.StorageKey;
+        existing.ProducerVersion = stem.ProducerVersion;
+        existing.CreatedAt = DateTime.UtcNow;
+
+        await context.SaveChangesAsync(ct);
+        return PluginWriteResult.Accepted();
+    }
+
+    public async Task<PluginWriteResult> MarkFailedAsync(
+        Guid trackId,
+        int djAnalyzerVersion,
+        int baseAnalyzerVersion,
+        string reason,
+        CancellationToken ct = default
+    )
+    {
+        await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
+
+        bool trackExists = await context.Tracks.AsNoTracking().AnyAsync(t => t.Id == trackId, ct);
+
+        if (!trackExists)
+            return PluginWriteResult.Refused($"track {trackId} does not exist");
+
+        string truncatedReason =
+            reason.Length > MaxFailureReasonLength ? reason[..MaxFailureReasonLength] : reason;
+
+        TrackDjAnalysis? existing = await context.TrackDjAnalysis.FirstOrDefaultAsync(
+            analysis => analysis.TrackId == trackId,
+            ct
+        );
+
+        if (existing is null)
+        {
+            existing = new TrackDjAnalysis { TrackId = trackId };
+            context.TrackDjAnalysis.Add(existing);
+        }
+
+        existing.ProducerPluginId = pluginId;
+        existing.DjAnalyzerVersion = djAnalyzerVersion;
+        existing.BaseAnalyzerVersion = baseAnalyzerVersion;
+        existing.State = AudioAnalysisState.Failed;
+        existing.FailureReason = truncatedReason;
+        existing.AnalyzedAt = DateTime.UtcNow;
+
+        await context.SaveChangesAsync(ct);
+        return PluginWriteResult.Accepted();
+    }
+
+    public async Task DeleteDjAnalysisAsync(Guid trackId, CancellationToken ct = default)
+    {
+        await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
+
+        TrackDjAnalysis? existing = await context.TrackDjAnalysis.FirstOrDefaultAsync(
+            analysis => analysis.TrackId == trackId,
+            ct
+        );
+
+        if (existing is null)
+            return;
+
+        context.TrackDjAnalysis.Remove(existing);
+        await context.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Every millisecond-denominated value in <paramref name="record" /> -
+    /// phrase starts, vocal region bounds, cue points, chord timestamps - has
+    /// to fall inside the track, checked in that order so the first offender
+    /// is always the one reported.
+    /// </summary>
+    private static PluginWriteResult? CheckMsRange(PluginTrackDjAnalysis record, double durationMs)
+    {
+        foreach (int value in record.PhraseStartsMs)
+        {
+            if (IsOutOfRange(value, durationMs))
+                return OutOfRangeRefusal("phrase_starts_ms", value, durationMs);
+        }
+
+        foreach (int[] region in record.VocalRegionsMs)
+        {
+            foreach (int value in region)
+            {
+                if (IsOutOfRange(value, durationMs))
+                    return OutOfRangeRefusal("vocal_regions_ms", value, durationMs);
+            }
+        }
+
+        foreach (PluginCuePoint cue in record.CuePoints)
+        {
+            if (IsOutOfRange(cue.Ms, durationMs))
+                return OutOfRangeRefusal("cue_points", cue.Ms, durationMs);
+        }
+
+        foreach (PluginChord chord in record.Chords)
+        {
+            if (IsOutOfRange(chord.Ms, durationMs))
+                return OutOfRangeRefusal("chords", chord.Ms, durationMs);
+        }
+
+        return null;
+    }
+
+    private static bool IsOutOfRange(int value, double durationMs) =>
+        value < 0 || value > durationMs;
+
+    private static PluginWriteResult OutOfRangeRefusal(
+        string field,
+        int value,
+        double durationMs
+    ) =>
+        PluginWriteResult.Refused(
+            $"{field} value {value} lies outside the track (0..{(long)Math.Round(durationMs)} ms)"
+        );
+
+    /// <summary>
+    /// Phrase boundaries strictly increase: two phrases cannot start at the
+    /// same millisecond, so equal neighbours fail this the same as a drop.
+    /// </summary>
+    private static bool IsAscending(IReadOnlyList<int> values)
+    {
+        for (int i = 1; i < values.Count; i++)
+        {
+            if (values[i] <= values[i - 1])
+                return false;
+        }
+
+        return true;
+    }
+
+    private static PluginWriteResult? CheckJsonSize(params (string Field, string Json)[] columns)
+    {
+        foreach ((string field, string json) in columns)
+        {
+            if (json.Length > MaxJsonColumnLength)
+                return PluginWriteResult.Refused($"{field} exceeds 64 kB");
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Maps the plugin's stem-coverage enum to the database's own. An
+    /// explicit switch, the mirror of <see cref="PluginMusicQuery" />'s own
+    /// mapping the other way, rather than a cast the two enums only happen to
+    /// agree on today.
+    /// </summary>
+    private static StemCoverage ToDbCoverage(PluginStemCoverage coverage) =>
+        coverage switch
+        {
+            PluginStemCoverage.Full => StemCoverage.Full,
+            PluginStemCoverage.MixIn => StemCoverage.MixIn,
+            PluginStemCoverage.MixOut => StemCoverage.MixOut,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(coverage),
+                coverage,
+                "Unknown stem coverage"
+            ),
+        };
+}

--- a/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
@@ -178,7 +178,14 @@ public class PluginMusicAnalysisWriter(
         if (!trackExists)
             return PluginWriteResult.Refused($"track {stem.TrackId} does not exist");
 
-        if (!await store.ExistsAsync(stem.StorageKey, ct))
+        // A key the store could never have minted gets the same answer as one
+        // it simply does not hold - a plugin has one thing to fix either way -
+        // but it is checked here first, because asking the store means slicing
+        // the key into a path.
+        if (
+            !DerivedAudioKey.IsValid(stem.StorageKey)
+            || !await store.ExistsAsync(stem.StorageKey, ct)
+        )
             return PluginWriteResult.Refused(
                 $"storage key {stem.StorageKey} is not in the derived store"
             );

--- a/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriterFactory.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriterFactory.cs
@@ -1,0 +1,31 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Microsoft.EntityFrameworkCore;
+using NoMercy.Database;
+using NoMercy.MediaProcessing.DerivedAudio;
+using NoMercy.Plugins.Abstractions;
+
+namespace NoMercy.Data.Plugins;
+
+/// <summary>
+/// Builds a <see cref="PluginMusicAnalysisWriter" /> bound to one plugin's
+/// id. A singleton holding only the two collaborators every writer needs -
+/// the plugin id itself is per-call, not held here.
+/// </summary>
+public class PluginMusicAnalysisWriterFactory(
+    IDbContextFactory<MediaContext> contextFactory,
+    IDerivedAudioStore store
+) : IPluginMusicAnalysisWriterFactory
+{
+    public IPluginMusicAnalysisWriter CreateFor(Ulid pluginId) =>
+        new PluginMusicAnalysisWriter(pluginId, contextFactory, store);
+}

--- a/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriterFactory.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriterFactory.cs
@@ -10,6 +10,7 @@
 // -----------------------------------------------------------------------------
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using NoMercy.Database;
 using NoMercy.MediaProcessing.DerivedAudio;
 using NoMercy.Plugins.Abstractions;
@@ -18,14 +19,15 @@ namespace NoMercy.Data.Plugins;
 
 /// <summary>
 /// Builds a <see cref="PluginMusicAnalysisWriter" /> bound to one plugin's
-/// id. A singleton holding only the two collaborators every writer needs -
-/// the plugin id itself is per-call, not held here.
+/// id. A singleton holding the collaborators every writer needs - the
+/// plugin id itself is per-call, not held here.
 /// </summary>
 public class PluginMusicAnalysisWriterFactory(
     IDbContextFactory<MediaContext> contextFactory,
-    IDerivedAudioStore store
+    IDerivedAudioStore store,
+    ILogger<PluginMusicAnalysisWriter> logger
 ) : IPluginMusicAnalysisWriterFactory
 {
     public IPluginMusicAnalysisWriter CreateFor(Ulid pluginId) =>
-        new PluginMusicAnalysisWriter(pluginId, contextFactory, store);
+        new PluginMusicAnalysisWriter(pluginId, contextFactory, store, logger);
 }

--- a/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriterFactory.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriterFactory.cs
@@ -13,6 +13,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NoMercy.Database;
 using NoMercy.MediaProcessing.DerivedAudio;
+using NoMercy.Plugins;
 using NoMercy.Plugins.Abstractions;
 
 namespace NoMercy.Data.Plugins;

--- a/src/NoMercy.Data/Plugins/PluginMusicQuery.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicQuery.cs
@@ -10,9 +10,9 @@
 // -----------------------------------------------------------------------------
 
 using System.Globalization;
-using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using NoMercy.Data.Music;
 using NoMercy.Database;
 using NoMercy.Database.Models.Music;
 using NoMercy.MediaProcessing.AudioAnalysis;
@@ -40,11 +40,6 @@ public class PluginMusicQuery(
     /// memory in one hop.
     /// </summary>
     private const int MaxPageSize = 1000;
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
 
     public async Task<IReadOnlyList<PluginTrack>> GetTracksAsync(
         string? libraryId = null,
@@ -181,7 +176,11 @@ public class PluginMusicQuery(
                 DeserializeJsonList<int>(row.PhraseStartsMs, row.TrackId, "phrase_starts_ms"),
                 DeserializeJsonList<int[]>(row.VocalRegionsMs, row.TrackId, "vocal_regions_ms"),
                 DeserializeJsonList<double>(row.BarEnergy, row.TrackId, "bar_energy"),
-                DeserializeJsonList<CuePointRow>(row.CuePoints, row.TrackId, "cue_points")
+                DeserializeJsonList<DjAnalysisJson.CuePointRow>(
+                        row.CuePoints,
+                        row.TrackId,
+                        "cue_points"
+                    )
                     .Select(cue => new PluginCuePoint(
                         cue.Ms,
                         cue.Type ?? string.Empty,
@@ -189,7 +188,7 @@ public class PluginMusicQuery(
                         cue.Score
                     ))
                     .ToList(),
-                DeserializeJsonList<ChordRow>(row.Chords, row.TrackId, "chords")
+                DeserializeJsonList<DjAnalysisJson.ChordRow>(row.Chords, row.TrackId, "chords")
                     .Select(chord => new PluginChord(chord.Ms, chord.Chord ?? string.Empty))
                     .ToList()
             ))
@@ -317,13 +316,20 @@ public class PluginMusicQuery(
         };
 
     /// <summary>
-    /// Deserializes one of <see cref="TrackDjAnalysis" />'s JSON text columns.
-    /// A missing or malformed column is never this method's caller's problem
-    /// to throw over — it logs what it found and hands back an empty list, so
-    /// one bad row never takes a whole page of plugin results down with it.
+    /// Deserializes one of <see cref="TrackDjAnalysis" />'s JSON text columns
+    /// via <see cref="DjAnalysisJson.TryDeserialize{T}" />. A missing or
+    /// malformed column is never this method's caller's problem to throw over
+    /// — it logs what it found and hands back an empty list, so one bad row
+    /// never takes a whole page of plugin results down with it.
     /// </summary>
     private List<T> DeserializeJsonList<T>(string? json, Guid trackId, string column)
     {
+        List<T>? result = DjAnalysisJson.TryDeserialize<T>(json);
+        if (result is not null)
+        {
+            return result;
+        }
+
         if (string.IsNullOrWhiteSpace(json))
         {
             logger.LogWarning(
@@ -331,23 +337,17 @@ public class PluginMusicQuery(
                 trackId,
                 column
             );
-            return [];
         }
-
-        try
-        {
-            return JsonSerializer.Deserialize<List<T>>(json, JsonOptions) ?? [];
-        }
-        catch (JsonException ex)
+        else
         {
             logger.LogWarning(
-                ex,
                 "Track {TrackId}: malformed {Column} JSON on a DJ analysis row; treating it as an empty list",
                 trackId,
                 column
             );
-            return [];
         }
+
+        return [];
     }
 
     /// <summary>
@@ -444,18 +444,4 @@ public class PluginMusicQuery(
         string StorageKey,
         string ProducerVersion
     );
-
-    /// <summary>
-    /// The shape one entry of <see cref="TrackDjAnalysis.CuePoints" /> takes on
-    /// disk: <c>{ ms, type, direction, score }</c>. Matched case-insensitively
-    /// rather than with <c>[JsonPropertyName]</c> so this stays a plain DTO the
-    /// house naming rules apply to normally.
-    /// </summary>
-    private sealed record CuePointRow(int Ms, string? Type, string? Direction, double Score);
-
-    /// <summary>
-    /// The shape one entry of <see cref="TrackDjAnalysis.Chords" /> takes on
-    /// disk: <c>{ ms, chord }</c>.
-    /// </summary>
-    private sealed record ChordRow(int Ms, string? Chord);
 }

--- a/src/NoMercy.Data/Plugins/PluginMusicQuery.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicQuery.cs
@@ -176,11 +176,7 @@ public class PluginMusicQuery(
                 DeserializeJsonList<int>(row.PhraseStartsMs, row.TrackId, "phrase_starts_ms"),
                 DeserializeJsonList<int[]>(row.VocalRegionsMs, row.TrackId, "vocal_regions_ms"),
                 DeserializeJsonList<double>(row.BarEnergy, row.TrackId, "bar_energy"),
-                DeserializeJsonList<DjAnalysisJson.CuePointRow>(
-                        row.CuePoints,
-                        row.TrackId,
-                        "cue_points"
-                    )
+                DeserializeJsonList<CuePointRow>(row.CuePoints, row.TrackId, "cue_points")
                     .Select(cue => new PluginCuePoint(
                         cue.Ms,
                         cue.Type ?? string.Empty,
@@ -188,7 +184,7 @@ public class PluginMusicQuery(
                         cue.Score
                     ))
                     .ToList(),
-                DeserializeJsonList<DjAnalysisJson.ChordRow>(row.Chords, row.TrackId, "chords")
+                DeserializeJsonList<ChordRow>(row.Chords, row.TrackId, "chords")
                     .Select(chord => new PluginChord(chord.Ms, chord.Chord ?? string.Empty))
                     .ToList()
             ))
@@ -317,20 +313,21 @@ public class PluginMusicQuery(
 
     /// <summary>
     /// Deserializes one of <see cref="TrackDjAnalysis" />'s JSON text columns
-    /// via <see cref="DjAnalysisJson.TryDeserialize{T}" />. A missing or
-    /// malformed column is never this method's caller's problem to throw over
-    /// — it logs what it found and hands back an empty list, so one bad row
-    /// never takes a whole page of plugin results down with it.
+    /// via <see cref="DjAnalysisJson.TryDeserialize{T}(string?, out Exception?)" />.
+    /// A missing or malformed column is never this method's caller's problem
+    /// to throw over — it logs what it found (the parse exception too, when
+    /// there was one) and hands back an empty list, so one bad row never
+    /// takes a whole page of plugin results down with it.
     /// </summary>
     private List<T> DeserializeJsonList<T>(string? json, Guid trackId, string column)
     {
-        List<T>? result = DjAnalysisJson.TryDeserialize<T>(json);
+        List<T>? result = DjAnalysisJson.TryDeserialize<T>(json, out Exception? error);
         if (result is not null)
         {
             return result;
         }
 
-        if (string.IsNullOrWhiteSpace(json))
+        if (error is null)
         {
             logger.LogWarning(
                 "Track {TrackId}: {Column} column is empty on an Ok DJ analysis row; treating it as an empty list",
@@ -341,6 +338,7 @@ public class PluginMusicQuery(
         else
         {
             logger.LogWarning(
+                error,
                 "Track {TrackId}: malformed {Column} JSON on a DJ analysis row; treating it as an empty list",
                 trackId,
                 column

--- a/src/NoMercy.Data/Plugins/PluginMusicQuery.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicQuery.cs
@@ -355,8 +355,13 @@ public class PluginMusicQuery(
     /// "00:" stripped, so a track under an hour reads "mm:ss". Parsed by hand:
     /// <see cref="TimeSpan.TryParse(string?, out TimeSpan)" /> takes two parts
     /// as hours and minutes and would make a 3:45 track last all afternoon.
+    /// <para>
+    /// <c>internal</c> rather than private: the one duration parser in the
+    /// repo, so <see cref="PluginMusicAnalysisWriter" /> reuses it for its
+    /// track-duration bound checks instead of copying it.
+    /// </para>
     /// </summary>
-    private static double? ParseDurationSeconds(string? duration)
+    internal static double? ParseDurationSeconds(string? duration)
     {
         if (string.IsNullOrWhiteSpace(duration))
         {

--- a/src/NoMercy.Data/Plugins/PluginMusicQuery.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicQuery.cs
@@ -10,9 +10,12 @@
 // -----------------------------------------------------------------------------
 
 using System.Globalization;
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using NoMercy.Database;
 using NoMercy.Database.Models.Music;
+using NoMercy.MediaProcessing.AudioAnalysis;
 using NoMercy.Plugins.Abstractions;
 
 namespace NoMercy.Data.Plugins;
@@ -26,7 +29,10 @@ namespace NoMercy.Data.Plugins;
 /// <c>AsNoTracking</c>.
 /// </para>
 /// </summary>
-public class PluginMusicQuery(IDbContextFactory<MediaContext> contextFactory) : IPluginMusicQuery
+public class PluginMusicQuery(
+    IDbContextFactory<MediaContext> contextFactory,
+    ILogger<PluginMusicQuery> logger
+) : IPluginMusicQuery
 {
     /// <summary>
     /// The most tracks one call will return, whatever the caller asked for. A
@@ -34,6 +40,11 @@ public class PluginMusicQuery(IDbContextFactory<MediaContext> contextFactory) : 
     /// memory in one hop.
     /// </summary>
     private const int MaxPageSize = 1000;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
 
     public async Task<IReadOnlyList<PluginTrack>> GetTracksAsync(
         string? libraryId = null,
@@ -128,6 +139,217 @@ public class PluginMusicQuery(IDbContextFactory<MediaContext> contextFactory) : 
             .ToListAsync(ct);
     }
 
+    public async Task<IReadOnlyList<PluginTrackDjAnalysis>> GetDjAnalysisAsync(
+        IReadOnlyList<Guid> trackIds,
+        CancellationToken ct = default
+    )
+    {
+        if (trackIds.Count == 0)
+        {
+            return [];
+        }
+
+        await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
+
+        Guid[] ids = trackIds.Distinct().Take(MaxPageSize).ToArray();
+
+        List<DjAnalysisRow> rows = await context
+            .TrackDjAnalysis.AsNoTracking()
+            .Where(dj => ids.Contains(dj.TrackId) && dj.State == AudioAnalysisState.Ok)
+            .Select(dj => new DjAnalysisRow(
+                dj.TrackId,
+                dj.DjAnalyzerVersion,
+                dj.BaseAnalyzerVersion,
+                dj.DownbeatIndex,
+                dj.BeatsPerBar,
+                dj.PhraseLengthBars,
+                dj.PhraseStartsMs,
+                dj.VocalRegionsMs,
+                dj.BarEnergy,
+                dj.CuePoints,
+                dj.Chords
+            ))
+            .ToListAsync(ct);
+
+        return rows.Select(row => new PluginTrackDjAnalysis(
+                row.TrackId,
+                row.DjAnalyzerVersion,
+                row.BaseAnalyzerVersion,
+                row.DownbeatIndex,
+                row.BeatsPerBar,
+                row.PhraseLengthBars,
+                DeserializeJsonList<int>(row.PhraseStartsMs, row.TrackId, "phrase_starts_ms"),
+                DeserializeJsonList<int[]>(row.VocalRegionsMs, row.TrackId, "vocal_regions_ms"),
+                DeserializeJsonList<double>(row.BarEnergy, row.TrackId, "bar_energy"),
+                DeserializeJsonList<CuePointRow>(row.CuePoints, row.TrackId, "cue_points")
+                    .Select(cue => new PluginCuePoint(
+                        cue.Ms,
+                        cue.Type ?? string.Empty,
+                        cue.Direction ?? string.Empty,
+                        cue.Score
+                    ))
+                    .ToList(),
+                DeserializeJsonList<ChordRow>(row.Chords, row.TrackId, "chords")
+                    .Select(chord => new PluginChord(chord.Ms, chord.Chord ?? string.Empty))
+                    .ToList()
+            ))
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<PluginTrackStem>> GetStemsAsync(
+        IReadOnlyList<Guid> trackIds,
+        CancellationToken ct = default
+    )
+    {
+        if (trackIds.Count == 0)
+        {
+            return [];
+        }
+
+        await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
+
+        Guid[] ids = trackIds.Distinct().Take(MaxPageSize).ToArray();
+
+        List<StemRow> rows = await context
+            .TrackStems.AsNoTracking()
+            .Where(stem => ids.Contains(stem.TrackId))
+            .Select(stem => new StemRow(
+                stem.TrackId,
+                stem.Kind,
+                stem.Coverage,
+                stem.WindowStartMs,
+                stem.WindowEndMs,
+                stem.Format,
+                stem.SampleRate,
+                stem.StorageKey,
+                stem.ProducerVersion
+            ))
+            .ToListAsync(ct);
+
+        return rows.Select(row => new PluginTrackStem(
+                row.TrackId,
+                row.Kind,
+                ToPluginCoverage(row.Coverage),
+                row.WindowStartMs,
+                row.WindowEndMs,
+                row.Format,
+                row.SampleRate,
+                row.StorageKey,
+                row.ProducerVersion
+            ))
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<Guid>> GetTracksNeedingDjAnalysisAsync(
+        string libraryId,
+        int djAnalyzerVersion,
+        int skip = 0,
+        int take = 500,
+        CancellationToken ct = default
+    )
+    {
+        if (!Ulid.TryParse(libraryId, out Ulid parsedLibraryId))
+        {
+            return [];
+        }
+
+        await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
+
+        return await DjAnalysisQueries
+            .TracksNeedingDjAnalysis(context, parsedLibraryId, djAnalyzerVersion)
+            .Skip(Math.Max(0, skip))
+            .Take(Math.Clamp(take, 1, MaxPageSize))
+            .ToListAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<Guid>> GetTracksMissingStemsAsync(
+        string libraryId,
+        string producerVersion,
+        PluginStemPolicy policy,
+        int skip = 0,
+        int take = 500,
+        CancellationToken ct = default
+    )
+    {
+        // Nothing to sweep for: a plugin under this policy splits the first
+        // time a track is asked for, so there is no worklist to compute.
+        if (policy == PluginStemPolicy.OnDemand)
+        {
+            return [];
+        }
+
+        if (!Ulid.TryParse(libraryId, out Ulid parsedLibraryId))
+        {
+            return [];
+        }
+
+        StemCoverage[] required =
+            policy == PluginStemPolicy.Full
+                ? [StemCoverage.Full]
+                : [StemCoverage.MixIn, StemCoverage.MixOut];
+
+        await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
+
+        return await DjAnalysisQueries
+            .TracksMissingStems(context, parsedLibraryId, producerVersion, required)
+            .Skip(Math.Max(0, skip))
+            .Take(Math.Clamp(take, 1, MaxPageSize))
+            .ToListAsync(ct);
+    }
+
+    /// <summary>
+    /// Maps the database's stem-coverage enum to the plugin's own. Kept as an
+    /// explicit switch rather than a numeric cast: the two enums happen to
+    /// share values today, but a cast would silently keep "happening to" work
+    /// if that ever stopped being true.
+    /// </summary>
+    private static PluginStemCoverage ToPluginCoverage(StemCoverage coverage) =>
+        coverage switch
+        {
+            StemCoverage.Full => PluginStemCoverage.Full,
+            StemCoverage.MixIn => PluginStemCoverage.MixIn,
+            StemCoverage.MixOut => PluginStemCoverage.MixOut,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(coverage),
+                coverage,
+                "Unknown stem coverage"
+            ),
+        };
+
+    /// <summary>
+    /// Deserializes one of <see cref="TrackDjAnalysis" />'s JSON text columns.
+    /// A missing or malformed column is never this method's caller's problem
+    /// to throw over — it logs what it found and hands back an empty list, so
+    /// one bad row never takes a whole page of plugin results down with it.
+    /// </summary>
+    private List<T> DeserializeJsonList<T>(string? json, Guid trackId, string column)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            logger.LogWarning(
+                "Track {TrackId}: {Column} column is empty on an Ok DJ analysis row; treating it as an empty list",
+                trackId,
+                column
+            );
+            return [];
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<T>>(json, JsonOptions) ?? [];
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Track {TrackId}: malformed {Column} JSON on a DJ analysis row; treating it as an empty list",
+                trackId,
+                column
+            );
+            return [];
+        }
+    }
+
     /// <summary>
     /// The library stores a duration as ffprobe's "hh:mm:ss" with a leading
     /// "00:" stripped, so a track under an hour reads "mm:ss". Parsed by hand:
@@ -183,4 +405,52 @@ public class PluginMusicQuery(IDbContextFactory<MediaContext> contextFactory) : 
         string? Duration,
         string LibraryId
     );
+
+    /// <summary>
+    /// One DJ analysis row before its JSON columns are parsed into the typed
+    /// lists <see cref="PluginTrackDjAnalysis" /> carries.
+    /// </summary>
+    private sealed record DjAnalysisRow(
+        Guid TrackId,
+        int DjAnalyzerVersion,
+        int BaseAnalyzerVersion,
+        int? DownbeatIndex,
+        int BeatsPerBar,
+        int PhraseLengthBars,
+        string? PhraseStartsMs,
+        string? VocalRegionsMs,
+        string? BarEnergy,
+        string? CuePoints,
+        string? Chords
+    );
+
+    /// <summary>
+    /// One stem row before <see cref="StemCoverage" /> is mapped to
+    /// <see cref="PluginStemCoverage" />.
+    /// </summary>
+    private sealed record StemRow(
+        Guid TrackId,
+        string Kind,
+        StemCoverage Coverage,
+        int? WindowStartMs,
+        int? WindowEndMs,
+        string Format,
+        int SampleRate,
+        string StorageKey,
+        string ProducerVersion
+    );
+
+    /// <summary>
+    /// The shape one entry of <see cref="TrackDjAnalysis.CuePoints" /> takes on
+    /// disk: <c>{ ms, type, direction, score }</c>. Matched case-insensitively
+    /// rather than with <c>[JsonPropertyName]</c> so this stays a plain DTO the
+    /// house naming rules apply to normally.
+    /// </summary>
+    private sealed record CuePointRow(int Ms, string? Type, string? Direction, double Score);
+
+    /// <summary>
+    /// The shape one entry of <see cref="TrackDjAnalysis.Chords" /> takes on
+    /// disk: <c>{ ms, chord }</c>.
+    /// </summary>
+    private sealed record ChordRow(int Ms, string? Chord);
 }

--- a/src/NoMercy.Data/Repositories/IMusicRepository.cs
+++ b/src/NoMercy.Data/Repositories/IMusicRepository.cs
@@ -53,6 +53,18 @@ public interface IMusicRepository
         CancellationToken ct = default
     );
 
+    /// <summary>
+    /// The base analysis alongside the automix plugin's DJ record and stem
+    /// files for the named tracks — three queries, each scoped the same way
+    /// <see cref="GetTrackAudioAnalysisAsync" /> is: an Ok base row, an Ok DJ
+    /// row, and every stem row regardless of state (a stem file either
+    /// exists or it doesn't; there is no in-between to filter on).
+    /// </summary>
+    Task<TrackAnalysisBundle> GetTrackAnalysisBundleAsync(
+        IReadOnlyCollection<Guid> trackIds,
+        CancellationToken ct = default
+    );
+
     Task<Lyric[]?> UpdateTrackLyricsAsync(
         Track track,
         string lyricsJson,

--- a/src/NoMercy.Data/Repositories/MusicRepository.Tracks.cs
+++ b/src/NoMercy.Data/Repositories/MusicRepository.Tracks.cs
@@ -120,6 +120,34 @@ public partial class MusicRepository
             .ToListAsync(ct);
     }
 
+    public async Task<TrackAnalysisBundle> GetTrackAnalysisBundleAsync(
+        IReadOnlyCollection<Guid> trackIds,
+        CancellationToken ct = default
+    )
+    {
+        if (trackIds.Count == 0)
+            return new([], [], []);
+
+        await using MediaContext mediaContext = await contextFactory.CreateDbContextAsync(ct);
+
+        List<TrackAudioAnalysis> analysis = await mediaContext
+            .TrackAudioAnalysis.AsNoTracking()
+            .Where(row => trackIds.Contains(row.TrackId) && row.State == AudioAnalysisState.Ok)
+            .ToListAsync(ct);
+
+        List<TrackDjAnalysis> dj = await mediaContext
+            .TrackDjAnalysis.AsNoTracking()
+            .Where(row => trackIds.Contains(row.TrackId) && row.State == AudioAnalysisState.Ok)
+            .ToListAsync(ct);
+
+        List<TrackStem> stems = await mediaContext
+            .TrackStems.AsNoTracking()
+            .Where(row => trackIds.Contains(row.TrackId))
+            .ToListAsync(ct);
+
+        return new(analysis, dj, stems);
+    }
+
     public async Task<Lyric[]?> UpdateTrackLyricsAsync(
         Track track,
         string lyricsJson,

--- a/src/NoMercy.Data/Repositories/TrackAnalysisBundle.cs
+++ b/src/NoMercy.Data/Repositories/TrackAnalysisBundle.cs
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using NoMercy.Database.Models.Music;
+
+namespace NoMercy.Data.Repositories;
+
+/// <summary>
+/// The rows behind one track-analysis response: the base measurements, the
+/// automix plugin's DJ record, and the stem files — one Ok/absent list each,
+/// from three separate tables that are never invalidated by the same write.
+/// </summary>
+public sealed record TrackAnalysisBundle(
+    List<TrackAudioAnalysis> Analysis,
+    List<TrackDjAnalysis> Dj,
+    List<TrackStem> Stems
+);

--- a/src/NoMercy.Database/Contexts/MediaContext.cs
+++ b/src/NoMercy.Database/Contexts/MediaContext.cs
@@ -157,6 +157,29 @@ public class MediaContext : DbContext
             .OnDelete(DeleteBehavior.Cascade);
 
         modelBuilder
+            .Entity<TrackDjAnalysis>()
+            .HasOne(analysis => analysis.Track)
+            .WithOne()
+            .HasForeignKey<TrackDjAnalysis>(analysis => analysis.TrackId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder
+            .Entity<TrackStem>()
+            .HasOne(stem => stem.Track)
+            .WithMany()
+            .HasForeignKey(stem => stem.TrackId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Eviction deletes the register row; the stems that pointed at the file
+        // have nothing left to point at and go with it.
+        modelBuilder
+            .Entity<TrackStem>()
+            .HasOne(stem => stem.DerivedAudio)
+            .WithMany()
+            .HasForeignKey(stem => stem.StorageKey)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder
             .Model.GetEntityTypes()
             .SelectMany(t => t.GetProperties())
             .Where(p => p.ClrType == typeof(string))
@@ -556,6 +579,9 @@ public class MediaContext : DbContext
     public virtual DbSet<TrackUser> TrackUser { get; init; }
     public virtual DbSet<Track> Tracks { get; init; }
     public virtual DbSet<TrackAudioAnalysis> TrackAudioAnalysis { get; init; }
+    public virtual DbSet<TrackDjAnalysis> TrackDjAnalysis { get; init; }
+    public virtual DbSet<TrackStem> TrackStems { get; init; }
+    public virtual DbSet<DerivedAudio> DerivedAudio { get; init; }
     public virtual DbSet<ReleaseGroup> ReleaseGroups { get; init; }
     public virtual DbSet<AlbumReleaseGroup> AlbumReleaseGroup { get; init; }
     public virtual DbSet<ArtistReleaseGroup> ArtistReleaseGroup { get; init; }

--- a/src/NoMercy.Database/Migrations/20260910223822_AnalysisRecord.Designer.cs
+++ b/src/NoMercy.Database/Migrations/20260910223822_AnalysisRecord.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NoMercy.Database;
 
@@ -10,9 +11,11 @@ using NoMercy.Database;
 namespace NoMercy.Database.Migrations
 {
     [DbContext(typeof(MediaContext))]
-    partial class MediaContextModelSnapshot : ModelSnapshot
+    [Migration("20260910223822_AnalysisRecord")]
+    partial class AnalysisRecord
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NoMercy.Database/Migrations/20260910223822_AnalysisRecord.cs
+++ b/src/NoMercy.Database/Migrations/20260910223822_AnalysisRecord.cs
@@ -16,15 +16,24 @@ namespace NoMercy.Database.Migrations
                 columns: table => new
                 {
                     Key = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
-                    ContentType = table.Column<string>(type: "TEXT", maxLength: 32, nullable: false),
+                    ContentType = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 32,
+                        nullable: false
+                    ),
                     Bytes = table.Column<long>(type: "INTEGER", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
-                    LastUsedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                    CreatedAt = table.Column<DateTime>(
+                        type: "TEXT",
+                        nullable: false,
+                        defaultValueSql: "CURRENT_TIMESTAMP"
+                    ),
+                    LastUsedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
                 },
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_DerivedAudio", x => x.Key);
-                });
+                }
+            );
 
             migrationBuilder.CreateTable(
                 name: "TrackDjAnalysis",
@@ -35,16 +44,36 @@ namespace NoMercy.Database.Migrations
                     DjAnalyzerVersion = table.Column<int>(type: "INTEGER", nullable: false),
                     BaseAnalyzerVersion = table.Column<int>(type: "INTEGER", nullable: false),
                     State = table.Column<int>(type: "INTEGER", nullable: false),
-                    FailureReason = table.Column<string>(type: "TEXT", maxLength: 1024, nullable: true),
+                    FailureReason = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 1024,
+                        nullable: true
+                    ),
                     DownbeatIndex = table.Column<int>(type: "INTEGER", nullable: true),
                     BeatsPerBar = table.Column<int>(type: "INTEGER", nullable: false),
                     PhraseLengthBars = table.Column<int>(type: "INTEGER", nullable: false),
-                    PhraseStartsMs = table.Column<string>(type: "TEXT", maxLength: 65536, nullable: true),
-                    VocalRegionsMs = table.Column<string>(type: "TEXT", maxLength: 65536, nullable: true),
-                    BarEnergy = table.Column<string>(type: "TEXT", maxLength: 65536, nullable: true),
-                    CuePoints = table.Column<string>(type: "TEXT", maxLength: 65536, nullable: true),
+                    PhraseStartsMs = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 65536,
+                        nullable: true
+                    ),
+                    VocalRegionsMs = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 65536,
+                        nullable: true
+                    ),
+                    BarEnergy = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 65536,
+                        nullable: true
+                    ),
+                    CuePoints = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 65536,
+                        nullable: true
+                    ),
                     Chords = table.Column<string>(type: "TEXT", maxLength: 65536, nullable: true),
-                    AnalyzedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                    AnalyzedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -54,8 +83,10 @@ namespace NoMercy.Database.Migrations
                         column: x => x.TrackId,
                         principalTable: "Tracks",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
 
             migrationBuilder.CreateTable(
                 name: "TrackStems",
@@ -70,8 +101,16 @@ namespace NoMercy.Database.Migrations
                     Format = table.Column<string>(type: "TEXT", maxLength: 8, nullable: false),
                     SampleRate = table.Column<int>(type: "INTEGER", nullable: false),
                     StorageKey = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
-                    ProducerVersion = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                    ProducerVersion = table.Column<string>(
+                        type: "TEXT",
+                        maxLength: 64,
+                        nullable: false
+                    ),
+                    CreatedAt = table.Column<DateTime>(
+                        type: "TEXT",
+                        nullable: false,
+                        defaultValueSql: "CURRENT_TIMESTAMP"
+                    ),
                 },
                 constraints: table =>
                 {
@@ -81,38 +120,40 @@ namespace NoMercy.Database.Migrations
                         column: x => x.StorageKey,
                         principalTable: "DerivedAudio",
                         principalColumn: "Key",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Cascade
+                    );
                     table.ForeignKey(
                         name: "FK_TrackStems_Tracks_TrackId",
                         column: x => x.TrackId,
                         principalTable: "Tracks",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_TrackStems_StorageKey",
                 table: "TrackStems",
-                column: "StorageKey");
+                column: "StorageKey"
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_TrackStems_TrackId_Kind_Coverage_ProducerVersion",
                 table: "TrackStems",
                 columns: new[] { "TrackId", "Kind", "Coverage", "ProducerVersion" },
-                unique: true);
+                unique: true
+            );
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable(
-                name: "TrackDjAnalysis");
+            migrationBuilder.DropTable(name: "TrackDjAnalysis");
 
-            migrationBuilder.DropTable(
-                name: "TrackStems");
+            migrationBuilder.DropTable(name: "TrackStems");
 
-            migrationBuilder.DropTable(
-                name: "DerivedAudio");
+            migrationBuilder.DropTable(name: "DerivedAudio");
         }
     }
 }

--- a/src/NoMercy.Database/Migrations/20260910223822_AnalysisRecord.cs
+++ b/src/NoMercy.Database/Migrations/20260910223822_AnalysisRecord.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NoMercy.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AnalysisRecord : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DerivedAudio",
+                columns: table => new
+                {
+                    Key = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    ContentType = table.Column<string>(type: "TEXT", maxLength: 32, nullable: false),
+                    Bytes = table.Column<long>(type: "INTEGER", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    LastUsedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DerivedAudio", x => x.Key);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TrackDjAnalysis",
+                columns: table => new
+                {
+                    TrackId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ProducerPluginId = table.Column<string>(type: "TEXT", nullable: false),
+                    DjAnalyzerVersion = table.Column<int>(type: "INTEGER", nullable: false),
+                    BaseAnalyzerVersion = table.Column<int>(type: "INTEGER", nullable: false),
+                    State = table.Column<int>(type: "INTEGER", nullable: false),
+                    FailureReason = table.Column<string>(type: "TEXT", maxLength: 1024, nullable: true),
+                    DownbeatIndex = table.Column<int>(type: "INTEGER", nullable: true),
+                    BeatsPerBar = table.Column<int>(type: "INTEGER", nullable: false),
+                    PhraseLengthBars = table.Column<int>(type: "INTEGER", nullable: false),
+                    PhraseStartsMs = table.Column<string>(type: "TEXT", maxLength: 65536, nullable: true),
+                    VocalRegionsMs = table.Column<string>(type: "TEXT", maxLength: 65536, nullable: true),
+                    BarEnergy = table.Column<string>(type: "TEXT", maxLength: 65536, nullable: true),
+                    CuePoints = table.Column<string>(type: "TEXT", maxLength: 65536, nullable: true),
+                    Chords = table.Column<string>(type: "TEXT", maxLength: 65536, nullable: true),
+                    AnalyzedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrackDjAnalysis", x => x.TrackId);
+                    table.ForeignKey(
+                        name: "FK_TrackDjAnalysis_Tracks_TrackId",
+                        column: x => x.TrackId,
+                        principalTable: "Tracks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TrackStems",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "TEXT", nullable: false),
+                    TrackId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Kind = table.Column<string>(type: "TEXT", maxLength: 16, nullable: false),
+                    Coverage = table.Column<int>(type: "INTEGER", nullable: false),
+                    WindowStartMs = table.Column<int>(type: "INTEGER", nullable: true),
+                    WindowEndMs = table.Column<int>(type: "INTEGER", nullable: true),
+                    Format = table.Column<string>(type: "TEXT", maxLength: 8, nullable: false),
+                    SampleRate = table.Column<int>(type: "INTEGER", nullable: false),
+                    StorageKey = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    ProducerVersion = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrackStems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TrackStems_DerivedAudio_StorageKey",
+                        column: x => x.StorageKey,
+                        principalTable: "DerivedAudio",
+                        principalColumn: "Key",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_TrackStems_Tracks_TrackId",
+                        column: x => x.TrackId,
+                        principalTable: "Tracks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrackStems_StorageKey",
+                table: "TrackStems",
+                column: "StorageKey");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrackStems_TrackId_Kind_Coverage_ProducerVersion",
+                table: "TrackStems",
+                columns: new[] { "TrackId", "Kind", "Coverage", "ProducerVersion" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TrackDjAnalysis");
+
+            migrationBuilder.DropTable(
+                name: "TrackStems");
+
+            migrationBuilder.DropTable(
+                name: "DerivedAudio");
+        }
+    }
+}

--- a/src/NoMercy.Database/Models/Music/DerivedAudio.cs
+++ b/src/NoMercy.Database/Models/Music/DerivedAudio.cs
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+
+namespace NoMercy.Database.Models.Music;
+
+/// <summary>
+/// The register of the derived-audio store: one row per content hash. The
+/// file lives at <c>cache/derived/&lt;key[0..2]&gt;/&lt;key&gt;</c>; the row
+/// carries what eviction needs (size, last use) so the policy is a query,
+/// not a directory walk.
+/// </summary>
+[PrimaryKey(nameof(Key))]
+public class DerivedAudio
+{
+    /// <summary>Lower-case hex sha256 of the content.</summary>
+    [MaxLength(64)]
+    [JsonProperty("key")]
+    public string Key { get; set; } = string.Empty;
+
+    [MaxLength(32)]
+    [JsonProperty("content_type")]
+    public string ContentType { get; set; } = string.Empty;
+
+    [JsonProperty("bytes")]
+    public long Bytes { get; set; }
+
+    [JsonProperty("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [JsonProperty("last_used_at")]
+    public DateTime LastUsedAt { get; set; }
+}

--- a/src/NoMercy.Database/Models/Music/StemCoverage.cs
+++ b/src/NoMercy.Database/Models/Music/StemCoverage.cs
@@ -1,0 +1,28 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Database.Models.Music;
+
+/// <summary>
+/// What part of the track a stem file covers. The retention query reads
+/// this, never the millisecond window, so "do we have what the policy wants"
+/// is one equality rather than arithmetic on durations.
+/// </summary>
+public enum StemCoverage
+{
+    Full = 0,
+
+    /// <summary>The first 20 % of the track: where a mix-in lands.</summary>
+    MixIn = 1,
+
+    /// <summary>The last 25 % of the track: where a mix-out lands.</summary>
+    MixOut = 2,
+}

--- a/src/NoMercy.Database/Models/Music/TrackDjAnalysis.cs
+++ b/src/NoMercy.Database/Models/Music/TrackDjAnalysis.cs
@@ -1,0 +1,93 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+
+namespace NoMercy.Database.Models.Music;
+
+/// <summary>
+/// The DJ half of a track's analysis: downbeat, phrases, vocal activity,
+/// per-bar energy, cue points and chords. Written by the automix plugin
+/// through <c>IPluginMusicAnalysisWriter</c>, never by the server, and kept
+/// apart from <see cref="TrackAudioAnalysis" /> so the two owners never
+/// invalidate each other's rows. Lists are JSON text: a track has one to two
+/// hundred bars and the planner reads a whole row at a time, so a child
+/// table per bar would cost millions of rows for nothing that needs SQL.
+/// </summary>
+[PrimaryKey(nameof(TrackId))]
+public class TrackDjAnalysis
+{
+    [JsonProperty("track_id")]
+    public Guid TrackId { get; set; }
+
+    public Track Track { get; set; } = null!;
+
+    [JsonProperty("producer_plugin_id")]
+    public Ulid ProducerPluginId { get; set; }
+
+    /// <summary>Version of the plugin's stages. A bump redoes every row.</summary>
+    [JsonProperty("dj_analyzer_version")]
+    public int DjAnalyzerVersion { get; set; }
+
+    /// <summary>
+    /// The <see cref="TrackAudioAnalysis.AnalyzerVersion" /> this row was
+    /// computed against. When the base row moves on, this row is stale.
+    /// </summary>
+    [JsonProperty("base_analyzer_version")]
+    public int BaseAnalyzerVersion { get; set; }
+
+    [JsonProperty("state")]
+    public AudioAnalysisState State { get; set; }
+
+    [MaxLength(1024)]
+    [JsonProperty("failure_reason")]
+    public string? FailureReason { get; set; }
+
+    /// <summary>Which beat of the base grid is beat 1: 0 to BeatsPerBar − 1.</summary>
+    [JsonProperty("downbeat_index")]
+    public int? DownbeatIndex { get; set; }
+
+    [JsonProperty("beats_per_bar")]
+    public int BeatsPerBar { get; set; } = 4;
+
+    [JsonProperty("phrase_length_bars")]
+    public int PhraseLengthBars { get; set; } = 8;
+
+    /// <summary>JSON <c>int[]</c>: phrase boundaries in milliseconds from the start.</summary>
+    [MaxLength(65536)]
+    [JsonProperty("phrase_starts_ms")]
+    public string? PhraseStartsMs { get; set; }
+
+    /// <summary>JSON <c>[start, end][]</c> in milliseconds, regions of at least one second.</summary>
+    [MaxLength(65536)]
+    [JsonProperty("vocal_regions_ms")]
+    public string? VocalRegionsMs { get; set; }
+
+    /// <summary>JSON <c>double[]</c>: short-term loudness in LUFS per bar, index = bar.</summary>
+    [MaxLength(65536)]
+    [JsonProperty("bar_energy")]
+    public string? BarEnergy { get; set; }
+
+    /// <summary>JSON <c>{ ms, type, direction, score }[]</c>, ranked by score descending.</summary>
+    [MaxLength(65536)]
+    [JsonProperty("cue_points")]
+    public string? CuePoints { get; set; }
+
+    /// <summary>JSON <c>{ ms, chord }[]</c>.</summary>
+    [MaxLength(65536)]
+    [JsonProperty("chords")]
+    public string? Chords { get; set; }
+
+    [JsonProperty("analyzed_at")]
+    public DateTime AnalyzedAt { get; set; }
+}

--- a/src/NoMercy.Database/Models/Music/TrackStem.cs
+++ b/src/NoMercy.Database/Models/Music/TrackStem.cs
@@ -1,0 +1,70 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+
+namespace NoMercy.Database.Models.Music;
+
+/// <summary>
+/// One stem file of one track: which kind, what it covers, who produced it
+/// and where it lives in the derived store. The file itself is addressed by
+/// content, so the row carries a key and never a path.
+/// </summary>
+[PrimaryKey(nameof(Id))]
+[Index(nameof(TrackId), nameof(Kind), nameof(Coverage), nameof(ProducerVersion), IsUnique = true)]
+public class TrackStem
+{
+    [JsonProperty("id")]
+    public Ulid Id { get; set; }
+
+    [JsonProperty("track_id")]
+    public Guid TrackId { get; set; }
+
+    public Track Track { get; set; } = null!;
+
+    /// <summary><c>vocals</c>, <c>accompaniment</c>; later <c>drums</c>, <c>bass</c>, <c>other</c>.</summary>
+    [MaxLength(16)]
+    [JsonProperty("kind")]
+    public string Kind { get; set; } = string.Empty;
+
+    [JsonProperty("coverage")]
+    public StemCoverage Coverage { get; set; }
+
+    /// <summary>Both null when <see cref="Coverage" /> is <see cref="StemCoverage.Full" />.</summary>
+    [JsonProperty("window_start_ms")]
+    public int? WindowStartMs { get; set; }
+
+    [JsonProperty("window_end_ms")]
+    public int? WindowEndMs { get; set; }
+
+    [MaxLength(8)]
+    [JsonProperty("format")]
+    public string Format { get; set; } = "opus";
+
+    [JsonProperty("sample_rate")]
+    public int SampleRate { get; set; }
+
+    [MaxLength(64)]
+    [JsonProperty("storage_key")]
+    public string StorageKey { get; set; } = string.Empty;
+
+    public DerivedAudio DerivedAudio { get; set; } = null!;
+
+    /// <summary>Model and ffmpeg, e.g. <c>spleeter-2stems-f16@v1.0.41</c>.</summary>
+    [MaxLength(64)]
+    [JsonProperty("producer_version")]
+    public string ProducerVersion { get; set; } = string.Empty;
+
+    [JsonProperty("created_at")]
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/NoMercy.Events/Music/TrackAudioAnalysisCompletedEvent.cs
+++ b/src/NoMercy.Events/Music/TrackAudioAnalysisCompletedEvent.cs
@@ -20,4 +20,12 @@ public sealed class TrackAudioAnalysisCompletedEvent : EventBase
 
     /// <summary>"Ok" or "Failed", the enum's name, so the events package needs no reference to the database.</summary>
     public required string State { get; init; }
+
+    /// <summary>
+    /// Every library the track belongs to at the moment the analysis landed.
+    /// A track can be in several, and retention is decided per library, so a
+    /// subscriber needs all of them rather than one representative id. Empty
+    /// when the track is in no library at all.
+    /// </summary>
+    public required IReadOnlyList<Ulid> LibraryIds { get; init; }
 }

--- a/src/NoMercy.Events/Music/TrackAudioAnalysisCompletedEvent.cs
+++ b/src/NoMercy.Events/Music/TrackAudioAnalysisCompletedEvent.cs
@@ -1,0 +1,23 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Events.Music;
+
+public sealed class TrackAudioAnalysisCompletedEvent : EventBase
+{
+    public override string Source => "MusicAnalysisJob";
+
+    public required Guid TrackId { get; init; }
+    public required int AnalyzerVersion { get; init; }
+
+    /// <summary>"Ok" or "Failed", the enum's name, so the events package needs no reference to the database.</summary>
+    public required string State { get; init; }
+}

--- a/src/NoMercy.MediaProcessing/AudioAnalysis/CamelotKey.cs
+++ b/src/NoMercy.MediaProcessing/AudioAnalysis/CamelotKey.cs
@@ -67,4 +67,53 @@ public static class CamelotKey
 
         return Wheel.GetValueOrDefault(keyName.Trim());
     }
+
+    private static readonly IReadOnlyDictionary<string, int> PitchClasses = new Dictionary<
+        string,
+        int
+    >(StringComparer.OrdinalIgnoreCase)
+    {
+        ["C"] = 0,
+        ["B#"] = 0,
+        ["C#"] = 1,
+        ["Db"] = 1,
+        ["D"] = 2,
+        ["D#"] = 3,
+        ["Eb"] = 3,
+        ["E"] = 4,
+        ["Fb"] = 4,
+        ["F"] = 5,
+        ["E#"] = 5,
+        ["F#"] = 6,
+        ["Gb"] = 6,
+        ["G"] = 7,
+        ["G#"] = 8,
+        ["Ab"] = 8,
+        ["A"] = 9,
+        ["A#"] = 10,
+        ["Bb"] = 10,
+        ["B"] = 11,
+        ["Cb"] = 11,
+    };
+
+    /// <summary>
+    /// The pitch class (0 = C .. 11 = B) of a detector key name's tonic, or
+    /// null when the name is empty or its tonic is not one of the twelve
+    /// notes (sharp or flat spelling, either is accepted). A minor key is
+    /// keyed by its tonic — "Am" is 9, the same as "A" — because automix
+    /// key-matching cares which note two tracks share, not whether either is
+    /// major or minor.
+    /// </summary>
+    public static int? PitchClassFromKeyName(string? keyName)
+    {
+        if (string.IsNullOrWhiteSpace(keyName))
+        {
+            return null;
+        }
+
+        string trimmed = keyName.Trim();
+        string tonic = trimmed.Length > 1 && trimmed.EndsWith('m') ? trimmed[..^1] : trimmed;
+
+        return PitchClasses.TryGetValue(tonic, out int pitchClass) ? pitchClass : null;
+    }
 }

--- a/src/NoMercy.MediaProcessing/AudioAnalysis/DjAnalysisQueries.cs
+++ b/src/NoMercy.MediaProcessing/AudioAnalysis/DjAnalysisQueries.cs
@@ -1,0 +1,119 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Microsoft.EntityFrameworkCore;
+using NoMercy.Database;
+using NoMercy.Database.Models.Music;
+
+namespace NoMercy.MediaProcessing.AudioAnalysis;
+
+/// <summary>
+/// The queries the automix plugin's sweep runs to find work: tracks that need
+/// a DJ analysis row and tracks that need stem files. Kept beside
+/// <see cref="AudioAnalysisQueries" /> for the same reason that one exists in
+/// one place — a test can assert the plan rather than assert a copy of it.
+/// </summary>
+public static class DjAnalysisQueries
+{
+    /// <summary>
+    /// Tracks in the named library that have a base analysis verdict but no
+    /// current DJ row: no row at all, a row from an older DJ analyzer, a row
+    /// computed from a base analysis that has since moved on, or a row a run
+    /// left <see cref="AudioAnalysisState.Pending" /> without finishing.
+    /// <para>
+    /// A track whose base analysis is not <see cref="AudioAnalysisState.Ok" />
+    /// (missing, pending or failed) is never returned — the DJ analyzer needs
+    /// the tempo and beat grid the base analysis produces, so there is nothing
+    /// for it to work from yet.
+    /// </para>
+    /// </summary>
+    public static IQueryable<Guid> TracksNeedingDjAnalysis(
+        MediaContext context,
+        Ulid libraryId,
+        int djAnalyzerVersion
+    )
+    {
+        return context
+            .LibraryTrack.AsNoTracking()
+            .Where(libraryTrack => libraryTrack.LibraryId == libraryId)
+            .Select(libraryTrack => libraryTrack.TrackId)
+            .Distinct()
+            .Where(trackId =>
+                context.TrackAudioAnalysis.Any(analysis =>
+                    analysis.TrackId == trackId && analysis.State == AudioAnalysisState.Ok
+                )
+                && !context.TrackDjAnalysis.Any(dj =>
+                    dj.TrackId == trackId
+                    && dj.DjAnalyzerVersion == djAnalyzerVersion
+                    && dj.State != AudioAnalysisState.Pending
+                    && context.TrackAudioAnalysis.Any(analysis =>
+                        analysis.TrackId == trackId
+                        && analysis.AnalyzerVersion == dj.BaseAnalyzerVersion
+                    )
+                )
+            )
+            .OrderBy(trackId => trackId);
+    }
+
+    /// <summary>
+    /// Tracks in the named library whose DJ analysis is
+    /// <see cref="AudioAnalysisState.Ok" /> but are still missing at least one
+    /// of the <paramref name="required" /> stem windows at
+    /// <paramref name="producerVersion" />.
+    /// <para>
+    /// Checked against the "vocals" kind only: the splitter always produces
+    /// both stems of the two-stem set together, so one kind stands for both
+    /// and keeps the query from doubling its work for nothing it would learn.
+    /// A <see cref="StemCoverage.Full" /> row satisfies every required
+    /// coverage, since it contains whatever a windowed row would have held.
+    /// </para>
+    /// </summary>
+    public static IQueryable<Guid> TracksMissingStems(
+        MediaContext context,
+        Ulid libraryId,
+        string producerVersion,
+        StemCoverage[] required
+    )
+    {
+        int requiredCount = required.Length;
+
+        return context
+            .LibraryTrack.AsNoTracking()
+            .Where(libraryTrack => libraryTrack.LibraryId == libraryId)
+            .Select(libraryTrack => libraryTrack.TrackId)
+            .Distinct()
+            .Where(trackId =>
+                context.TrackDjAnalysis.Any(dj =>
+                    dj.TrackId == trackId && dj.State == AudioAnalysisState.Ok
+                )
+                && !(
+                    // A Full stem covers every required window by itself.
+                    context.TrackStems.Any(stem =>
+                        stem.TrackId == trackId
+                        && stem.Kind == "vocals"
+                        && stem.ProducerVersion == producerVersion
+                        && stem.Coverage == StemCoverage.Full
+                    )
+                    || context
+                        .TrackStems.Where(stem =>
+                            stem.TrackId == trackId
+                            && stem.Kind == "vocals"
+                            && stem.ProducerVersion == producerVersion
+                            && required.Contains(stem.Coverage)
+                        )
+                        .Select(stem => stem.Coverage)
+                        .Distinct()
+                        .Count() == requiredCount
+                )
+            )
+            .OrderBy(trackId => trackId);
+    }
+}

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioEntry.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioEntry.cs
@@ -1,0 +1,15 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.MediaProcessing.DerivedAudio;
+
+/// <summary>The result of <see cref="IDerivedAudioStore.PutAsync"/>: the content hash, what it is, and its size.</summary>
+public sealed record DerivedAudioEntry(string Key, string ContentType, long Bytes);

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioEviction.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioEviction.cs
@@ -1,0 +1,57 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using DerivedAudioRow = NoMercy.Database.Models.Music.DerivedAudio;
+
+namespace NoMercy.MediaProcessing.DerivedAudio;
+
+/// <summary>
+/// Which register rows to evict: the least recently used first, until the
+/// total is under the cap, never a row used inside the grace window. A pure
+/// function over rows so the policy is tested without a disk.
+/// </summary>
+/// <remarks>
+/// Rows are aliased to <c>DerivedAudioRow</c> because this namespace shares
+/// its last segment with <see cref="NoMercy.Database.Models.Music.DerivedAudio"/> —
+/// the bare name would resolve to the namespace, not the type (CS0118).
+/// </remarks>
+public static class DerivedAudioEviction
+{
+    public static IReadOnlyList<DerivedAudioRow> Choose(
+        IReadOnlyCollection<DerivedAudioRow> rows,
+        long capBytes,
+        TimeSpan grace,
+        DateTime now
+    )
+    {
+        long total = rows.Sum(row => row.Bytes);
+        if (total <= capBytes)
+        {
+            return [];
+        }
+
+        DateTime cutoff = now - grace;
+        List<DerivedAudioRow> chosen = [];
+        foreach (
+            DerivedAudioRow row in rows.Where(row => row.LastUsedAt <= cutoff)
+                .OrderBy(row => row.LastUsedAt)
+        )
+        {
+            if (total <= capBytes)
+            {
+                break;
+            }
+            chosen.Add(row);
+            total -= row.Bytes;
+        }
+        return chosen;
+    }
+}

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioKey.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioKey.cs
@@ -1,0 +1,55 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.MediaProcessing.DerivedAudio;
+
+/// <summary>
+/// What a derived-audio key is allowed to look like.
+/// <para>
+/// <see cref="IDerivedAudioStore.PutAsync" /> is the only thing that mints a
+/// key, and it always mints the lowercase hex of a SHA-256 digest: exactly 64
+/// characters from <c>0-9a-f</c>. Anything else was invented by a caller, and
+/// a caller here can be a third-party plugin, so it is checked rather than
+/// trusted - <see cref="IDerivedAudioStore.RelativePath" /> slices a key into
+/// a path, and a key that is not a digest is a path traversal waiting to
+/// happen.
+/// </para>
+/// </summary>
+public static class DerivedAudioKey
+{
+    /// <summary>The length of a lowercase hex SHA-256 digest.</summary>
+    public const int Length = 64;
+
+    /// <summary>
+    /// True only for a key <see cref="IDerivedAudioStore.PutAsync" /> could
+    /// have produced. Uppercase hex is rejected on purpose: the store writes
+    /// lowercase, so an uppercase key would miss on a case-sensitive
+    /// filesystem and hit on a case-insensitive one.
+    /// </summary>
+    public static bool IsValid(string? key)
+    {
+        if (key is null || key.Length != Length)
+        {
+            return false;
+        }
+
+        foreach (char character in key)
+        {
+            bool isHexDigit = character is >= '0' and <= '9' or >= 'a' and <= 'f';
+            if (!isHexDigit)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
@@ -9,6 +9,7 @@
 //  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
 // -----------------------------------------------------------------------------
 
+using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -26,6 +27,15 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
     private readonly IStorage _storage;
     private readonly IDbContextFactory<MediaContext> _contextFactory;
     private readonly ILogger<DerivedAudioStore> _logger;
+
+    // Serializes concurrent PutAsync calls for the same key within this store
+    // instance. The store is registered as a process-wide singleton, so two
+    // jobs producing the same stem or rendered segment racing through PutAsync
+    // is the expected case, not an edge case. One SemaphoreSlim accumulates
+    // per distinct key for the store's lifetime — acceptable because the key
+    // space is bounded by distinct content ever produced, which is small next
+    // to a media library.
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
 
     /// <param name="storage">An <see cref="IStorage" /> scoped to <c>AppFiles.DerivedAudioPath</c>; every path below is relative to it.</param>
     /// <param name="contextFactory">Creates a fresh <see cref="MediaContext" /> per operation.</param>
@@ -68,15 +78,73 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             key = Convert.ToHexStringLower(hash.GetHashAndReset());
         }
 
-        string finalPath = RelativePath(key);
-        if (await _storage.ExistsAsync(finalPath, ct))
+        SemaphoreSlim keyLock = _locks.GetOrAdd(key, static _ => new SemaphoreSlim(1, 1));
+        await keyLock.WaitAsync(ct);
+        try
         {
-            await _storage.DeleteAsync(tempPath, ct);
+            return await StoreAndRegisterAsync(tempPath, key, contentType, bytes, ct);
         }
-        else
+        finally
         {
-            await _storage.CreateDirectoryAsync(key[..2], ct);
-            await _storage.MoveAsync(tempPath, finalPath, ct);
+            keyLock.Release();
+        }
+    }
+
+    // Split out of PutAsync so the per-key lock covers only the exists/move/
+    // register sequence, not the hashing above it. Even with the lock, a
+    // second store instance (a second process, or a second DI resolution
+    // that is not actually a singleton) can still race here, so both the
+    // move and the insert additionally treat "someone else already did this"
+    // as success rather than letting the caller fail: the content is stored
+    // and registered either way, which is the contract PutAsync promises.
+    private async Task<DerivedAudioEntry> StoreAndRegisterAsync(
+        string tempPath,
+        string key,
+        string contentType,
+        long bytes,
+        CancellationToken ct
+    )
+    {
+        string finalPath = RelativePath(key);
+        bool tempPending = true;
+        try
+        {
+            if (await _storage.ExistsAsync(finalPath, ct))
+            {
+                // Another PutAsync call already landed this exact content under this key.
+            }
+            else
+            {
+                await _storage.CreateDirectoryAsync(key[..2], ct);
+                try
+                {
+                    await _storage.MoveAsync(tempPath, finalPath, ct);
+                    tempPending = false;
+                }
+                catch (IOException)
+                {
+                    // await is not allowed in an exception filter, so the
+                    // "did someone else already win this race" check happens
+                    // here instead: if the destination exists, that is exactly
+                    // what happened and the loser can carry on; anything else
+                    // is a real I/O failure and must not be swallowed.
+                    if (!await _storage.ExistsAsync(finalPath, ct))
+                    {
+                        throw;
+                    }
+                    // Lost a cross-instance race to move the same content into
+                    // place; the winner's file is already there.
+                }
+            }
+        }
+        finally
+        {
+            // A crash here (or the losing branch above) would otherwise leave
+            // tempPath behind forever; EvictAsync also sweeps tmp/ as a backstop.
+            if (tempPending && await _storage.ExistsAsync(tempPath, ct))
+            {
+                await _storage.DeleteAsync(tempPath, ct);
+            }
         }
 
         await using MediaContext context = await _contextFactory.CreateDbContextAsync(ct);
@@ -84,9 +152,9 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             row => row.Key == key,
             ct
         );
-        DateTime now = DateTime.UtcNow;
         if (existing is null)
         {
+            DateTime now = DateTime.UtcNow;
             context.DerivedAudio.Add(
                 new DerivedAudioRow
                 {
@@ -97,12 +165,21 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
                     LastUsedAt = now,
                 }
             );
+            try
+            {
+                await context.SaveChangesAsync(ct);
+            }
+            catch (DbUpdateException)
+            {
+                // Lost a cross-instance race to register the row; the winner's
+                // row is already there — bump it instead of failing the caller.
+                await TouchAsync(key, ct);
+            }
         }
         else
         {
-            existing.LastUsedAt = now;
+            await TouchAsync(key, ct);
         }
-        await context.SaveChangesAsync(ct);
 
         return new DerivedAudioEntry(key, contentType, bytes);
     }
@@ -165,10 +242,35 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             freed += row.Bytes;
         }
 
+        await SweepStaleTempFilesAsync(grace, ct);
+
         if (freed > 0)
         {
             _logger.LogInformation("Derived audio eviction freed {Freed} bytes", freed);
         }
         return freed;
+    }
+
+    // A crash between the temp write in PutAsync and the move into place is
+    // the only thing that should ever leave a file under tmp/ — nothing else
+    // ever revisits that folder, so it needs its own sweep rather than relying
+    // on the register-row policy above, which never sees these files at all.
+    private async Task SweepStaleTempFilesAsync(TimeSpan grace, CancellationToken ct)
+    {
+        if (!await _storage.ExistsAsync(TempFolder, ct))
+        {
+            return;
+        }
+
+        DateTimeOffset cutoff = DateTimeOffset.UtcNow - grace;
+        await foreach (StorageEntry entry in _storage.ListAsync(TempFolder, null, false, ct))
+        {
+            ct.ThrowIfCancellationRequested();
+            if (entry.IsDirectory || entry.LastModified > cutoff)
+            {
+                continue;
+            }
+            await _storage.DeleteAsync(entry.Path, ct);
+        }
     }
 }

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
@@ -1,0 +1,174 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NoMercy.Database;
+using NoMercy.Storage;
+using DerivedAudioRow = NoMercy.Database.Models.Music.DerivedAudio;
+
+namespace NoMercy.MediaProcessing.DerivedAudio;
+
+/// <inheritdoc />
+public sealed class DerivedAudioStore : IDerivedAudioStore
+{
+    private const string TempFolder = "tmp";
+
+    private readonly IStorage _storage;
+    private readonly IDbContextFactory<MediaContext> _contextFactory;
+    private readonly ILogger<DerivedAudioStore> _logger;
+
+    /// <param name="storage">An <see cref="IStorage" /> scoped to <c>AppFiles.DerivedAudioPath</c>; every path below is relative to it.</param>
+    /// <param name="contextFactory">Creates a fresh <see cref="MediaContext" /> per operation.</param>
+    /// <param name="logger">Reports how many bytes eviction frees.</param>
+    public DerivedAudioStore(
+        IStorage storage,
+        IDbContextFactory<MediaContext> contextFactory,
+        ILogger<DerivedAudioStore> logger
+    )
+    {
+        _storage = storage;
+        _contextFactory = contextFactory;
+        _logger = logger;
+    }
+
+    public string RelativePath(string key) => $"{key[..2]}/{key}";
+
+    public async Task<DerivedAudioEntry> PutAsync(
+        Stream content,
+        string contentType,
+        CancellationToken ct = default
+    )
+    {
+        await _storage.CreateDirectoryAsync(TempFolder, ct);
+        string tempPath = $"{TempFolder}/{Ulid.NewUlid()}";
+        long bytes = 0;
+        string key;
+
+        await using (Stream target = await _storage.OpenWriteAsync(tempPath, true, ct))
+        using (IncrementalHash hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256))
+        {
+            byte[] buffer = new byte[81920];
+            int read;
+            while ((read = await content.ReadAsync(buffer, ct)) > 0)
+            {
+                hash.AppendData(buffer, 0, read);
+                await target.WriteAsync(buffer.AsMemory(0, read), ct);
+                bytes += read;
+            }
+            key = Convert.ToHexStringLower(hash.GetHashAndReset());
+        }
+
+        string finalPath = RelativePath(key);
+        if (await _storage.ExistsAsync(finalPath, ct))
+        {
+            await _storage.DeleteAsync(tempPath, ct);
+        }
+        else
+        {
+            await _storage.CreateDirectoryAsync(key[..2], ct);
+            await _storage.MoveAsync(tempPath, finalPath, ct);
+        }
+
+        await using MediaContext context = await _contextFactory.CreateDbContextAsync(ct);
+        DerivedAudioRow? existing = await context.DerivedAudio.FirstOrDefaultAsync(
+            row => row.Key == key,
+            ct
+        );
+        DateTime now = DateTime.UtcNow;
+        if (existing is null)
+        {
+            context.DerivedAudio.Add(
+                new DerivedAudioRow
+                {
+                    Key = key,
+                    ContentType = contentType,
+                    Bytes = bytes,
+                    CreatedAt = now,
+                    LastUsedAt = now,
+                }
+            );
+        }
+        else
+        {
+            existing.LastUsedAt = now;
+        }
+        await context.SaveChangesAsync(ct);
+
+        return new DerivedAudioEntry(key, contentType, bytes);
+    }
+
+    public Task<bool> ExistsAsync(string key, CancellationToken ct = default) =>
+        _storage.ExistsAsync(RelativePath(key), ct);
+
+    public async Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default)
+    {
+        if (!await _storage.ExistsAsync(RelativePath(key), ct))
+        {
+            return null;
+        }
+        await TouchAsync(key, ct);
+        return await _storage.OpenReadAsync(RelativePath(key), ct);
+    }
+
+    public async Task TouchAsync(string key, CancellationToken ct = default)
+    {
+        await using MediaContext context = await _contextFactory.CreateDbContextAsync(ct);
+        await context
+            .DerivedAudio.Where(row => row.Key == key)
+            .ExecuteUpdateAsync(set => set.SetProperty(row => row.LastUsedAt, DateTime.UtcNow), ct);
+    }
+
+    public async Task DeleteAsync(string key, CancellationToken ct = default)
+    {
+        if (await _storage.ExistsAsync(RelativePath(key), ct))
+        {
+            await _storage.DeleteAsync(RelativePath(key), ct);
+        }
+        await using MediaContext context = await _contextFactory.CreateDbContextAsync(ct);
+        await context.DerivedAudio.Where(row => row.Key == key).ExecuteDeleteAsync(ct);
+    }
+
+    public async Task<long> EvictAsync(
+        long capBytes,
+        TimeSpan grace,
+        CancellationToken ct = default
+    )
+    {
+        List<DerivedAudioRow> rows;
+        await using (MediaContext context = await _contextFactory.CreateDbContextAsync(ct))
+        {
+            rows = await context.DerivedAudio.AsNoTracking().ToListAsync(ct);
+        }
+
+        long freed = 0;
+        foreach (
+            DerivedAudioRow row in DerivedAudioEviction.Choose(
+                rows,
+                capBytes,
+                grace,
+                DateTime.UtcNow
+            )
+        )
+        {
+            ct.ThrowIfCancellationRequested();
+            await DeleteAsync(row.Key, ct);
+            freed += row.Bytes;
+        }
+
+        if (freed > 0)
+        {
+            _logger.LogInformation("Derived audio eviction freed {Freed} bytes", freed);
+        }
+        return freed;
+    }
+}

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
@@ -51,7 +51,25 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
         _logger = logger;
     }
 
-    public string RelativePath(string key) => $"{key[..2]}/{key}";
+    /// <summary>
+    /// The only member that throws on a bad key rather than answering "not
+    /// found": it returns a path, so it has no way to say "there is none".
+    /// Every other member below treats an invalid key as an absent one, which
+    /// is what a plugin holding a stale or invented key should see.
+    /// </summary>
+    /// <exception cref="ArgumentException">The key is not a lowercase hex SHA-256 digest.</exception>
+    public string RelativePath(string key)
+    {
+        if (!DerivedAudioKey.IsValid(key))
+        {
+            throw new ArgumentException(
+                "A derived-audio key is 64 lowercase hex characters.",
+                nameof(key)
+            );
+        }
+
+        return $"{key[..2]}/{key}";
+    }
 
     public async Task<DerivedAudioEntry> PutAsync(
         Stream content,
@@ -184,11 +202,35 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
         return new DerivedAudioEntry(key, contentType, bytes);
     }
 
-    public Task<bool> ExistsAsync(string key, CancellationToken ct = default) =>
-        _storage.ExistsAsync(RelativePath(key), ct);
+    /// <summary>
+    /// True only when both halves of the entry are there: the file AND its
+    /// register row. A file without a row is what a crash between the move and
+    /// the insert leaves behind - handing that key back as present would give
+    /// a caller a file eviction never counts and a foreign key rejects.
+    /// </summary>
+    public async Task<bool> ExistsAsync(string key, CancellationToken ct = default)
+    {
+        if (!DerivedAudioKey.IsValid(key))
+        {
+            return false;
+        }
+
+        if (!await _storage.ExistsAsync(RelativePath(key), ct))
+        {
+            return false;
+        }
+
+        await using MediaContext context = await _contextFactory.CreateDbContextAsync(ct);
+        return await context.DerivedAudio.AsNoTracking().AnyAsync(row => row.Key == key, ct);
+    }
 
     public async Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default)
     {
+        if (!DerivedAudioKey.IsValid(key))
+        {
+            return null;
+        }
+
         if (!await _storage.ExistsAsync(RelativePath(key), ct))
         {
             return null;
@@ -199,6 +241,11 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
 
     public async Task TouchAsync(string key, CancellationToken ct = default)
     {
+        if (!DerivedAudioKey.IsValid(key))
+        {
+            return;
+        }
+
         await using MediaContext context = await _contextFactory.CreateDbContextAsync(ct);
         await context
             .DerivedAudio.Where(row => row.Key == key)
@@ -207,6 +254,11 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
 
     public async Task DeleteAsync(string key, CancellationToken ct = default)
     {
+        if (!DerivedAudioKey.IsValid(key))
+        {
+            return;
+        }
+
         if (await _storage.ExistsAsync(RelativePath(key), ct))
         {
             await _storage.DeleteAsync(RelativePath(key), ct);
@@ -243,12 +295,62 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
         }
 
         await SweepStaleTempFilesAsync(grace, ct);
+        await SweepOrphanedContentFilesAsync(grace, ct);
 
         if (freed > 0)
         {
             _logger.LogInformation("Derived audio eviction freed {Freed} bytes", freed);
         }
         return freed;
+    }
+
+    // The mirror of the tmp/ sweep, one step further along: a crash between
+    // the move into place and the register insert leaves a content file whose
+    // row never landed. Nothing addresses it - ExistsAsync answers false for a
+    // file without a row - so only this sweep will ever free it. The grace
+    // window is what keeps it from racing a PutAsync that is between its own
+    // move and insert right now.
+    private async Task SweepOrphanedContentFilesAsync(TimeSpan grace, CancellationToken ct)
+    {
+        HashSet<string> knownKeys;
+        await using (MediaContext context = await _contextFactory.CreateDbContextAsync(ct))
+        {
+            knownKeys = (
+                await context.DerivedAudio.AsNoTracking().Select(row => row.Key).ToListAsync(ct)
+            ).ToHashSet(StringComparer.Ordinal);
+        }
+
+        DateTimeOffset cutoff = DateTimeOffset.UtcNow - grace;
+
+        List<string> contentFolders = [];
+        await foreach (StorageEntry entry in _storage.ListAsync(string.Empty, null, false, ct))
+        {
+            ct.ThrowIfCancellationRequested();
+            string name = entry.Path.Split('/')[^1];
+            if (entry.IsDirectory && name.Length == 2 && name != TempFolder)
+            {
+                contentFolders.Add(entry.Path);
+            }
+        }
+
+        foreach (string folder in contentFolders)
+        {
+            await foreach (StorageEntry entry in _storage.ListAsync(folder, null, false, ct))
+            {
+                ct.ThrowIfCancellationRequested();
+                string name = entry.Path.Split('/')[^1];
+                if (entry.IsDirectory || entry.LastModified > cutoff || knownKeys.Contains(name))
+                {
+                    continue;
+                }
+
+                _logger.LogInformation(
+                    "Derived audio: removing content file {Key} that has no register row",
+                    name
+                );
+                await _storage.DeleteAsync(entry.Path, ct);
+            }
+        }
     }
 
     // A crash between the temp write in PutAsync and the move into place is

--- a/src/NoMercy.MediaProcessing/DerivedAudio/IDerivedAudioStore.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/IDerivedAudioStore.cs
@@ -1,0 +1,43 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.MediaProcessing.DerivedAudio;
+
+/// <summary>
+/// Content-addressed store for rendered audio (stems, rendered transitions):
+/// the file lives under <c>AppFiles.DerivedAudioPath</c> keyed by its sha256,
+/// and a register row (<c>MediaContext.DerivedAudio</c>) tracks its size and
+/// last use for <see cref="EvictAsync"/>.
+/// </summary>
+public interface IDerivedAudioStore
+{
+    /// <summary>Streams the content to a temp file while hashing it, then moves it under its key. Same content twice is one file and one row.</summary>
+    Task<DerivedAudioEntry> PutAsync(
+        Stream content,
+        string contentType,
+        CancellationToken ct = default
+    );
+
+    Task<bool> ExistsAsync(string key, CancellationToken ct = default);
+
+    /// <summary>Null when the key is unknown. Bumps LastUsedAt.</summary>
+    Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default);
+
+    Task TouchAsync(string key, CancellationToken ct = default);
+
+    Task DeleteAsync(string key, CancellationToken ct = default);
+
+    /// <summary>Applies the policy: returns how many bytes were freed.</summary>
+    Task<long> EvictAsync(long capBytes, TimeSpan grace, CancellationToken ct = default);
+
+    /// <summary>The storage-relative path of a key: "ab/abcdef…". For the audio tools, which hand ffmpeg a local path through a lease.</summary>
+    string RelativePath(string key);
+}

--- a/src/NoMercy.MediaProcessing/Jobs/MediaJobs/MusicAnalysisJob.cs
+++ b/src/NoMercy.MediaProcessing/Jobs/MediaJobs/MusicAnalysisJob.cs
@@ -15,6 +15,8 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using NoMercy.Database;
 using NoMercy.Database.Models.Music;
+using NoMercy.Events;
+using NoMercy.Events.Music;
 using NoMercy.MediaProcessing.AudioAnalysis;
 using NoMercy.Storage;
 using NoMercyQueue.Core.Interfaces;
@@ -44,6 +46,9 @@ public class MusicAnalysisJob : IShouldQueue
     [JsonIgnore]
     private readonly IDbContextFactory<MediaContext> _contextFactory = null!;
 
+    [JsonIgnore]
+    private readonly IEventBus _eventBus = null!;
+
     public string QueueName => "music";
     public int Priority => 0;
 
@@ -59,13 +64,15 @@ public class MusicAnalysisJob : IShouldQueue
         IAudioAnalyzer analyzer,
         IStorageDriver storageDriver,
         IDbContextFactory<MediaContext> contextFactory,
-        ILoggerFactory loggerFactory
+        ILoggerFactory loggerFactory,
+        IEventBus eventBus
     )
     {
         _analyzer = analyzer;
         _storageDriver = storageDriver;
         _contextFactory = contextFactory;
         _logger = loggerFactory.CreateLogger<MusicAnalysisJob>();
+        _eventBus = eventBus;
     }
 
     public MusicAnalysisJob()
@@ -195,5 +202,14 @@ public class MusicAnalysisJob : IShouldQueue
         }
 
         await mediaContext.SaveChangesAsync();
+
+        await _eventBus.PublishAsync(
+            new TrackAudioAnalysisCompletedEvent
+            {
+                TrackId = TrackId,
+                AnalyzerVersion = row.AnalyzerVersion,
+                State = row.State.ToString(),
+            }
+        );
     }
 }

--- a/src/NoMercy.MediaProcessing/Jobs/MediaJobs/MusicAnalysisJob.cs
+++ b/src/NoMercy.MediaProcessing/Jobs/MediaJobs/MusicAnalysisJob.cs
@@ -203,12 +203,23 @@ public class MusicAnalysisJob : IShouldQueue
 
         await mediaContext.SaveChangesAsync();
 
+        // Read here rather than carried on the job: the membership can change
+        // between queueing and running, and a subscriber deciding retention
+        // per library needs the state the verdict was actually written under.
+        List<Ulid> libraryIds = await mediaContext
+            .LibraryTrack.AsNoTracking()
+            .Where(libraryTrack => libraryTrack.TrackId == TrackId)
+            .Select(libraryTrack => libraryTrack.LibraryId)
+            .Distinct()
+            .ToListAsync();
+
         await _eventBus.PublishAsync(
             new TrackAudioAnalysisCompletedEvent
             {
                 TrackId = TrackId,
                 AnalyzerVersion = row.AnalyzerVersion,
                 State = row.State.ToString(),
+                LibraryIds = libraryIds,
             }
         );
     }

--- a/src/NoMercy.NmSystem/Configuration/RuntimeServerSettings.cs
+++ b/src/NoMercy.NmSystem/Configuration/RuntimeServerSettings.cs
@@ -67,4 +67,9 @@ public class RuntimeServerSettings
     // Safe-by-default: adult content is shown only when explicitly enabled.
     // A null (never configured) or false setting both resolve to hidden.
     public bool ShowAdultContent => AllowAdultContent == true;
+
+    // Size cap for the content-addressed derived-audio store (rendered stems
+    // and transitions); the hourly eviction cron job evicts oldest-first down
+    // to this cap. 50 GiB is a reasonable default for a self-hosted server.
+    public long DerivedAudioCapBytes { get; set; } = 50L * 1024 * 1024 * 1024;
 }

--- a/src/NoMercy.NmSystem/Information/AppFiles.cs
+++ b/src/NoMercy.NmSystem/Information/AppFiles.cs
@@ -76,6 +76,11 @@ public static class AppFiles
     public static string TempPath => Path.Combine(CachePath, "temp");
     public static string TranscodePath => Path.Combine(CachePath, "transcode");
     public static string EncoderCachePath => Path.Combine(CachePath, "encoder");
+
+    // Content-addressed derived audio (stems, rendered transitions) for the
+    // automix feature — keyed by sha256, registered in MediaContext.DerivedAudio,
+    // evicted by DerivedAudioEviction. Same shape as TranscodePath above.
+    public static string DerivedAudioPath => Path.Combine(CachePath, "derived");
     public static string ImagesPath => Path.Combine(CachePath, "images");
     public static string MusicImagesPath => Path.Combine(ImagesPath, "music");
     public static string TempImagesPath => Path.Combine(ImagesPath, "temp");
@@ -204,6 +209,7 @@ public static class AppFiles
             BrowserPath,
             CachePath,
             ApiCachePath,
+            DerivedAudioPath,
             EncoderCachePath,
             CertPath,
             ConfigPath,

--- a/src/NoMercy.Plugins.Abstractions/IPluginAudioTools.cs
+++ b/src/NoMercy.Plugins.Abstractions/IPluginAudioTools.cs
@@ -1,0 +1,57 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>
+/// Running the server's own ffmpeg build - the one built with beat, key and
+/// stem detection, never with rubberband - over a track or a derived file.
+/// <para>
+/// Without this, a plugin doing DJ-grade analysis has two bad options: ship
+/// its own ffmpeg, which drifts from the server's build and cannot use its
+/// custom filters, or shell out to a binary it found on the host's PATH,
+/// which is a different binary on every self-hosted machine and answers to
+/// no capability check. Neither is a thing an owner can consent to or revoke.
+/// </para>
+/// <para>
+/// Elevated - see <see cref="PluginHookCapability.AudioTools" /> - because an
+/// arbitrary filter graph is an arbitrary ffmpeg invocation against a library
+/// file, which is not a thing to arrive through a baseline auto-enable.
+/// </para>
+/// </summary>
+public interface IPluginAudioTools
+{
+    /// <summary>
+    /// Runs one filter graph over one input and streams its own stdout and
+    /// stderr back live, so a caller can show progress or bail out through
+    /// <paramref name="ct" /> rather than waiting for a multi-minute stem
+    /// split to finish before learning it failed on the first second.
+    /// </summary>
+    Task<PluginAudioRunResult> RunFilterGraphAsync(
+        PluginAudioInput input,
+        PluginFilterGraph graph,
+        Action<string>? onStdOut,
+        Action<string>? onStdErr,
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// Coverage Full splits the whole track; MixIn or MixOut split that
+    /// window (first 20 % / last 25 %, computed by the host from the track
+    /// duration). Stems land in the derived store and in the stem register.
+    /// </summary>
+    Task<PluginStemSplitResult> SplitStemsAsync(
+        string trackId,
+        PluginStemCoverage coverage,
+        PluginStemSet stemSet,
+        CancellationToken ct = default
+    );
+}

--- a/src/NoMercy.Plugins.Abstractions/IPluginContext.cs
+++ b/src/NoMercy.Plugins.Abstractions/IPluginContext.cs
@@ -109,6 +109,37 @@ public interface IPluginContext
     /// </summary>
     IPluginStorage? Storage => null;
 
+    /// <summary>
+    /// Running ffmpeg over a track or a derived file, and splitting stems.
+    /// <para>
+    /// Present only when the plugin declared
+    /// <see cref="PluginHookCapability.AudioTools" />; null otherwise, so the
+    /// absence is checkable rather than a call that throws.
+    /// </para>
+    /// </summary>
+    IPluginAudioTools? AudioTools => null;
+
+    /// <summary>
+    /// The server's own store of files derived from analysis - stems, rendered
+    /// transitions - keyed by content rather than by library path.
+    /// <para>
+    /// Present only when the plugin declared
+    /// <see cref="PluginHookCapability.DerivedAudio" />; null otherwise, so the
+    /// absence is checkable rather than a call that throws.
+    /// </para>
+    /// </summary>
+    IPluginDerivedAudio? DerivedAudio => null;
+
+    /// <summary>
+    /// Writing the DJ analysis record and the stem register.
+    /// <para>
+    /// Present only when the plugin declared
+    /// <see cref="PluginHookCapability.MusicAnalysisWrite" />; null otherwise,
+    /// so the absence is checkable rather than a call that throws.
+    /// </para>
+    /// </summary>
+    IPluginMusicAnalysisWriter? MusicAnalysisWriter => null;
+
     /// <summary>What the owner has granted this plugin, and how to ask for more.</summary>
     IPluginGrants Grants { get; }
 

--- a/src/NoMercy.Plugins.Abstractions/IPluginDerivedAudio.cs
+++ b/src/NoMercy.Plugins.Abstractions/IPluginDerivedAudio.cs
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>
+/// The server's own store for files nothing in a library owns: separated
+/// stems, rendered transitions, anything <see cref="IPluginAudioTools" />
+/// produces. Addressed by a content key rather than a path, so two plugins
+/// that derive the same stem from the same track share one copy instead of
+/// each staging its own multi-megabyte file next to a library it does not
+/// own.
+/// <para>
+/// Elevated - see <see cref="PluginHookCapability.DerivedAudio" /> - for the
+/// same reason <see cref="IPluginStorage" /> is: it is a place the plugin did
+/// not stage itself into, and deleting from it is not harmless.
+/// </para>
+/// </summary>
+public interface IPluginDerivedAudio
+{
+    /// <summary>Writes a new file and returns the key to read it back with.</summary>
+    Task<string> PutAsync(Stream content, string contentType, CancellationToken ct = default);
+
+    Task<bool> ExistsAsync(string key, CancellationToken ct = default);
+
+    /// <summary>Null when the key is not one the store knows.</summary>
+    Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default);
+
+    /// <summary>Marks a file as still wanted, so a cache sweep does not reclaim it.</summary>
+    Task TouchAsync(string key, CancellationToken ct = default);
+
+    Task DeleteAsync(string key, CancellationToken ct = default);
+}

--- a/src/NoMercy.Plugins.Abstractions/IPluginDerivedAudio.cs
+++ b/src/NoMercy.Plugins.Abstractions/IPluginDerivedAudio.cs
@@ -23,19 +23,40 @@ namespace NoMercy.Plugins.Abstractions;
 /// same reason <see cref="IPluginStorage" /> is: it is a place the plugin did
 /// not stage itself into, and deleting from it is not harmless.
 /// </para>
+/// <para>
+/// A key is the lowercase hex of a SHA-256 digest - 64 characters from
+/// <c>0-9a-f</c> - and only <see cref="PutAsync" /> mints one. Any other
+/// string is treated as a key the store does not hold.
+/// </para>
+/// <para>
+/// None of these members but <see cref="PutAsync" /> has a way to say why it
+/// could not answer, so none of them throws: a key the store will not take,
+/// and a failure inside the server, both read as an absence -
+/// <see cref="ExistsAsync" /> false, <see cref="OpenReadAsync" /> null,
+/// <see cref="TouchAsync" /> and <see cref="DeleteAsync" /> no-ops - and the
+/// server logs the reason on its own side. <see cref="PutAsync" /> has to
+/// return a key, so it throws when there is none. A
+/// <see cref="OperationCanceledException" /> from the token the caller passed
+/// is never swallowed by any of them.
+/// </para>
 /// </summary>
 public interface IPluginDerivedAudio
 {
-    /// <summary>Writes a new file and returns the key to read it back with.</summary>
+    /// <summary>
+    /// Writes a new file and returns the key to read it back with. The one
+    /// member here that throws rather than answering with an absence.
+    /// </summary>
     Task<string> PutAsync(Stream content, string contentType, CancellationToken ct = default);
 
+    /// <summary>False when the key is not one the store knows, or the server could not answer.</summary>
     Task<bool> ExistsAsync(string key, CancellationToken ct = default);
 
-    /// <summary>Null when the key is not one the store knows.</summary>
+    /// <summary>Null when the key is not one the store knows, or the server could not answer.</summary>
     Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default);
 
-    /// <summary>Marks a file as still wanted, so a cache sweep does not reclaim it.</summary>
+    /// <summary>Marks a file as still wanted, so a cache sweep does not reclaim it. A no-op for an unknown key.</summary>
     Task TouchAsync(string key, CancellationToken ct = default);
 
+    /// <summary>A no-op for a key the store does not know.</summary>
     Task DeleteAsync(string key, CancellationToken ct = default);
 }

--- a/src/NoMercy.Plugins.Abstractions/IPluginMusicAnalysisWriter.cs
+++ b/src/NoMercy.Plugins.Abstractions/IPluginMusicAnalysisWriter.cs
@@ -1,0 +1,57 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>
+/// Writing the DJ analysis record and the stem register -
+/// <see cref="IPluginMusicQuery" />'s write side. Kept a separate contract
+/// rather than added to that one, the same way
+/// <see cref="IPluginLibraryWriter" /> is separate from
+/// <see cref="IPluginLibraryQuery" />: reading a library needs no consent,
+/// writing what every other plugin's read will trust does.
+/// <para>
+/// Elevated - see <see cref="PluginHookCapability.MusicAnalysisWrite" /> -
+/// because it is a write to data every other plugin's
+/// <see cref="IPluginMusicQuery" /> can read, so a plugin declaring it can
+/// shape what the rest of the platform believes about a track.
+/// </para>
+/// </summary>
+public interface IPluginMusicAnalysisWriter
+{
+    /// <summary>
+    /// Replaces the DJ analysis row for a track, or inserts one if none
+    /// exists yet.
+    /// </summary>
+    Task<PluginWriteResult> UpsertDjAnalysisAsync(
+        PluginTrackDjAnalysis record,
+        CancellationToken ct = default
+    );
+
+    /// <summary>Adds or replaces one stem's entry in the register.</summary>
+    Task<PluginWriteResult> RegisterStemAsync(PluginTrackStem stem, CancellationToken ct = default);
+
+    /// <summary>
+    /// Records that analysis was attempted and did not produce a row, so a
+    /// sweep can tell "not analysed yet" from "analysed and failed" instead
+    /// of retrying the same broken file for ever.
+    /// </summary>
+    Task<PluginWriteResult> MarkFailedAsync(
+        Guid trackId,
+        int djAnalyzerVersion,
+        int baseAnalyzerVersion,
+        string reason,
+        CancellationToken ct = default
+    );
+
+    /// <summary>Removes the DJ analysis row for a track, if one exists.</summary>
+    Task DeleteDjAnalysisAsync(Guid trackId, CancellationToken ct = default);
+}

--- a/src/NoMercy.Plugins.Abstractions/IPluginMusicQuery.cs
+++ b/src/NoMercy.Plugins.Abstractions/IPluginMusicQuery.cs
@@ -59,6 +59,65 @@ public interface IPluginMusicQuery
         IReadOnlyList<Guid> trackIds,
         CancellationToken ct = default
     );
+
+    /// <summary>
+    /// The DJ measurements for the given tracks, for the ones that have an Ok
+    /// row.
+    /// <para>
+    /// A separate call from <see cref="GetAnalysisAsync" /> for the reason
+    /// <see cref="PluginTrackDjAnalysis" /> is a separate record: most tracks
+    /// have no DJ row for most of a library's life, and a plugin reading the
+    /// base analysis should not pay for the heavier DJ measurements it did not
+    /// ask for. A track with no DJ row, or one that is not Ok, is absent from
+    /// the result rather than returned with empty lists.
+    /// </para>
+    /// </summary>
+    Task<IReadOnlyList<PluginTrackDjAnalysis>> GetDjAnalysisAsync(
+        IReadOnlyList<Guid> trackIds,
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// The stem files registered for the given tracks, of every kind and
+    /// coverage. A track with no stems yet contributes nothing to the result.
+    /// </summary>
+    Task<IReadOnlyList<PluginTrackStem>> GetStemsAsync(
+        IReadOnlyList<Guid> trackIds,
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// Tracks in the named library that have a base analysis verdict but no DJ
+    /// row current with <paramref name="djAnalyzerVersion" /> — the automix
+    /// sweep's worklist. <paramref name="take" /> is clamped by the host, the
+    /// same way <see cref="GetTracksAsync" /> clamps it. A library id that
+    /// does not parse yields an empty result rather than a throw.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetTracksNeedingDjAnalysisAsync(
+        string libraryId,
+        int djAnalyzerVersion,
+        int skip = 0,
+        int take = 500,
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// Tracks in the named library whose DJ analysis is Ok but are still
+    /// missing a stem file the given <paramref name="policy" /> calls for at
+    /// <paramref name="producerVersion" />. <see cref="PluginStemPolicy.OnDemand" />
+    /// always answers empty without touching the database — under that policy
+    /// there is no sweep to drive. <paramref name="take" /> is clamped the same
+    /// way <see cref="GetTracksAsync" /> clamps it, and a library id that does
+    /// not parse yields an empty result rather than a throw.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetTracksMissingStemsAsync(
+        string libraryId,
+        string producerVersion,
+        PluginStemPolicy policy,
+        int skip = 0,
+        int take = 500,
+        CancellationToken ct = default
+    );
 }
 
 /// <param name="DurationSeconds">Null when the library never recorded one.</param>

--- a/src/NoMercy.Plugins.Abstractions/PluginAbi.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginAbi.cs
@@ -16,7 +16,9 @@ public static class PluginAbi
     // 10.1 added IPluginMusicQuery and IPluginContext.Music. Both are additive
     // and the member defaults to null, so every plugin targeting 10.0 still
     // loads — which is what IsCompatible's "minor may be lower" rule means.
-    public static Version Current { get; } = new(10, 1);
+    // 10.2 added IPluginAudioTools, IPluginDerivedAudio, IPluginMusicAnalysisWriter and the
+    // DJ members of IPluginMusicQuery. Additive; the context members default to null.
+    public static Version Current { get; } = new(10, 2);
 
     public static bool IsCompatible(string? targetAbi)
     {

--- a/src/NoMercy.Plugins.Abstractions/PluginAudioInput.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginAudioInput.cs
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>
+/// What ffmpeg reads: a library track by id, or a file in the derived store
+/// by key. Exactly one of the two is set, and the factory methods below are
+/// the only way to build one, so a caller never has to weigh which id a
+/// filter graph is meant to run against.
+/// </summary>
+/// <param name="TrackId">Set by <see cref="Track" />; null when the input is a derived file.</param>
+/// <param name="StorageKey">Set by <see cref="Derived" />; null when the input is a library track.</param>
+public sealed record PluginAudioInput(string? TrackId, string? StorageKey)
+{
+    /// <summary>A track already in the library, addressed by its id.</summary>
+    public static PluginAudioInput Track(string trackId) => new(trackId, null);
+
+    /// <summary>
+    /// A file already in the derived store - a stem, an earlier render -
+    /// addressed by the key <see cref="IPluginDerivedAudio.PutAsync" /> returned.
+    /// </summary>
+    public static PluginAudioInput Derived(string storageKey) => new(null, storageKey);
+}

--- a/src/NoMercy.Plugins.Abstractions/PluginAudioRunResult.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginAudioRunResult.cs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>
+/// What became of <see cref="IPluginAudioTools.RunFilterGraphAsync" />. A run
+/// that never started - a bad filter graph, a missing model file, a track
+/// the host would not open - looks identical to a crash from the outside
+/// unless the reason travels with the result, so it does here rather than as
+/// an exception a caller has to know to catch.
+/// </summary>
+/// <param name="ExitCode">ffmpeg's own exit code. -1 when the run never started; see <see cref="Refused" />.</param>
+/// <param name="Refusal">Why not, in words the owner can act on. Null when the run started.</param>
+public sealed record PluginAudioRunResult(int ExitCode, string? Refusal)
+{
+    /// <summary>True once the run started, whatever ffmpeg's own exit code turned out to be.</summary>
+    public bool Ran => Refusal is null;
+
+    public static PluginAudioRunResult Refused(string reason) => new(-1, reason);
+}

--- a/src/NoMercy.Plugins.Abstractions/PluginChord.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginChord.cs
@@ -1,0 +1,16 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>One chord change, as ffmpeg's keydetect filter timed it.</summary>
+/// <param name="Chord">As the detector named it, for example "Am" or "F#maj".</param>
+public sealed record PluginChord(int Ms, string Chord);

--- a/src/NoMercy.Plugins.Abstractions/PluginChord.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginChord.cs
@@ -12,5 +12,6 @@
 namespace NoMercy.Plugins.Abstractions;
 
 /// <summary>One chord change, as ffmpeg's keydetect filter timed it.</summary>
+/// <param name="Ms">Milliseconds from the start of the track.</param>
 /// <param name="Chord">As the detector named it, for example "Am" or "F#maj".</param>
 public sealed record PluginChord(int Ms, string Chord);

--- a/src/NoMercy.Plugins.Abstractions/PluginCuePoint.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginCuePoint.cs
@@ -15,6 +15,7 @@ namespace NoMercy.Plugins.Abstractions;
 /// One place in a track a transition could sensibly start or land, found by
 /// analysis rather than guessed from the beat grid alone.
 /// </summary>
+/// <param name="Ms">Milliseconds from the start of the track.</param>
 /// <param name="Type">One of "intro", "drop", "breakdown" or "outro" - what kind of section boundary this is.</param>
 /// <param name="Direction">One of "mixIn" or "mixOut" - whether this point suits entering or leaving the track.</param>
 /// <param name="Score">0..1, how strong a candidate this is relative to the track's other cue points.</param>

--- a/src/NoMercy.Plugins.Abstractions/PluginCuePoint.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginCuePoint.cs
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>
+/// One place in a track a transition could sensibly start or land, found by
+/// analysis rather than guessed from the beat grid alone.
+/// </summary>
+/// <param name="Type">One of "intro", "drop", "breakdown" or "outro" - what kind of section boundary this is.</param>
+/// <param name="Direction">One of "mixIn" or "mixOut" - whether this point suits entering or leaving the track.</param>
+/// <param name="Score">0..1, how strong a candidate this is relative to the track's other cue points.</param>
+public sealed record PluginCuePoint(int Ms, string Type, string Direction, double Score);

--- a/src/NoMercy.Plugins.Abstractions/PluginFilterGraph.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginFilterGraph.cs
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>
+/// An ffmpeg filter chain, written by the plugin and run by the host so a
+/// plugin never has to know where the server's ffmpeg build lives, what
+/// flags it needs to find a model file, or how to invoke it safely.
+/// </summary>
+/// <param name="Text">
+/// The filter chain itself, in ffmpeg's own syntax - for example
+/// <c>"stereotools=mlev=0"</c>. The literal token <c>"{stemsModel}"</c>,
+/// where a filter needs one, is replaced by the host with the model file's
+/// name before the graph runs, so a plugin never hard-codes a path that only
+/// exists on the machine running the server.
+/// </param>
+/// <param name="Complex">
+/// False runs <see cref="Text" /> as <c>-af</c>, a single input to a single
+/// output. True runs it as <c>-filter_complex</c>, with the untouched input
+/// also mapped to the null muxer so ffmpeg does not refuse to run against an
+/// output stream nothing consumes.
+/// </param>
+public sealed record PluginFilterGraph(string Text, bool Complex);

--- a/src/NoMercy.Plugins.Abstractions/PluginHookCapability.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginHookCapability.cs
@@ -45,6 +45,40 @@ public static class PluginHookCapability
     public const string Storage = "storage";
 
     /// <summary>
+    /// Running ffmpeg over a track or a derived file, and splitting stems from
+    /// it, through <see cref="IPluginAudioTools" />.
+    /// <para>
+    /// Elevated: an arbitrary filter graph is an arbitrary ffmpeg invocation
+    /// against a library file, which is not a thing to arrive through a
+    /// baseline auto-enable.
+    /// </para>
+    /// </summary>
+    public const string AudioTools = "audioTools";
+
+    /// <summary>
+    /// Reading and writing the server's own store of files derived from
+    /// analysis - stems, rendered transitions - through
+    /// <see cref="IPluginDerivedAudio" />.
+    /// <para>
+    /// Elevated for the same reason <see cref="Storage" /> is: it is a place
+    /// the plugin did not stage itself into, and deleting from it is not
+    /// harmless.
+    /// </para>
+    /// </summary>
+    public const string DerivedAudio = "derivedAudio";
+
+    /// <summary>
+    /// Writing the DJ analysis record and the stem register through
+    /// <see cref="IPluginMusicAnalysisWriter" />.
+    /// <para>
+    /// Elevated: it is a write to data every other plugin's
+    /// <see cref="IPluginMusicQuery" /> can read, so a plugin declaring it can
+    /// shape what the rest of the platform believes about a track.
+    /// </para>
+    /// </summary>
+    public const string MusicAnalysisWrite = "musicAnalysisWrite";
+
+    /// <summary>
     /// Hooks that can never be baseline, whatever else a plugin declares.
     /// <para>Consent classification asks whether every declared hook is
     /// harmless. A hook that can delete a user's media is not, so it is named
@@ -59,5 +93,8 @@ public static class PluginHookCapability
             Auth,
             Encoder,
             Storage,
+            AudioTools,
+            DerivedAudio,
+            MusicAnalysisWrite,
         };
 }

--- a/src/NoMercy.Plugins.Abstractions/PluginStemCoverage.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginStemCoverage.cs
@@ -1,0 +1,39 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>
+/// How much of a track <see cref="IPluginAudioTools.SplitStemsAsync" /> ran
+/// Spleeter over. A transition only ever touches the two ends of a track, so
+/// separating four stems across an entire six-minute file to use twenty
+/// seconds of it is wasted CPU a self-hosted owner is paying for on their own
+/// machine.
+/// </summary>
+public enum PluginStemCoverage
+{
+    /// <summary>The whole track, start to end.</summary>
+    Full = 0,
+
+    /// <summary>
+    /// The first 20 % of the track, the window a mix into the next track
+    /// draws from. The exact bound is computed by the host from the track's
+    /// duration, not by the caller.
+    /// </summary>
+    MixIn = 1,
+
+    /// <summary>
+    /// The last 25 % of the track, the window a mix out of it draws from. The
+    /// exact bound is computed by the host from the track's duration, not by
+    /// the caller.
+    /// </summary>
+    MixOut = 2,
+}

--- a/src/NoMercy.Plugins.Abstractions/PluginStemFile.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginStemFile.cs
@@ -1,0 +1,26 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>One separated stem, already written to the derived store.</summary>
+/// <param name="Kind">
+/// What Spleeter named it: "vocals" and "accompaniment" for
+/// <see cref="PluginStemSet.Two" />; "vocals", "drums", "bass" and "other"
+/// for <see cref="PluginStemSet.Four" />.
+/// </param>
+/// <param name="StorageKey">The key to read it back with <see cref="IPluginDerivedAudio.OpenReadAsync" />.</param>
+public sealed record PluginStemFile(
+    string Kind,
+    PluginStemCoverage Coverage,
+    string StorageKey,
+    long Bytes
+);

--- a/src/NoMercy.Plugins.Abstractions/PluginStemFile.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginStemFile.cs
@@ -17,7 +17,9 @@ namespace NoMercy.Plugins.Abstractions;
 /// <see cref="PluginStemSet.Two" />; "vocals", "drums", "bass" and "other"
 /// for <see cref="PluginStemSet.Four" />.
 /// </param>
+/// <param name="Coverage">How much of the track this stem was split from; see <see cref="PluginStemCoverage" />.</param>
 /// <param name="StorageKey">The key to read it back with <see cref="IPluginDerivedAudio.OpenReadAsync" />.</param>
+/// <param name="Bytes">The stem file's size, for a caller budgeting cache space before it reads anything.</param>
 public sealed record PluginStemFile(
     string Kind,
     PluginStemCoverage Coverage,

--- a/src/NoMercy.Plugins.Abstractions/PluginStemPolicy.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginStemPolicy.cs
@@ -1,0 +1,35 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>
+/// How eagerly a library's stems get produced and kept. Declared here so
+/// that whatever schedules <see cref="IPluginAudioTools.SplitStemsAsync" />
+/// across a library - a later contract, not this one - and a plugin reading
+/// the result back through <see cref="IPluginMusicQuery" /> agree on one
+/// vocabulary for it, rather than each inventing its own strings.
+/// </summary>
+public enum PluginStemPolicy
+{
+    /// <summary>
+    /// Split only the mix-in and mix-out windows a transition needs, as
+    /// <see cref="PluginStemCoverage.MixIn" /> and
+    /// <see cref="PluginStemCoverage.MixOut" /> describe.
+    /// </summary>
+    Windows = 0,
+
+    /// <summary>Split every track's full duration, as <see cref="PluginStemCoverage.Full" />.</summary>
+    Full = 1,
+
+    /// <summary>Split nothing ahead of time; split the first time a track is asked for.</summary>
+    OnDemand = 2,
+}

--- a/src/NoMercy.Plugins.Abstractions/PluginStemSet.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginStemSet.cs
@@ -1,0 +1,28 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>
+/// How many stems Spleeter separates a track into, passed to
+/// <see cref="IPluginAudioTools.SplitStemsAsync" />. Named by the value
+/// rather than by what each stem is called, because that is what Spleeter's
+/// own model names call it and a plugin author picking one is choosing a
+/// model, not a track layout.
+/// </summary>
+public enum PluginStemSet
+{
+    /// <summary>Vocals and accompaniment.</summary>
+    Two = 2,
+
+    /// <summary>Vocals, drums, bass and other.</summary>
+    Four = 4,
+}

--- a/src/NoMercy.Plugins.Abstractions/PluginStemSplitResult.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginStemSplitResult.cs
@@ -1,0 +1,27 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>
+/// What became of <see cref="IPluginAudioTools.SplitStemsAsync" />. A track
+/// the host could not open, or a Spleeter model that is not installed on this
+/// server, both look like an empty stem list unless the reason travels with
+/// the result, so it does here.
+/// </summary>
+/// <param name="Stems">The separated stems. Empty when refused.</param>
+/// <param name="Refusal">Why not, in words the owner can act on. Null when accepted.</param>
+public sealed record PluginStemSplitResult(IReadOnlyList<PluginStemFile> Stems, string? Refusal)
+{
+    public bool Accepted => Refusal is null;
+
+    public static PluginStemSplitResult Refused(string reason) => new([], reason);
+}

--- a/src/NoMercy.Plugins.Abstractions/PluginTrackDjAnalysis.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginTrackDjAnalysis.cs
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>
+/// The measurements automix needs on top of <c>PluginTrackAudioAnalysis</c> -
+/// where the bars and phrases fall, where the vocal is present, and where a
+/// transition could plausibly start or land. A separate record rather than
+/// more members on the base analysis: the base analysis is read by any
+/// plugin through <see cref="IPluginMusicQuery" /> and computed once per
+/// track; this is heavier, DJ-specific, and versioned on its own so a change
+/// to phrase detection does not force every base analysis row to be
+/// recomputed.
+/// </summary>
+/// <param name="TrackId"><c>Guid</c>, matching <c>PluginTrackAudioAnalysis.TrackId</c>.</param>
+/// <param name="DjAnalyzerVersion">Which run of this analyzer produced the row.</param>
+/// <param name="BaseAnalyzerVersion">
+/// The <c>PluginTrackAudioAnalysis.AnalyzerVersion</c> this row was computed
+/// from - beat and phrase detection both need the tempo and beat grid the
+/// base analysis already found. A consumer holding a newer base analysis
+/// than this can tell the DJ row is stale without re-deriving anything.
+/// </param>
+/// <param name="DownbeatIndex">
+/// Which beat of the beat grid is the first downbeat, 0-based. Null when the
+/// detector found beats but could not place the bar.
+/// </param>
+/// <param name="BeatsPerBar">Almost always 4; carried explicitly rather than assumed.</param>
+/// <param name="PhraseLengthBars">How many bars make one phrase in this track, typically 8 or 16.</param>
+/// <param name="PhraseStartsMs">Where each phrase begins, in track time.</param>
+/// <param name="VocalRegionsMs">
+/// Where a vocal is present, as <c>[startMs, endMs]</c> pairs. Absence of a
+/// region does not claim silence, only that no vocal was detected there.
+/// </param>
+/// <param name="BarEnergy">
+/// One 0..1 value per bar, in bar order, cheap enough to hold for a whole
+/// track so a caller can plot or search an energy arc without asking per bar.
+/// </param>
+/// <param name="CuePoints">Candidate transition points; see <see cref="PluginCuePoint" />.</param>
+/// <param name="Chords">The chord timeline; see <see cref="PluginChord" />.</param>
+public sealed record PluginTrackDjAnalysis(
+    Guid TrackId,
+    int DjAnalyzerVersion,
+    int BaseAnalyzerVersion,
+    int? DownbeatIndex,
+    int BeatsPerBar,
+    int PhraseLengthBars,
+    IReadOnlyList<int> PhraseStartsMs,
+    IReadOnlyList<int[]> VocalRegionsMs,
+    IReadOnlyList<double> BarEnergy,
+    IReadOnlyList<PluginCuePoint> CuePoints,
+    IReadOnlyList<PluginChord> Chords
+);

--- a/src/NoMercy.Plugins.Abstractions/PluginTrackDjAnalysis.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginTrackDjAnalysis.cs
@@ -41,8 +41,10 @@ namespace NoMercy.Plugins.Abstractions;
 /// region does not claim silence, only that no vocal was detected there.
 /// </param>
 /// <param name="BarEnergy">
-/// One 0..1 value per bar, in bar order, cheap enough to hold for a whole
-/// track so a caller can plot or search an energy arc without asking per bar.
+/// Short-term loudness in LUFS per bar, index = bar; not normalised, so
+/// values are typically negative, roughly -60 to 0. Cheap enough to hold for
+/// a whole track so a caller can plot or search an energy arc without asking
+/// per bar.
 /// </param>
 /// <param name="CuePoints">Candidate transition points; see <see cref="PluginCuePoint" />.</param>
 /// <param name="Chords">The chord timeline; see <see cref="PluginChord" />.</param>

--- a/src/NoMercy.Plugins.Abstractions/PluginTrackStem.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginTrackStem.cs
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>
+/// One stem's entry in the register - what
+/// <see cref="IPluginMusicAnalysisWriter.RegisterStemAsync" /> writes so a
+/// later reader can find a stem by track and kind instead of having to know
+/// the derived-store key <see cref="IPluginAudioTools.SplitStemsAsync" />
+/// happened to produce.
+/// </summary>
+/// <param name="Kind">"vocals", "accompaniment", "drums", "bass" or "other", as Spleeter named it.</param>
+/// <param name="WindowStartMs">Null when <paramref name="Coverage" /> is <see cref="PluginStemCoverage.Full" />.</param>
+/// <param name="WindowEndMs">Null when <paramref name="Coverage" /> is <see cref="PluginStemCoverage.Full" />.</param>
+/// <param name="Format">The container/codec the stem file was written in, for example "flac".</param>
+/// <param name="StorageKey">The key to read it back with <see cref="IPluginDerivedAudio.OpenReadAsync" />.</param>
+/// <param name="ProducerVersion">
+/// Which build of the splitter produced this stem, so a model upgrade can be
+/// detected the same way <see cref="PluginTrackDjAnalysis.DjAnalyzerVersion" />
+/// detects an analyzer upgrade.
+/// </param>
+public sealed record PluginTrackStem(
+    Guid TrackId,
+    string Kind,
+    PluginStemCoverage Coverage,
+    int? WindowStartMs,
+    int? WindowEndMs,
+    string Format,
+    int SampleRate,
+    string StorageKey,
+    string ProducerVersion
+);

--- a/src/NoMercy.Plugins.Abstractions/PluginWriteResult.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginWriteResult.cs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.Plugins.Abstractions;
+
+/// <summary>
+/// What became of one write through <see cref="IPluginMusicAnalysisWriter" />.
+/// A write that never lands - a track id the host does not know, a version
+/// older than the row already stored - looks identical to success unless the
+/// reason travels with the result, so it does here rather than as an
+/// exception a caller has to know to catch.
+/// </summary>
+/// <param name="Refusal">Why not, in words the owner can act on. Null when accepted.</param>
+public sealed record PluginWriteResult(string? Refusal)
+{
+    public bool Ok => Refusal is null;
+
+    public static PluginWriteResult Accepted() => new((string?)null);
+
+    public static PluginWriteResult Refused(string reason) => new(reason);
+}

--- a/src/NoMercy.Plugins/IPluginAudioToolsFactory.cs
+++ b/src/NoMercy.Plugins/IPluginAudioToolsFactory.cs
@@ -11,19 +11,20 @@
 
 using NoMercy.Plugins.Abstractions;
 
-namespace NoMercy.Data.Plugins;
+namespace NoMercy.Plugins;
 
 /// <summary>
-/// Builds the host's <see cref="IPluginMusicAnalysisWriter" /> for one plugin.
+/// Hands out the host's <see cref="IPluginAudioTools" /> for one plugin.
 /// <para>
-/// Unlike <c>IPluginLibraryWriterFactory</c>, this never returns null: the
-/// grant question here is whether a plugin declared
-/// <c>PluginHookCapability.MusicAnalysisWrite</c>, which the plugin host
-/// checks before handing the writer out at all, not something this factory
-/// re-checks per call.
+/// The same instance every time for the same plugin, deliberately: the
+/// one-ffmpeg-at-a-time guard lives inside the instance, so a fresh one per
+/// call would let a plugin start as many ffmpeg processes as it has call
+/// sites. Whether a plugin may have these tools at all is the
+/// <c>PluginHookCapability.AudioTools</c> question the plugin host answers
+/// before asking for them, not something this factory re-checks.
 /// </para>
 /// </summary>
-public interface IPluginMusicAnalysisWriterFactory
+public interface IPluginAudioToolsFactory
 {
-    IPluginMusicAnalysisWriter CreateFor(Ulid pluginId);
+    IPluginAudioTools CreateFor(Ulid pluginId);
 }

--- a/src/NoMercy.Plugins/IPluginMusicAnalysisWriterFactory.cs
+++ b/src/NoMercy.Plugins/IPluginMusicAnalysisWriterFactory.cs
@@ -11,20 +11,19 @@
 
 using NoMercy.Plugins.Abstractions;
 
-namespace NoMercy.Data.Plugins;
+namespace NoMercy.Plugins;
 
 /// <summary>
-/// Hands out the host's <see cref="IPluginAudioTools" /> for one plugin.
+/// Builds the host's <see cref="IPluginMusicAnalysisWriter" /> for one plugin.
 /// <para>
-/// The same instance every time for the same plugin, deliberately: the
-/// one-ffmpeg-at-a-time guard lives inside the instance, so a fresh one per
-/// call would let a plugin start as many ffmpeg processes as it has call
-/// sites. Whether a plugin may have these tools at all is the
-/// <c>PluginHookCapability.AudioTools</c> question the plugin host answers
-/// before asking for them, not something this factory re-checks.
+/// Unlike <c>IPluginLibraryWriterFactory</c>, this never returns null: the
+/// grant question here is whether a plugin declared
+/// <c>PluginHookCapability.MusicAnalysisWrite</c>, which the plugin host
+/// checks before handing the writer out at all, not something this factory
+/// re-checks per call.
 /// </para>
 /// </summary>
-public interface IPluginAudioToolsFactory
+public interface IPluginMusicAnalysisWriterFactory
 {
-    IPluginAudioTools CreateFor(Ulid pluginId);
+    IPluginMusicAnalysisWriter CreateFor(Ulid pluginId);
 }

--- a/src/NoMercy.Plugins/PluginContext.cs
+++ b/src/NoMercy.Plugins/PluginContext.cs
@@ -47,6 +47,24 @@ public class PluginContext : IPluginContext
     public IPluginStorage? Storage { get; }
 
     /// <summary>
+    /// Running ffmpeg over a track or a derived file, and splitting stems.
+    /// Null when the plugin never declared the <c>audioTools</c> hook.
+    /// </summary>
+    public IPluginAudioTools? AudioTools { get; }
+
+    /// <summary>
+    /// The server's own store of files derived from analysis. Null when the
+    /// plugin never declared the <c>derivedAudio</c> hook.
+    /// </summary>
+    public IPluginDerivedAudio? DerivedAudio { get; }
+
+    /// <summary>
+    /// Writing the DJ analysis record and the stem register. Null when the
+    /// plugin never declared the <c>musicAnalysisWrite</c> hook.
+    /// </summary>
+    public IPluginMusicAnalysisWriter? MusicAnalysisWriter { get; }
+
+    /// <summary>
     /// Playback, typed. Always present: the grants decide whether an intent
     /// reaches anyone, and a plugin branching on null for a surface that is part
     /// of its contract would be branching on how the host was wired rather than
@@ -73,12 +91,18 @@ public class PluginContext : IPluginContext
         IPluginEncoder? encoder = null,
         IPluginJobs? jobs = null,
         IPluginStorage? pluginStorage = null,
-        IPluginMusicQuery? music = null
+        IPluginMusicQuery? music = null,
+        IPluginAudioTools? audioTools = null,
+        IPluginDerivedAudio? derivedAudio = null,
+        IPluginMusicAnalysisWriter? musicAnalysisWriter = null
     )
     {
         Encoder = encoder;
         Jobs = jobs;
         Storage = pluginStorage;
+        AudioTools = audioTools;
+        DerivedAudio = derivedAudio;
+        MusicAnalysisWriter = musicAnalysisWriter;
 
         PluginId = pluginId;
         EventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));

--- a/src/NoMercy.Plugins/PluginContextFactory.cs
+++ b/src/NoMercy.Plugins/PluginContextFactory.cs
@@ -35,7 +35,10 @@ public class PluginContextFactory(
     IPluginEncoder? encoder = null,
     IPluginJobs? jobs = null,
     IPluginStorage? pluginStorage = null,
-    IPluginMusicQuery? musicQuery = null
+    IPluginMusicQuery? musicQuery = null,
+    IPluginAudioToolsFactory? audioToolsFactory = null,
+    IPluginDerivedAudio? derivedAudio = null,
+    IPluginMusicAnalysisWriterFactory? analysisWriterFactory = null
 ) : IPluginContextFactory
 {
     public IPluginContext Create(
@@ -76,6 +79,26 @@ public class PluginContextFactory(
         if (PluginCapabilityGuard.DeclaresHook(capabilities, PluginHookCapability.Storage))
             storageFacade = pluginStorage;
 
+        // The three analysis facades: each gated on its own hook, the same
+        // "declaring is not holding" rule as the writer and the storage/encoder
+        // pair above.
+        IPluginAudioTools? audioToolsFacade = null;
+        if (PluginCapabilityGuard.DeclaresHook(capabilities, PluginHookCapability.AudioTools))
+            audioToolsFacade = audioToolsFactory?.CreateFor(pluginId);
+
+        IPluginDerivedAudio? derivedAudioFacade = null;
+        if (PluginCapabilityGuard.DeclaresHook(capabilities, PluginHookCapability.DerivedAudio))
+            derivedAudioFacade = derivedAudio;
+
+        IPluginMusicAnalysisWriter? analysisWriter = null;
+        if (
+            PluginCapabilityGuard.DeclaresHook(
+                capabilities,
+                PluginHookCapability.MusicAnalysisWrite
+            )
+        )
+            analysisWriter = analysisWriterFactory?.CreateFor(pluginId);
+
         return new PluginContext(
             pluginId,
             eventBus,
@@ -95,7 +118,10 @@ public class PluginContextFactory(
             encoderFacade,
             jobsFacade,
             storageFacade,
-            musicQuery
+            musicQuery,
+            audioToolsFacade,
+            derivedAudioFacade,
+            analysisWriter
         );
     }
 }

--- a/src/NoMercy.Plugins/PluginServiceCollectionExtensions.cs
+++ b/src/NoMercy.Plugins/PluginServiceCollectionExtensions.cs
@@ -135,7 +135,20 @@ public static class PluginServiceCollectionExtensions
             sp.GetRequiredService<IPluginLibraryQuery>(),
             sp.GetRequiredService<IPluginLibraryWriterFactory>(),
             PlatformConfiguration(sp, pluginsPath),
-            sp.GetRequiredService<IPluginHubContextFactory>()
+            sp.GetRequiredService<IPluginHubContextFactory>(),
+            // Optional: GetService, not GetRequiredService. A host that never
+            // called AddPluginLibraryAccess (or the encoder/storage wiring)
+            // still gets a working platform, the same TryAdd philosophy as the
+            // library query and writer factory above — a plugin just finds the
+            // corresponding hook gated to null instead of the resolve itself
+            // failing for every plugin on every host.
+            encoder: sp.GetService<IPluginEncoder>(),
+            jobs: sp.GetService<IPluginJobs>(),
+            pluginStorage: sp.GetService<IPluginStorage>(),
+            musicQuery: sp.GetService<IPluginMusicQuery>(),
+            audioToolsFactory: sp.GetService<IPluginAudioToolsFactory>(),
+            derivedAudio: sp.GetService<IPluginDerivedAudio>(),
+            analysisWriterFactory: sp.GetService<IPluginMusicAnalysisWriterFactory>()
         ));
 
         services.AddSingleton<IPluginManager>(sp =>

--- a/src/NoMercy.Service/Configuration/ServiceConfiguration.Core.cs
+++ b/src/NoMercy.Service/Configuration/ServiceConfiguration.Core.cs
@@ -31,6 +31,7 @@ using NoMercy.Encoder.Subtitles;
 using NoMercy.Events;
 using NoMercy.Events.Audit;
 using NoMercy.MediaProcessing.Collections;
+using NoMercy.MediaProcessing.DerivedAudio;
 using NoMercy.MediaProcessing.Episodes;
 using NoMercy.MediaProcessing.EventHandlers;
 using NoMercy.MediaProcessing.Files;
@@ -666,6 +667,27 @@ public static partial class ServiceConfiguration
                 return new Storage.Drivers.Local.LocalStorage(driver, guard);
             }
         );
+
+        // Derived-audio-scoped IStorage: stems and rendered transitions live under
+        // AppFiles.DerivedAudioPath, addressed by content hash. Same shape as the
+        // transcode scope above.
+        services.AddKeyedSingleton<IStorage>(
+            "derived-audio",
+            (sp, _) =>
+            {
+                IStorageDriver driver = sp.GetRequiredService<IStorageDriver>();
+                Storage.Validation.StoragePathGuard guard = new(
+                    [AppFiles.DerivedAudioPath],
+                    driver
+                );
+                return new Storage.Drivers.Local.LocalStorage(driver, guard);
+            }
+        );
+        services.AddSingleton<IDerivedAudioStore>(sp => new DerivedAudioStore(
+            sp.GetRequiredKeyedService<IStorage>("derived-audio"),
+            sp.GetRequiredService<IDbContextFactory<MediaContext>>(),
+            sp.GetRequiredService<ILogger<DerivedAudioStore>>()
+        ));
 
         // Concrete activity probe for the deferred hardware benchmark —
         // Encoder's default is a no-op (always idle) so it stays decoupled

--- a/src/NoMercy.Service/Configuration/ServiceConfiguration.Cron.cs
+++ b/src/NoMercy.Service/Configuration/ServiceConfiguration.Cron.cs
@@ -28,5 +28,6 @@ public static partial class ServiceConfiguration
         services.AddCronJob<DatabaseBackupCronJob>("database-backup");
         services.AddCronJob<IpBanExpiryCronJob>("ip-ban-expiry");
         services.AddCronJob<AudioAnalysisSweepCronJob>("audio-analysis-sweep");
+        services.AddCronJob<DerivedAudioEvictionCronJob>("derived-audio-eviction");
     }
 }

--- a/src/NoMercy.Service/Jobs/DerivedAudioEvictionCronJob.cs
+++ b/src/NoMercy.Service/Jobs/DerivedAudioEvictionCronJob.cs
@@ -1,0 +1,46 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using NoMercy.MediaProcessing.DerivedAudio;
+using NoMercy.NmSystem.Configuration;
+using NoMercyQueue.Core;
+using NoMercyQueue.Core.Interfaces;
+
+namespace NoMercy.Service.Jobs;
+
+/// <summary>
+/// Keeps the content-addressed derived-audio store (rendered stems and
+/// transitions) under the dashboard-configured size cap. Runs hourly,
+/// evicting the oldest entries by <c>LastUsedAt</c> — never one still inside
+/// the store's own grace window — until the store is back under
+/// <see cref="RuntimeServerSettings.DerivedAudioCapBytes" />.
+/// </summary>
+public class DerivedAudioEvictionCronJob : ICronJobExecutor
+{
+    private readonly IDerivedAudioStore _store;
+
+    public string CronExpression => new CronExpressionBuilder().Hourly();
+    public string JobName => "Derived Audio Eviction";
+
+    public DerivedAudioEvictionCronJob(IDerivedAudioStore store)
+    {
+        _store = store;
+    }
+
+    public async Task ExecuteAsync(string parameters, CancellationToken cancellationToken = default)
+    {
+        await _store.EvictAsync(
+            RuntimeServerSettings.Current.DerivedAudioCapBytes,
+            TimeSpan.FromHours(24),
+            cancellationToken
+        );
+    }
+}

--- a/src/NoMercy.Setup/Ui/UserSettings.cs
+++ b/src/NoMercy.Setup/Ui/UserSettings.cs
@@ -317,6 +317,19 @@ public static class UserSettings
                     if (Enum.TryParse(setting.Value, true, out ConnectivityMode connectivityMode))
                         RuntimeServerSettings.Current.ConnectivityMode = connectivityMode;
                     break;
+                case "derivedAudioCapGb":
+                    if (!int.TryParse(setting.Value, out int derivedAudioCapGb))
+                    {
+                        Logger.App(
+                            $"UserSettings: skipping malformed 'derivedAudioCapGb' value '{setting.Value}' — keeping current runtime setting",
+                            LogEventLevel.Warning
+                        );
+                        break;
+                    }
+
+                    RuntimeServerSettings.Current.DerivedAudioCapBytes =
+                        derivedAudioCapGb * 1024L * 1024 * 1024;
+                    break;
             }
         }
     }

--- a/tests/NoMercy.Tests.Api/Dashboard/ConfigurationControllerTests.cs
+++ b/tests/NoMercy.Tests.Api/Dashboard/ConfigurationControllerTests.cs
@@ -15,6 +15,7 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NoMercy.Database;
+using NoMercy.NmSystem.Configuration;
 using NoMercy.Tests.Api.Infrastructure;
 using Xunit;
 using Configuration = NoMercy.Database.Models.Common.Configuration;
@@ -229,6 +230,39 @@ public class ConfigurationControllerTests : IClassFixture<NoMercyApiFactory>
         );
         persisted.Should().NotBeNull();
         persisted!.Value.Should().Be(newInternalPort.ToString());
+    }
+
+    [Fact]
+    public async Task PatchConfiguration_DerivedAudioCapGb_PersistsRoundTrip_AndUpdatesRuntimeSettings()
+    {
+        HttpResponseMessage patchResponse = await PatchAsync(
+            _authed,
+            "/api/v1/dashboard/configuration",
+            new { derived_audio_cap_gb = 20 }
+        );
+        patchResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        HttpResponseMessage getResponse = await _authed.GetAsync("/api/v1/dashboard/configuration");
+        string body = await getResponse.Content.ReadAsStringAsync();
+        using JsonDocument doc = JsonDocument.Parse(body);
+
+        JsonElement data = doc.RootElement.GetProperty("data");
+        data.TryGetProperty("derived_audio_cap_gb", out JsonElement capEl).Should().BeTrue();
+        capEl.GetInt32().Should().Be(20);
+
+        RuntimeServerSettings.Current.DerivedAudioCapBytes.Should().Be(20L * 1024 * 1024 * 1024);
+    }
+
+    [Fact]
+    public async Task PatchConfiguration_DerivedAudioCapGb_BelowOne_ReturnsBadRequest()
+    {
+        HttpResponseMessage patchResponse = await PatchAsync(
+            _authed,
+            "/api/v1/dashboard/configuration",
+            new { derived_audio_cap_gb = 0 }
+        );
+
+        patchResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]

--- a/tests/NoMercy.Tests.Api/Dashboard/ConfigurationControllerTests.cs
+++ b/tests/NoMercy.Tests.Api/Dashboard/ConfigurationControllerTests.cs
@@ -251,6 +251,14 @@ public class ConfigurationControllerTests : IClassFixture<NoMercyApiFactory>
         capEl.GetInt32().Should().Be(20);
 
         RuntimeServerSettings.Current.DerivedAudioCapBytes.Should().Be(20L * 1024 * 1024 * 1024);
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        AppDbContext appContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        Configuration? persisted = await appContext.Configuration.FirstOrDefaultAsync(c =>
+            c.Key == "derivedAudioCapGb"
+        );
+        persisted.Should().NotBeNull();
+        persisted!.Value.Should().Be("20");
     }
 
     [Fact]

--- a/tests/NoMercy.Tests.Api/Music/TrackAudioAnalysisEndpointTests.cs
+++ b/tests/NoMercy.Tests.Api/Music/TrackAudioAnalysisEndpointTests.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using NoMercy.Database;
+using NoMercy.Database.Models.Music;
 using NoMercy.Tests.Api.Infrastructure;
 using Xunit;
 
@@ -162,5 +163,254 @@ public class TrackAudioAnalysisEndpointTests : IClassFixture<NoMercyApiFactory>
         );
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    /// <summary>
+    /// The DJ record and stems the automix plugin wrote for a track ride
+    /// along with its base analysis — a nested field rather than a second
+    /// round trip, since a caller asking for one almost always wants both.
+    /// </summary>
+    [Fact]
+    public async Task Analysis_IncludesTheDjRecordAndStems_WhenPresent()
+    {
+        Guid trackId = Guid.NewGuid();
+        string storageKey = Guid.NewGuid().ToString("N") + Guid.NewGuid().ToString("N");
+
+        using (MediaContext context = new())
+        {
+            context.Tracks.Add(
+                new Track
+                {
+                    Id = trackId,
+                    Name = "Dj Endpoint Track",
+                    FolderId = NoMercyApiFactory.MusicFolderId,
+                }
+            );
+
+            context.TrackAudioAnalysis.Add(
+                new TrackAudioAnalysis
+                {
+                    TrackId = trackId,
+                    AnalyzerVersion = 1,
+                    State = AudioAnalysisState.Ok,
+                    KeyName = "Am",
+                    KeyCamelot = "8A",
+                    AnalyzedAt = DateTime.UtcNow,
+                }
+            );
+
+            context.TrackDjAnalysis.Add(
+                new TrackDjAnalysis
+                {
+                    TrackId = trackId,
+                    ProducerPluginId = Ulid.NewUlid(),
+                    DjAnalyzerVersion = 1,
+                    BaseAnalyzerVersion = 1,
+                    State = AudioAnalysisState.Ok,
+                    DownbeatIndex = 0,
+                    BeatsPerBar = 4,
+                    PhraseLengthBars = 8,
+                    PhraseStartsMs = "[0,32000,64000]",
+                    VocalRegionsMs = "[[1000,5000],[9000,15000]]",
+                    BarEnergy = "[-20.5,-18.2,-14.0]",
+                    CuePoints = """[{"ms":1000,"type":"intro","direction":"mixIn","score":0.9}]""",
+                    Chords = """[{"ms":0,"chord":"Am"}]""",
+                    AnalyzedAt = DateTime.UtcNow,
+                }
+            );
+
+            context.DerivedAudio.Add(
+                new DerivedAudio
+                {
+                    Key = storageKey,
+                    ContentType = "audio/opus",
+                    Bytes = 10,
+                    CreatedAt = DateTime.UtcNow,
+                    LastUsedAt = DateTime.UtcNow,
+                }
+            );
+
+            context.TrackStems.Add(
+                new TrackStem
+                {
+                    Id = Ulid.NewUlid(),
+                    TrackId = trackId,
+                    Kind = "vocals",
+                    Coverage = StemCoverage.Full,
+                    Format = "opus",
+                    SampleRate = 48000,
+                    StorageKey = storageKey,
+                    ProducerVersion = "spleeter-2stems-f16@v1.0.41",
+                    CreatedAt = DateTime.UtcNow,
+                }
+            );
+
+            context.SaveChanges();
+        }
+
+        HttpResponseMessage response = await _owner.PostAsync(
+            AnalysisRoute,
+            JsonBody(new { track_ids = new[] { trackId } })
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement row = doc.RootElement.GetProperty("data")[0];
+
+        JsonElement dj = row.GetProperty("dj");
+        dj.GetProperty("dj_analyzer_version").GetInt32().Should().Be(1);
+        dj.GetProperty("base_analyzer_version").GetInt32().Should().Be(1);
+        dj.GetProperty("downbeat_index").GetInt32().Should().Be(0);
+        dj.GetProperty("beats_per_bar").GetInt32().Should().Be(4);
+        dj.GetProperty("phrase_length_bars").GetInt32().Should().Be(8);
+        dj.GetProperty("phrase_starts_ms")
+            .EnumerateArray()
+            .Select(e => e.GetInt32())
+            .Should()
+            .Equal(0, 32000, 64000);
+
+        JsonElement cuePoint = dj.GetProperty("cue_points")[0];
+        cuePoint.GetProperty("ms").GetInt32().Should().Be(1000);
+        cuePoint.GetProperty("type").GetString().Should().Be("intro");
+        cuePoint.GetProperty("direction").GetString().Should().Be("mixIn");
+        cuePoint.GetProperty("score").GetDouble().Should().Be(0.9);
+
+        // "Am" -> tonic A -> pitch class 9.
+        dj.GetProperty("pitch_class").GetInt32().Should().Be(9);
+
+        JsonElement stems = row.GetProperty("stems");
+        stems.GetArrayLength().Should().Be(1);
+        stems[0].GetProperty("kind").GetString().Should().Be("vocals");
+        stems[0].GetProperty("coverage").GetString().Should().Be("full");
+        stems[0].GetProperty("storage_key").GetString().Should().Be(storageKey);
+    }
+
+    /// <summary>
+    /// Most tracks never get a DJ row or a stem file — the shape has to be
+    /// honest about that rather than fake an empty-looking DJ object.
+    /// </summary>
+    [Fact]
+    public async Task Analysis_HasNullDjAndEmptyStems_WhenAbsent()
+    {
+        Guid trackId = Guid.NewGuid();
+
+        using (MediaContext context = new())
+        {
+            context.Tracks.Add(
+                new Track
+                {
+                    Id = trackId,
+                    Name = "No Dj Endpoint Track",
+                    FolderId = NoMercyApiFactory.MusicFolderId,
+                }
+            );
+
+            context.TrackAudioAnalysis.Add(
+                new TrackAudioAnalysis
+                {
+                    TrackId = trackId,
+                    AnalyzerVersion = 1,
+                    State = AudioAnalysisState.Ok,
+                    AnalyzedAt = DateTime.UtcNow,
+                }
+            );
+
+            context.SaveChanges();
+        }
+
+        HttpResponseMessage response = await _owner.PostAsync(
+            AnalysisRoute,
+            JsonBody(new { track_ids = new[] { trackId } })
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement row = doc.RootElement.GetProperty("data")[0];
+
+        row.GetProperty("dj").ValueKind.Should().Be(JsonValueKind.Null);
+        row.GetProperty("stems").GetArrayLength().Should().Be(0);
+    }
+
+    /// <summary>
+    /// The dashboard's audio-analysis panel needs the automix side of the
+    /// picture too: how much of the library the DJ analyzer has reached, and
+    /// how much of the derived-audio store the stems it wrote occupy.
+    /// </summary>
+    [Fact]
+    public async Task AudioAnalysisStatus_ReportsDjCountersAndStemBytes()
+    {
+        Guid okTrackId = Guid.NewGuid();
+        Guid failedTrackId = Guid.NewGuid();
+        string storageKey = Guid.NewGuid().ToString("N") + Guid.NewGuid().ToString("N");
+        const long seededBytes = 123_456;
+
+        using (MediaContext context = new())
+        {
+            context.Tracks.AddRange(
+                new Track
+                {
+                    Id = okTrackId,
+                    Name = "Dj Status Ok",
+                    FolderId = NoMercyApiFactory.MusicFolderId,
+                },
+                new Track
+                {
+                    Id = failedTrackId,
+                    Name = "Dj Status Failed",
+                    FolderId = NoMercyApiFactory.MusicFolderId,
+                }
+            );
+
+            context.TrackDjAnalysis.AddRange(
+                new TrackDjAnalysis
+                {
+                    TrackId = okTrackId,
+                    ProducerPluginId = Ulid.NewUlid(),
+                    DjAnalyzerVersion = 1,
+                    BaseAnalyzerVersion = 1,
+                    State = AudioAnalysisState.Ok,
+                    AnalyzedAt = DateTime.UtcNow,
+                },
+                new TrackDjAnalysis
+                {
+                    TrackId = failedTrackId,
+                    ProducerPluginId = Ulid.NewUlid(),
+                    DjAnalyzerVersion = 1,
+                    BaseAnalyzerVersion = 1,
+                    State = AudioAnalysisState.Failed,
+                    FailureReason = "vocal detector produced no regions",
+                    AnalyzedAt = DateTime.UtcNow,
+                }
+            );
+
+            context.DerivedAudio.Add(
+                new DerivedAudio
+                {
+                    Key = storageKey,
+                    ContentType = "audio/opus",
+                    Bytes = seededBytes,
+                    CreatedAt = DateTime.UtcNow,
+                    LastUsedAt = DateTime.UtcNow,
+                }
+            );
+
+            context.SaveChanges();
+        }
+
+        HttpResponseMessage response = await _owner.GetAsync(
+            "/api/v1/dashboard/tasks/audio-analysis/status"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("dj_analyzed").GetInt32().Should().BeGreaterThanOrEqualTo(1);
+        doc.RootElement.GetProperty("dj_failed").GetInt32().Should().BeGreaterThanOrEqualTo(1);
+        doc.RootElement.GetProperty("stems_bytes")
+            .GetInt64()
+            .Should()
+            .BeGreaterThanOrEqualTo(seededBytes);
     }
 }

--- a/tests/NoMercy.Tests.Database/Migrations/AnalysisRecordMigrationTests.cs
+++ b/tests/NoMercy.Tests.Database/Migrations/AnalysisRecordMigrationTests.cs
@@ -1,0 +1,137 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NoMercy.Database;
+using NoMercy.Database.Models.Libraries;
+using NoMercy.Database.Models.Music;
+using NoMercy.Database.Models.Storage;
+
+namespace NoMercy.Tests.Database.Migrations;
+
+/// <summary>
+/// The DJ record, stem register and derived-audio register are new tables on
+/// an existing database, not a rewrite of one. This replays the upgrade the
+/// way a self-hosted install sees it: a database that predates the change,
+/// carrying a track and its base analysis row, then the new migration on top
+/// of it — the track and its row must survive, and the three new tables must
+/// exist and be empty.
+/// </summary>
+public class AnalysisRecordMigrationTests : IDisposable
+{
+    private const string PreviousMigration = "20260909230447_AnalyzeAudioDefaultsOn";
+
+    private readonly string _databasePath;
+
+    public AnalysisRecordMigrationTests()
+    {
+        _databasePath = Path.Combine(
+            Path.GetTempPath(),
+            $"nm_analysisrecord_migration_{Guid.NewGuid():N}.db"
+        );
+    }
+
+    public void Dispose()
+    {
+        // Microsoft.Data.Sqlite pools physical file handles across connections
+        // even after Dispose(); on Windows the OS-level lock outlives the
+        // `using` above, so the delete fails unless the pool is cleared first.
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(_databasePath))
+        {
+            File.Delete(_databasePath);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private MediaContext OpenContext()
+    {
+        DbContextOptionsBuilder<MediaContext> builder = new();
+        builder.UseSqlite($"Data Source={_databasePath}");
+
+        return new(builder.Options);
+    }
+
+    [Fact]
+    public async Task AnUpgradedDatabase_KeepsItsRowsAndGainsTheEmptyTables()
+    {
+        Guid trackId = Guid.NewGuid();
+        Ulid driverId = Ulid.NewUlid();
+        Ulid folderId = Ulid.NewUlid();
+
+        await using (MediaContext oldContext = OpenContext())
+        {
+            IMigrator migrator = oldContext.GetService<IMigrator>();
+            await migrator.MigrateAsync(PreviousMigration);
+
+            oldContext.Add(
+                new Driver
+                {
+                    Id = driverId,
+                    Name = "local",
+                    Type = "local",
+                }
+            );
+            oldContext.Add(
+                new Folder
+                {
+                    Id = folderId,
+                    Path = "/music",
+                    DriverId = driverId,
+                }
+            );
+            oldContext.Add(
+                new Track
+                {
+                    Id = trackId,
+                    Name = "A Track",
+                    Duration = "03:45",
+                    FolderId = folderId,
+                }
+            );
+            oldContext.Add(
+                new TrackAudioAnalysis
+                {
+                    TrackId = trackId,
+                    AnalyzerVersion = 1,
+                    State = AudioAnalysisState.Ok,
+                    AnalyzedAt = DateTime.UtcNow,
+                }
+            );
+
+            await oldContext.SaveChangesAsync();
+        }
+
+        await using (MediaContext upgradeContext = OpenContext())
+        {
+            await upgradeContext.Database.MigrateAsync();
+        }
+
+        await using MediaContext readContext = OpenContext();
+
+        Track track = await readContext.Tracks.AsNoTracking().SingleAsync(t => t.Id == trackId);
+        Assert.Equal("A Track", track.Name);
+
+        TrackAudioAnalysis baseAnalysis = await readContext
+            .TrackAudioAnalysis.AsNoTracking()
+            .SingleAsync(a => a.TrackId == trackId);
+        Assert.Equal(AudioAnalysisState.Ok, baseAnalysis.State);
+
+        Assert.Empty(await readContext.TrackDjAnalysis.AsNoTracking().ToListAsync());
+        Assert.Empty(await readContext.TrackStems.AsNoTracking().ToListAsync());
+        Assert.Empty(await readContext.DerivedAudio.AsNoTracking().ToListAsync());
+    }
+}

--- a/tests/NoMercy.Tests.Database/Models/AnalysisRecordModelTests.cs
+++ b/tests/NoMercy.Tests.Database/Models/AnalysisRecordModelTests.cs
@@ -1,3 +1,14 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using NoMercy.Database;

--- a/tests/NoMercy.Tests.Database/Models/AnalysisRecordModelTests.cs
+++ b/tests/NoMercy.Tests.Database/Models/AnalysisRecordModelTests.cs
@@ -1,0 +1,204 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NoMercy.Database;
+using NoMercy.Database.Models.Libraries;
+using NoMercy.Database.Models.Music;
+using NoMercy.Database.Models.Storage;
+
+namespace NoMercy.Tests.Database.Models;
+
+/// <summary>
+/// The DJ record and the stem register hang off a track and off the derived
+/// store: deleting either parent must take the rows with it, and the JSON
+/// columns must come back byte-for-byte.
+/// </summary>
+public class AnalysisRecordModelTests : IDisposable
+{
+    private readonly SqliteConnection _connection = new("Data Source=:memory:");
+    private readonly DbContextOptions<MediaContext> _options;
+
+    public AnalysisRecordModelTests()
+    {
+        _connection.Open();
+        _options = new DbContextOptionsBuilder<MediaContext>().UseSqlite(_connection).Options;
+        using MediaContext context = new(_options);
+        context.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    // Track.FolderId is a required FK to Folder, which is itself a required FK
+    // to Driver, both enforced at the SQLite level (SqliteConnection enforces
+    // foreign keys by default). A dangling FolderId — as a bare scalar would
+    // leave it — fails the very first insert with "FOREIGN KEY constraint
+    // failed" before any of this file's own tables are touched, so TrackRow
+    // carries the whole chain through navigation properties for EF to insert
+    // alongside the track.
+    private static Track TrackRow(Guid id)
+    {
+        Ulid folderId = Ulid.NewUlid();
+        return new Track
+        {
+            Id = id,
+            Name = "A Track",
+            Duration = "03:45",
+            FolderId = folderId,
+            LibraryFolder = new Folder
+            {
+                Id = folderId,
+                Path = "/music",
+                DriverId = Driver.SystemLocalDriverId,
+                Driver = new Driver
+                {
+                    Id = Driver.SystemLocalDriverId,
+                    Name = "local",
+                    Type = "local",
+                },
+            },
+        };
+    }
+
+    [Fact]
+    public async Task DeletingATrack_RemovesItsDjAnalysisAndStems()
+    {
+        Guid trackId = Guid.NewGuid();
+        await using (MediaContext context = new(_options))
+        {
+            context.Tracks.Add(TrackRow(trackId));
+            context.DerivedAudio.Add(
+                new DerivedAudio
+                {
+                    Key = new string('a', 64),
+                    ContentType = "audio/opus",
+                    Bytes = 10,
+                    CreatedAt = DateTime.UtcNow,
+                    LastUsedAt = DateTime.UtcNow,
+                }
+            );
+            context.TrackDjAnalysis.Add(
+                new TrackDjAnalysis
+                {
+                    TrackId = trackId,
+                    ProducerPluginId = Ulid.NewUlid(),
+                    DjAnalyzerVersion = 1,
+                    BaseAnalyzerVersion = 4,
+                    State = AudioAnalysisState.Ok,
+                    PhraseStartsMs = "[0,15000]",
+                    AnalyzedAt = DateTime.UtcNow,
+                }
+            );
+            context.TrackStems.Add(
+                new TrackStem
+                {
+                    Id = Ulid.NewUlid(),
+                    TrackId = trackId,
+                    Kind = "vocals",
+                    Coverage = StemCoverage.Full,
+                    Format = "opus",
+                    SampleRate = 48000,
+                    StorageKey = new string('a', 64),
+                    ProducerVersion = "spleeter-2stems-f16@v1.0.41",
+                    CreatedAt = DateTime.UtcNow,
+                }
+            );
+            await context.SaveChangesAsync();
+        }
+
+        await using (MediaContext context = new(_options))
+        {
+            await context.Tracks.Where(track => track.Id == trackId).ExecuteDeleteAsync();
+        }
+
+        await using MediaContext read = new(_options);
+        Assert.Empty(await read.TrackDjAnalysis.AsNoTracking().ToListAsync());
+        Assert.Empty(await read.TrackStems.AsNoTracking().ToListAsync());
+        Assert.Single(await read.DerivedAudio.AsNoTracking().ToListAsync());
+    }
+
+    [Fact]
+    public async Task DeletingADerivedAudioRow_RemovesTheStemsThatPointAtIt()
+    {
+        Guid trackId = Guid.NewGuid();
+        string key = new string('b', 64);
+        await using (MediaContext context = new(_options))
+        {
+            context.Tracks.Add(TrackRow(trackId));
+            context.DerivedAudio.Add(
+                new DerivedAudio
+                {
+                    Key = key,
+                    ContentType = "audio/opus",
+                    Bytes = 10,
+                    CreatedAt = DateTime.UtcNow,
+                    LastUsedAt = DateTime.UtcNow,
+                }
+            );
+            context.TrackStems.Add(
+                new TrackStem
+                {
+                    Id = Ulid.NewUlid(),
+                    TrackId = trackId,
+                    Kind = "vocals",
+                    Coverage = StemCoverage.MixIn,
+                    WindowStartMs = 0,
+                    WindowEndMs = 45000,
+                    Format = "opus",
+                    SampleRate = 48000,
+                    StorageKey = key,
+                    ProducerVersion = "spleeter-2stems-f16@v1.0.41",
+                    CreatedAt = DateTime.UtcNow,
+                }
+            );
+            await context.SaveChangesAsync();
+        }
+
+        await using (MediaContext context = new(_options))
+        {
+            await context.DerivedAudio.Where(row => row.Key == key).ExecuteDeleteAsync();
+        }
+
+        await using MediaContext read = new(_options);
+        Assert.Empty(await read.TrackStems.AsNoTracking().ToListAsync());
+        Assert.Single(await read.Tracks.AsNoTracking().ToListAsync());
+    }
+
+    [Fact]
+    public async Task TheSameStemTwice_IsRejectedByTheUniqueIndex()
+    {
+        Guid trackId = Guid.NewGuid();
+        string key = new string('c', 64);
+        await using MediaContext context = new(_options);
+        context.Tracks.Add(TrackRow(trackId));
+        context.DerivedAudio.Add(
+            new DerivedAudio
+            {
+                Key = key,
+                ContentType = "audio/opus",
+                Bytes = 10,
+                CreatedAt = DateTime.UtcNow,
+                LastUsedAt = DateTime.UtcNow,
+            }
+        );
+        TrackStem Stem() =>
+            new()
+            {
+                Id = Ulid.NewUlid(),
+                TrackId = trackId,
+                Kind = "vocals",
+                Coverage = StemCoverage.Full,
+                Format = "opus",
+                SampleRate = 48000,
+                StorageKey = key,
+                ProducerVersion = "p@1",
+                CreatedAt = DateTime.UtcNow,
+            };
+        context.TrackStems.Add(Stem());
+        context.TrackStems.Add(Stem());
+
+        await Assert.ThrowsAsync<DbUpdateException>(() => context.SaveChangesAsync());
+    }
+}

--- a/tests/NoMercy.Tests.Database/Models/AnalysisRecordModelTests.cs
+++ b/tests/NoMercy.Tests.Database/Models/AnalysisRecordModelTests.cs
@@ -20,8 +20,8 @@ namespace NoMercy.Tests.Database.Models;
 
 /// <summary>
 /// The DJ record and the stem register hang off a track and off the derived
-/// store: deleting either parent must take the rows with it, and the JSON
-/// columns must come back byte-for-byte.
+/// store: deleting either parent must take the rows with it, and a JSON column
+/// must come back out of SQLite as the string that went in.
 /// </summary>
 public class AnalysisRecordModelTests : IDisposable
 {
@@ -71,6 +71,56 @@ public class AnalysisRecordModelTests : IDisposable
                 },
             },
         };
+    }
+
+    /// <summary>
+    /// The five JSON columns are text to SQLite and text to EF: the writer
+    /// serialises, the reader deserialises, and nothing in between is allowed
+    /// to reformat, re-order or re-encode what was stored. A column that came
+    /// back with its members in another order would still parse, and the
+    /// reader would still answer - while no longer describing the same track.
+    /// </summary>
+    [Fact]
+    public async Task AJsonColumn_ComesBackAsTheStringThatWentIn()
+    {
+        const string phraseStarts = "[0,15000,30000]";
+        const string vocalRegions = "[[1000,5000],[9000,15000]]";
+        const string barEnergy = "[-20.5,-18.2,-14]";
+        const string cuePoints =
+            "[{\"ms\":1000,\"type\":\"intro\",\"direction\":\"mixIn\",\"score\":0.9}]";
+        const string chords = "[{\"ms\":0,\"chord\":\"Am\"}]";
+
+        Guid trackId = Guid.NewGuid();
+        await using (MediaContext context = new(_options))
+        {
+            context.Tracks.Add(TrackRow(trackId));
+            context.TrackDjAnalysis.Add(
+                new TrackDjAnalysis
+                {
+                    TrackId = trackId,
+                    ProducerPluginId = Ulid.NewUlid(),
+                    DjAnalyzerVersion = 1,
+                    BaseAnalyzerVersion = 4,
+                    State = AudioAnalysisState.Ok,
+                    PhraseStartsMs = phraseStarts,
+                    VocalRegionsMs = vocalRegions,
+                    BarEnergy = barEnergy,
+                    CuePoints = cuePoints,
+                    Chords = chords,
+                    AnalyzedAt = DateTime.UtcNow,
+                }
+            );
+            await context.SaveChangesAsync();
+        }
+
+        await using MediaContext read = new(_options);
+        TrackDjAnalysis row = await read.TrackDjAnalysis.AsNoTracking().SingleAsync();
+
+        Assert.Equal(phraseStarts, row.PhraseStartsMs);
+        Assert.Equal(vocalRegions, row.VocalRegionsMs);
+        Assert.Equal(barEnergy, row.BarEnergy);
+        Assert.Equal(cuePoints, row.CuePoints);
+        Assert.Equal(chords, row.Chords);
     }
 
     [Fact]

--- a/tests/NoMercy.Tests.MediaProcessing/AudioAnalysis/MusicAnalysisJobTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/AudioAnalysis/MusicAnalysisJobTests.cs
@@ -15,6 +15,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NoMercy.Database;
 using NoMercy.Database.Models.Music;
+using NoMercy.Events;
+using NoMercy.Events.Music;
 using NoMercy.MediaProcessing.AudioAnalysis;
 using NoMercy.MediaProcessing.Jobs.MediaJobs;
 using NoMercy.Storage;
@@ -66,7 +68,8 @@ public class MusicAnalysisJobTests : IDisposable
 
     private MusicAnalysisJob CreateJob(
         AudioAnalysisResult? result,
-        Mock<IAudioAnalyzer>? analyzerMock = null
+        Mock<IAudioAnalyzer>? analyzerMock = null,
+        Mock<IEventBus>? eventBus = null
     )
     {
         Mock<IAudioAnalyzer> analyzer = analyzerMock ?? new Mock<IAudioAnalyzer>();
@@ -75,10 +78,13 @@ public class MusicAnalysisJobTests : IDisposable
             .Setup(a => a.AnalyzeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(result);
 
-        return CreateJobFrom(analyzer);
+        return CreateJobFrom(analyzer, eventBus);
     }
 
-    private MusicAnalysisJob CreateJobFrom(Mock<IAudioAnalyzer> analyzer)
+    private MusicAnalysisJob CreateJobFrom(
+        Mock<IAudioAnalyzer> analyzer,
+        Mock<IEventBus>? eventBus = null
+    )
     {
         Mock<IStorageDriver> storageDriver = new();
         storageDriver
@@ -90,11 +96,14 @@ public class MusicAnalysisJobTests : IDisposable
             .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => new(_options));
 
+        Mock<IEventBus> bus = eventBus ?? new Mock<IEventBus>();
+
         return new MusicAnalysisJob(
             analyzer.Object,
             storageDriver.Object,
             factory.Object,
-            NullLoggerFactory.Instance
+            NullLoggerFactory.Instance,
+            bus.Object
         )
         {
             TrackId = _trackId,
@@ -236,7 +245,8 @@ public class MusicAnalysisJobTests : IDisposable
             newer.Object,
             storageDriver.Object,
             factory.Object,
-            NullLoggerFactory.Instance
+            NullLoggerFactory.Instance,
+            new Mock<IEventBus>().Object
         )
         {
             TrackId = _trackId,
@@ -272,5 +282,45 @@ public class MusicAnalysisJobTests : IDisposable
         using MediaContext context = new(_options);
 
         Assert.Empty(context.TrackAudioAnalysis);
+    }
+
+    [Fact]
+    public async Task AnOkVerdict_PublishesACompletedEvent()
+    {
+        Mock<IEventBus> bus = new();
+
+        await CreateJob(SampleResult(), eventBus: bus).Handle();
+
+        bus.Verify(
+            b =>
+                b.PublishAsync(
+                    It.Is<TrackAudioAnalysisCompletedEvent>(e =>
+                        e.TrackId == _trackId
+                        && e.State == "Ok"
+                        && e.AnalyzerVersion == AnalyzerVersion
+                    ),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task AFailedVerdict_PublishesACompletedEvent()
+    {
+        Mock<IEventBus> bus = new();
+
+        await CreateJob(null, eventBus: bus).Handle();
+
+        bus.Verify(
+            b =>
+                b.PublishAsync(
+                    It.Is<TrackAudioAnalysisCompletedEvent>(e =>
+                        e.TrackId == _trackId && e.State == "Failed"
+                    ),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
     }
 }

--- a/tests/NoMercy.Tests.MediaProcessing/AudioAnalysis/MusicAnalysisJobTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/AudioAnalysis/MusicAnalysisJobTests.cs
@@ -31,6 +31,11 @@ public class MusicAnalysisJobTests : IDisposable
     private readonly DbContextOptions<MediaContext> _options;
     private readonly Guid _trackId = Guid.NewGuid();
 
+    // The track is in two libraries: the completion event has to name both,
+    // because the derived-audio retention policy is decided per library.
+    private readonly Ulid _libraryOneId = Ulid.NewUlid();
+    private readonly Ulid _libraryTwoId = Ulid.NewUlid();
+
     public MusicAnalysisJobTests()
     {
         _connection = new("Data Source=:memory:");
@@ -55,6 +60,11 @@ public class MusicAnalysisJobTests : IDisposable
                 HostFolder = "/music/album",
                 Filename = "/track.flac",
             }
+        );
+
+        context.LibraryTrack.AddRange(
+            new LibraryTrack(_libraryOneId, _trackId),
+            new LibraryTrack(_libraryTwoId, _trackId)
         );
 
         context.SaveChanges();
@@ -298,6 +308,9 @@ public class MusicAnalysisJobTests : IDisposable
                         e.TrackId == _trackId
                         && e.State == "Ok"
                         && e.AnalyzerVersion == AnalyzerVersion
+                        && e.LibraryIds.Count == 2
+                        && e.LibraryIds.Contains(_libraryOneId)
+                        && e.LibraryIds.Contains(_libraryTwoId)
                     ),
                     It.IsAny<CancellationToken>()
                 ),
@@ -316,7 +329,11 @@ public class MusicAnalysisJobTests : IDisposable
             b =>
                 b.PublishAsync(
                     It.Is<TrackAudioAnalysisCompletedEvent>(e =>
-                        e.TrackId == _trackId && e.State == "Failed"
+                        e.TrackId == _trackId
+                        && e.State == "Failed"
+                        && e.LibraryIds.Count == 2
+                        && e.LibraryIds.Contains(_libraryOneId)
+                        && e.LibraryIds.Contains(_libraryTwoId)
                     ),
                     It.IsAny<CancellationToken>()
                 ),

--- a/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioEvictionTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioEvictionTests.cs
@@ -1,0 +1,78 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using FluentAssertions;
+using NoMercy.MediaProcessing.DerivedAudio;
+using DerivedAudioRow = NoMercy.Database.Models.Music.DerivedAudio;
+
+namespace NoMercy.Tests.MediaProcessing.DerivedAudio;
+
+// This test namespace shares its last segment with NoMercy.Database.Models.Music.DerivedAudio;
+// the row type is aliased to DerivedAudioRow so the bare name resolves to the type, not the
+// enclosing namespace (CS0118).
+public class DerivedAudioEvictionTests
+{
+    private static DerivedAudioRow Row(string key, long bytes, DateTime lastUsed) =>
+        new()
+        {
+            Key = key,
+            ContentType = "audio/opus",
+            Bytes = bytes,
+            CreatedAt = lastUsed,
+            LastUsedAt = lastUsed,
+        };
+
+    [Fact]
+    public void UnderTheCap_NothingIsChosen()
+    {
+        DateTime now = new(2026, 9, 10, 12, 0, 0, DateTimeKind.Utc);
+        List<DerivedAudioRow> rows = [Row("a", 40, now.AddDays(-3)), Row("b", 40, now.AddDays(-2))];
+
+        DerivedAudioEviction
+            .Choose(rows, capBytes: 100, grace: TimeSpan.FromHours(24), now)
+            .Should()
+            .BeEmpty();
+    }
+
+    [Fact]
+    public void OverTheCap_TheLongestUnusedGoFirst_UntilUnderTheCap()
+    {
+        DateTime now = new(2026, 9, 10, 12, 0, 0, DateTimeKind.Utc);
+        List<DerivedAudioRow> rows =
+        [
+            Row("old", 50, now.AddDays(-5)),
+            Row("mid", 50, now.AddDays(-3)),
+            Row("new", 50, now.AddDays(-2)),
+        ];
+
+        DerivedAudioEviction
+            .Choose(rows, capBytes: 100, grace: TimeSpan.FromHours(24), now)
+            .Select(row => row.Key)
+            .Should()
+            .Equal("old");
+    }
+
+    [Fact]
+    public void RowsInsideTheGrace_AreNeverChosen_EvenOverTheCap()
+    {
+        DateTime now = new(2026, 9, 10, 12, 0, 0, DateTimeKind.Utc);
+        List<DerivedAudioRow> rows =
+        [
+            Row("fresh", 500, now.AddHours(-1)),
+            Row("fresh2", 500, now.AddHours(-2)),
+        ];
+
+        DerivedAudioEviction
+            .Choose(rows, capBytes: 100, grace: TimeSpan.FromHours(24), now)
+            .Should()
+            .BeEmpty();
+    }
+}

--- a/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
@@ -1,0 +1,206 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NoMercy.Database;
+using NoMercy.MediaProcessing.DerivedAudio;
+using NoMercy.Storage;
+using NoMercy.Storage.Drivers.Local;
+using NoMercy.Storage.Validation;
+
+namespace NoMercy.Tests.MediaProcessing.DerivedAudio;
+
+// This test namespace shares its last segment with NoMercy.Database.Models.Music.DerivedAudio,
+// but this file only ever reaches that type through NoMercy.Database.MediaContext.DerivedAudio
+// (the DbSet), never the bare type name, so no alias is needed here.
+[Trait("Category", "Unit")]
+public sealed class DerivedAudioStoreTests : IDisposable
+{
+    private readonly string _root;
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<MediaContext> _options;
+    private readonly IDbContextFactory<MediaContext> _contextFactory;
+
+    public DerivedAudioStoreTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"nm-derived-audio-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+        _options = new DbContextOptionsBuilder<MediaContext>().UseSqlite(_connection).Options;
+        using (MediaContext context = new(_options))
+        {
+            context.Database.EnsureCreated();
+        }
+
+        Mock<IDbContextFactory<MediaContext>> factory = new();
+        factory
+            .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new MediaContext(_options));
+        factory.Setup(f => f.CreateDbContext()).Returns(() => new MediaContext(_options));
+        _contextFactory = factory.Object;
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; a locked handle on Windows must not fail the test run.
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    private IDerivedAudioStore Store()
+    {
+        LocalStorageDriver driver = new();
+        StoragePathGuard guard = new([_root], driver);
+        IStorage storage = new LocalStorage(driver, guard);
+        return new DerivedAudioStore(
+            storage,
+            _contextFactory,
+            NullLogger<DerivedAudioStore>.Instance
+        );
+    }
+
+    [Fact]
+    public async Task Put_StoresUnderItsSha256_AndRegistersTheRow()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("stem bytes");
+        string expectedKey = Convert.ToHexStringLower(SHA256.HashData(content));
+
+        DerivedAudioEntry entry = await Store().PutAsync(new MemoryStream(content), "audio/opus");
+
+        entry.Key.Should().Be(expectedKey);
+        entry.Bytes.Should().Be(content.Length);
+        (await Store().ExistsAsync(entry.Key)).Should().BeTrue();
+        Store().RelativePath(entry.Key).Should().Be($"{expectedKey[..2]}/{expectedKey}");
+        await using MediaContext read = new(_options);
+        (await read.DerivedAudio.AsNoTracking().SingleAsync()).Bytes.Should().Be(content.Length);
+    }
+
+    [Fact]
+    public async Task PutTwice_IsOneFileAndOneRow()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("the same bytes, put twice");
+        IDerivedAudioStore store = Store();
+
+        DerivedAudioEntry first = await store.PutAsync(new MemoryStream(content), "audio/opus");
+        DerivedAudioEntry second = await store.PutAsync(new MemoryStream(content), "audio/opus");
+
+        second.Key.Should().Be(first.Key);
+        await using MediaContext read = new(_options);
+        (await read.DerivedAudio.AsNoTracking().CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task OpenRead_ReturnsTheBytes_AndBumpsLastUsedAt()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("read this back");
+        IDerivedAudioStore store = Store();
+        DerivedAudioEntry entry = await store.PutAsync(new MemoryStream(content), "audio/opus");
+
+        DateTime before;
+        await using (MediaContext read = new(_options))
+        {
+            before = (await read.DerivedAudio.AsNoTracking().SingleAsync()).LastUsedAt;
+        }
+
+        await Task.Delay(20);
+
+        await using Stream? stream = await store.OpenReadAsync(entry.Key);
+        stream.Should().NotBeNull();
+        using MemoryStream buffer = new();
+        await stream!.CopyToAsync(buffer);
+        buffer.ToArray().Should().Equal(content);
+
+        await using MediaContext read2 = new(_options);
+        DateTime after = (await read2.DerivedAudio.AsNoTracking().SingleAsync()).LastUsedAt;
+        after.Should().BeAfter(before);
+    }
+
+    [Fact]
+    public async Task OpenRead_OfAnUnknownKey_IsNull()
+    {
+        Stream? stream = await Store().OpenReadAsync(new string('a', 64));
+
+        stream.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Delete_RemovesFileAndRow()
+    {
+        byte[] content = Encoding.UTF8.GetBytes("delete this");
+        IDerivedAudioStore store = Store();
+        DerivedAudioEntry entry = await store.PutAsync(new MemoryStream(content), "audio/opus");
+
+        await store.DeleteAsync(entry.Key);
+
+        (await store.ExistsAsync(entry.Key)).Should().BeFalse();
+        await using MediaContext read = new(_options);
+        (await read.DerivedAudio.AsNoTracking().AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Evict_RemovesTheChosenFilesAndRows_AndReportsBytesFreed()
+    {
+        // Three puts with LastUsedAt set back by hand (3, 2, 1 days); cap = 2 files' worth.
+        // Expect: the oldest is gone from disk and from the register, freed == its size.
+        IDerivedAudioStore store = Store();
+        DerivedAudioEntry oldest = await store.PutAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes("oldest content")),
+            "audio/opus"
+        );
+        DerivedAudioEntry middle = await store.PutAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes("middle content")),
+            "audio/opus"
+        );
+        DerivedAudioEntry newest = await store.PutAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes("newest content")),
+            "audio/opus"
+        );
+
+        DateTime now = DateTime.UtcNow;
+        await using (MediaContext context = new(_options))
+        {
+            await context
+                .DerivedAudio.Where(row => row.Key == oldest.Key)
+                .ExecuteUpdateAsync(set => set.SetProperty(row => row.LastUsedAt, now.AddDays(-3)));
+            await context
+                .DerivedAudio.Where(row => row.Key == middle.Key)
+                .ExecuteUpdateAsync(set => set.SetProperty(row => row.LastUsedAt, now.AddDays(-2)));
+            await context
+                .DerivedAudio.Where(row => row.Key == newest.Key)
+                .ExecuteUpdateAsync(set => set.SetProperty(row => row.LastUsedAt, now.AddDays(-1)));
+        }
+
+        long capBytes = 2 * oldest.Bytes;
+        long freed = await store.EvictAsync(capBytes, TimeSpan.FromHours(1));
+
+        freed.Should().Be(oldest.Bytes);
+        (await store.ExistsAsync(oldest.Key)).Should().BeFalse();
+        (await store.ExistsAsync(middle.Key)).Should().BeTrue();
+        (await store.ExistsAsync(newest.Key)).Should().BeTrue();
+        await using MediaContext read = new(_options);
+        (await read.DerivedAudio.AsNoTracking().CountAsync()).Should().Be(2);
+    }
+}

--- a/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
@@ -203,4 +203,54 @@ public sealed class DerivedAudioStoreTests : IDisposable
         await using MediaContext read = new(_options);
         (await read.DerivedAudio.AsNoTracking().CountAsync()).Should().Be(2);
     }
+
+    [Fact]
+    public async Task PutConcurrently_TheSameContentTwice_IsOneFileAndOneRow()
+    {
+        // The store is a process-wide singleton, so two jobs racing to produce
+        // the same stem/segment share one store instance in practice — both
+        // calls below go through the same store for that reason.
+        byte[] content = Encoding.UTF8.GetBytes("racing content, same bytes twice");
+        string expectedKey = Convert.ToHexStringLower(SHA256.HashData(content));
+        IDerivedAudioStore store = Store();
+
+        Task<DerivedAudioEntry> first = store.PutAsync(new MemoryStream(content), "audio/opus");
+        Task<DerivedAudioEntry> second = store.PutAsync(new MemoryStream(content), "audio/opus");
+        DerivedAudioEntry[] entries = await Task.WhenAll(first, second);
+
+        entries[0].Key.Should().Be(expectedKey);
+        entries[1].Key.Should().Be(expectedKey);
+        await using MediaContext read = new(_options);
+        (await read.DerivedAudio.AsNoTracking().CountAsync()).Should().Be(1);
+        (await store.ExistsAsync(expectedKey)).Should().BeTrue();
+
+        // Neither racer left an orphaned temp file behind.
+        string tempDir = Path.Combine(_root, "tmp");
+        if (Directory.Exists(tempDir))
+        {
+            Directory.GetFiles(tempDir).Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task Evict_SweepsStaleTempFiles()
+    {
+        IDerivedAudioStore store = Store();
+        // A crash between the temp write and the move-into-place is the only
+        // thing that should ever leave a file under tmp/ — simulate it by
+        // planting one directly, since PutAsync always cleans up after itself.
+        string tempDir = Path.Combine(_root, "tmp");
+        Directory.CreateDirectory(tempDir);
+        string stalePath = Path.Combine(tempDir, "stale-orphan");
+        string freshPath = Path.Combine(tempDir, "fresh-orphan");
+        await File.WriteAllBytesAsync(stalePath, Encoding.UTF8.GetBytes("orphaned by a crash"));
+        await File.WriteAllBytesAsync(freshPath, Encoding.UTF8.GetBytes("still being written"));
+        File.SetLastWriteTimeUtc(stalePath, DateTime.UtcNow.AddDays(-2));
+        File.SetLastWriteTimeUtc(freshPath, DateTime.UtcNow);
+
+        await store.EvictAsync(capBytes: long.MaxValue, grace: TimeSpan.FromHours(1));
+
+        File.Exists(stalePath).Should().BeFalse();
+        File.Exists(freshPath).Should().BeTrue();
+    }
 }

--- a/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
@@ -17,6 +17,9 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NoMercy.Database;
+using NoMercy.Database.Models.Libraries;
+using NoMercy.Database.Models.Music;
+using NoMercy.Database.Models.Storage;
 using NoMercy.MediaProcessing.DerivedAudio;
 using NoMercy.Storage;
 using NoMercy.Storage.Drivers.Local;
@@ -68,6 +71,34 @@ public sealed class DerivedAudioStoreTests : IDisposable
             // Best-effort cleanup; a locked handle on Windows must not fail the test run.
         }
         GC.SuppressFinalize(this);
+    }
+
+    // Track.FolderId is a required FK to Folder, itself a required FK to
+    // Driver, and this test class runs with foreign keys ON, so the whole
+    // chain has to be inserted with the track. Mirrors
+    // AnalysisRecordModelTests.TrackRow.
+    private static Track TrackRow(Guid id)
+    {
+        Ulid folderId = Ulid.NewUlid();
+        return new Track
+        {
+            Id = id,
+            Name = "A Track",
+            Duration = "03:45",
+            FolderId = folderId,
+            LibraryFolder = new Folder
+            {
+                Id = folderId,
+                Path = "/music",
+                DriverId = Driver.SystemLocalDriverId,
+                Driver = new Driver
+                {
+                    Id = Driver.SystemLocalDriverId,
+                    Name = "local",
+                    Type = "local",
+                },
+            },
+        };
     }
 
     private IDerivedAudioStore Store()
@@ -179,6 +210,32 @@ public sealed class DerivedAudioStoreTests : IDisposable
             "audio/opus"
         );
 
+        // A stem row pointing at the oldest key: eviction deletes the register
+        // row, and the database's own cascade has to take the stem with it -
+        // a stem row surviving its content is a plan that renders silence.
+        // Foreign keys stay ON for this test (Microsoft.Data.Sqlite enables
+        // them per connection); turning them off would prove nothing.
+        Guid trackId = Guid.NewGuid();
+        await using (MediaContext context = new(_options))
+        {
+            context.Tracks.Add(TrackRow(trackId));
+            context.TrackStems.Add(
+                new TrackStem
+                {
+                    Id = Ulid.NewUlid(),
+                    TrackId = trackId,
+                    Kind = "vocals",
+                    Coverage = StemCoverage.Full,
+                    Format = "opus",
+                    SampleRate = 48000,
+                    StorageKey = oldest.Key,
+                    ProducerVersion = "spleeter-2stems-f16@v1",
+                    CreatedAt = DateTime.UtcNow,
+                }
+            );
+            await context.SaveChangesAsync();
+        }
+
         DateTime now = DateTime.UtcNow;
         await using (MediaContext context = new(_options))
         {
@@ -193,6 +250,11 @@ public sealed class DerivedAudioStoreTests : IDisposable
                 .ExecuteUpdateAsync(set => set.SetProperty(row => row.LastUsedAt, now.AddDays(-1)));
         }
 
+        await using (MediaContext seeded = new(_options))
+        {
+            (await seeded.TrackStems.AsNoTracking().CountAsync()).Should().Be(1);
+        }
+
         long capBytes = 2 * oldest.Bytes;
         long freed = await store.EvictAsync(capBytes, TimeSpan.FromHours(1));
 
@@ -202,6 +264,43 @@ public sealed class DerivedAudioStoreTests : IDisposable
         (await store.ExistsAsync(newest.Key)).Should().BeTrue();
         await using MediaContext read = new(_options);
         (await read.DerivedAudio.AsNoTracking().CountAsync()).Should().Be(2);
+        (await read.TrackStems.AsNoTracking().AnyAsync(stem => stem.StorageKey == oldest.Key))
+            .Should()
+            .BeFalse();
+    }
+
+    /// <summary>
+    /// The mirror of the tmp/ sweep, one step further along the put: a crash
+    /// between the move into place and the register insert leaves a content
+    /// file no key addresses and no policy counts. Only this sweep frees it,
+    /// and only after the grace window, so it cannot race a put that is
+    /// between its own move and insert right now.
+    /// </summary>
+    [Fact]
+    public async Task Evict_RemovesAContentFileThatHasNoRegisterRow()
+    {
+        IDerivedAudioStore store = Store();
+        DerivedAudioEntry kept = await store.PutAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes("registered content")),
+            "audio/opus"
+        );
+
+        string staleKey = new('c', 64);
+        string freshKey = new('d', 64);
+        Directory.CreateDirectory(Path.Combine(_root, staleKey[..2]));
+        Directory.CreateDirectory(Path.Combine(_root, freshKey[..2]));
+        string stalePath = Path.Combine(_root, staleKey[..2], staleKey);
+        string freshPath = Path.Combine(_root, freshKey[..2], freshKey);
+        await File.WriteAllBytesAsync(stalePath, Encoding.UTF8.GetBytes("orphaned by a crash"));
+        await File.WriteAllBytesAsync(freshPath, Encoding.UTF8.GetBytes("still being registered"));
+        File.SetLastWriteTimeUtc(stalePath, DateTime.UtcNow.AddDays(-2));
+        File.SetLastWriteTimeUtc(freshPath, DateTime.UtcNow);
+
+        await store.EvictAsync(capBytes: long.MaxValue, grace: TimeSpan.FromHours(1));
+
+        File.Exists(stalePath).Should().BeFalse();
+        File.Exists(freshPath).Should().BeTrue();
+        (await store.ExistsAsync(kept.Key)).Should().BeTrue();
     }
 
     [Fact]
@@ -230,6 +329,86 @@ public sealed class DerivedAudioStoreTests : IDisposable
         {
             Directory.GetFiles(tempDir).Should().BeEmpty();
         }
+    }
+
+    /// <summary>
+    /// A key a plugin invented rather than one <see cref="IDerivedAudioStore.PutAsync" />
+    /// minted: the store answers "not found" for it and never builds a path
+    /// out of it, so nothing under the derived root is read, touched or
+    /// removed. <see cref="IDerivedAudioStore.RelativePath" /> is the one
+    /// member that throws instead, because it has no "not found" to return.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("a")]
+    [InlineData("../../etc")]
+    [InlineData("ab/../../etc/passwd")]
+    public async Task AnInvalidKey_IsNotFound_AndNeverTouchesTheDisk(string key)
+    {
+        IDerivedAudioStore store = Store();
+        DerivedAudioEntry planted = await store.PutAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes("real content")),
+            "audio/opus"
+        );
+
+        (await store.ExistsAsync(key)).Should().BeFalse();
+        (await store.OpenReadAsync(key)).Should().BeNull();
+
+        Func<Task> touch = () => store.TouchAsync(key);
+        await touch.Should().NotThrowAsync();
+        Func<Task> delete = () => store.DeleteAsync(key);
+        await delete.Should().NotThrowAsync();
+
+        // The one real file and its row are still exactly where they were.
+        (await store.ExistsAsync(planted.Key))
+            .Should()
+            .BeTrue();
+        await using MediaContext read = new(_options);
+        (await read.DerivedAudio.AsNoTracking().CountAsync()).Should().Be(1);
+
+        Action relativePath = () => store.RelativePath(key);
+        relativePath.Should().Throw<ArgumentException>();
+    }
+
+    /// <summary>
+    /// Uppercase hex of the right length is still not a key this store minted:
+    /// it writes lowercase, so an uppercase key resolves to a different file on
+    /// a case-sensitive filesystem and the same one on Windows.
+    /// </summary>
+    [Fact]
+    public async Task AnUppercaseKey_IsNotFound()
+    {
+        IDerivedAudioStore store = Store();
+        DerivedAudioEntry entry = await store.PutAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes("cased content")),
+            "audio/opus"
+        );
+
+        (await store.ExistsAsync(entry.Key.ToUpperInvariant())).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The register row and the file are two halves of one entry. A file
+    /// without its row is the half-written state a crash leaves behind, and
+    /// answering "yes, that key is here" for it hands a caller a key that
+    /// nothing will ever evict and that a foreign key will reject.
+    /// </summary>
+    [Fact]
+    public async Task Exists_IsFalseForAFileWithoutARegisterRow()
+    {
+        IDerivedAudioStore store = Store();
+        DerivedAudioEntry entry = await store.PutAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes("orphan content")),
+            "audio/opus"
+        );
+
+        await using (MediaContext context = new(_options))
+        {
+            await context.DerivedAudio.Where(row => row.Key == entry.Key).ExecuteDeleteAsync();
+        }
+
+        File.Exists(Path.Combine(_root, entry.Key[..2], entry.Key)).Should().BeTrue();
+        (await store.ExistsAsync(entry.Key)).Should().BeFalse();
     }
 
     [Fact]

--- a/tests/NoMercy.Tests.Plugins/PluginAbiTests.cs
+++ b/tests/NoMercy.Tests.Plugins/PluginAbiTests.cs
@@ -21,7 +21,8 @@ public class PluginAbiTests
     [InlineData(["", true])]
     [InlineData(["10.0", true])]
     [InlineData(["10.1", true])]
-    [InlineData(["10.2", false])]
+    [InlineData(["10.2", true])]
+    [InlineData(["10.3", false])]
     [InlineData(["9.0", false])]
     [InlineData(["9.5", false])]
     [InlineData(["11.0", false])]
@@ -32,9 +33,22 @@ public class PluginAbiTests
     }
 
     [Fact]
-    public void Current_IsTenOne()
+    public void Current_IsTenTwo()
     {
-        Assert.Equal(new Version(10, 1), PluginAbi.Current);
+        Assert.Equal(new Version(10, 2), PluginAbi.Current);
+    }
+
+    /// <summary>
+    /// The three new elevated contracts arrive on this ABI bump; a plugin that
+    /// declares any of their hooks must be able to say so, and the host must be
+    /// able to recognise the declaration as one that always needs owner consent.
+    /// </summary>
+    [Fact]
+    public void Elevated_ContainsTheNewAnalysisHooks()
+    {
+        Assert.Contains(PluginHookCapability.AudioTools, PluginHookCapability.Elevated);
+        Assert.Contains(PluginHookCapability.DerivedAudio, PluginHookCapability.Elevated);
+        Assert.Contains(PluginHookCapability.MusicAnalysisWrite, PluginHookCapability.Elevated);
     }
 
     /// <summary>

--- a/tests/NoMercy.Tests.Plugins/PluginCapabilityGuardTests.cs
+++ b/tests/NoMercy.Tests.Plugins/PluginCapabilityGuardTests.cs
@@ -33,4 +33,34 @@ public class PluginCapabilityGuardTests
         Assert.True(PluginCapabilityGuard.DeclaresHook(caps, PluginHookCapability.Auth));
         Assert.False(PluginCapabilityGuard.DeclaresHook(caps, PluginHookCapability.MediaSource));
     }
+
+    /// <summary>
+    /// The three analysis hooks are elevated, not baseline - a plugin that
+    /// never says a word about them must not receive
+    /// <see cref="IPluginContext.AudioTools" />, <see cref="IPluginContext.DerivedAudio" />
+    /// or <see cref="IPluginContext.MusicAnalysisWriter" /> for free.
+    /// </summary>
+    [Fact]
+    public void NullCaps_DoNotDeclareTheAnalysisHooks()
+    {
+        Assert.False(PluginCapabilityGuard.DeclaresHook(null, PluginHookCapability.AudioTools));
+        Assert.False(PluginCapabilityGuard.DeclaresHook(null, PluginHookCapability.DerivedAudio));
+        Assert.False(
+            PluginCapabilityGuard.DeclaresHook(null, PluginHookCapability.MusicAnalysisWrite)
+        );
+    }
+
+    [Fact]
+    public void ExplicitCaps_DeclareTheAnalysisHooks()
+    {
+        PluginCapabilities caps = new()
+        {
+            Hooks = ["audioTools", "derivedAudio", "musicAnalysisWrite"],
+        };
+        Assert.True(PluginCapabilityGuard.DeclaresHook(caps, PluginHookCapability.AudioTools));
+        Assert.True(PluginCapabilityGuard.DeclaresHook(caps, PluginHookCapability.DerivedAudio));
+        Assert.True(
+            PluginCapabilityGuard.DeclaresHook(caps, PluginHookCapability.MusicAnalysisWrite)
+        );
+    }
 }

--- a/tests/NoMercy.Tests.Plugins/PluginContextFactoryTests.cs
+++ b/tests/NoMercy.Tests.Plugins/PluginContextFactoryTests.cs
@@ -1,0 +1,131 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NoMercy.Events;
+using NoMercy.Plugins;
+using NoMercy.Plugins.Abstractions;
+using NoMercy.Plugins.Capabilities;
+using NoMercy.Plugins.Hub;
+using NoMercy.Storage;
+using Xunit;
+
+namespace NoMercy.Tests.Plugins;
+
+/// <summary>
+/// The three analysis facades - <see cref="IPluginContext.AudioTools" />,
+/// <see cref="IPluginContext.DerivedAudio" /> and
+/// <see cref="IPluginContext.MusicAnalysisWriter" /> - each gated on its own
+/// hook, the same rule <see cref="PluginCapabilityGuardTests" /> exercises at
+/// the guard level: declaring a capability is an intention, not a grant, and
+/// the factory must hand back null rather than a facade for a hook a plugin
+/// never declared.
+/// </summary>
+public class PluginContextFactoryTests
+{
+    private static readonly Ulid PluginId = Ulid.NewUlid();
+
+    private readonly Mock<IEventBus> _eventBus = new();
+    private readonly Mock<IServiceProvider> _services = new();
+    private readonly Mock<IStorage> _storage = new();
+    private readonly Mock<IPluginGrantStore> _grantStore = new();
+    private readonly Mock<IDataProtectionProvider> _protectionProvider = new();
+    private readonly Mock<IPluginLibraryQuery> _libraryQuery = new();
+    private readonly Mock<IPluginLibraryWriterFactory> _libraryWriterFactory = new();
+    private readonly Mock<IPluginConfiguration> _platformConfiguration = new();
+    private readonly Mock<IPluginHubContextFactory> _hubContextFactory = new();
+    private readonly Mock<IPluginAudioToolsFactory> _audioToolsFactory = new();
+    private readonly Mock<IPluginDerivedAudio> _derivedAudio = new();
+    private readonly Mock<IPluginMusicAnalysisWriterFactory> _analysisWriterFactory = new();
+
+    public PluginContextFactoryTests()
+    {
+        _protectionProvider
+            .Setup(p => p.CreateProtector(It.IsAny<string>()))
+            .Returns(Mock.Of<IDataProtector>());
+        _hubContextFactory
+            .Setup(f => f.For(It.IsAny<Ulid>()))
+            .Returns(Mock.Of<IPluginHubContext>());
+    }
+
+    private PluginContextFactory BuildFactory() =>
+        new(
+            _eventBus.Object,
+            _services.Object,
+            _storage.Object,
+            _grantStore.Object,
+            _protectionProvider.Object,
+            _libraryQuery.Object,
+            _libraryWriterFactory.Object,
+            _platformConfiguration.Object,
+            _hubContextFactory.Object,
+            audioToolsFactory: _audioToolsFactory.Object,
+            derivedAudio: _derivedAudio.Object,
+            analysisWriterFactory: _analysisWriterFactory.Object
+        );
+
+    private IPluginContext Create(PluginCapabilities capabilities) =>
+        BuildFactory().Create(PluginId, "data", NullLogger.Instance, capabilities);
+
+    [Fact]
+    public void Create_AllThreeHooksDeclared_AllThreeNonNull_FactoriesCalledWithPluginId()
+    {
+        IPluginAudioTools audioTools = Mock.Of<IPluginAudioTools>();
+        IPluginMusicAnalysisWriter analysisWriter = Mock.Of<IPluginMusicAnalysisWriter>();
+        _audioToolsFactory.Setup(f => f.CreateFor(PluginId)).Returns(audioTools);
+        _analysisWriterFactory.Setup(f => f.CreateFor(PluginId)).Returns(analysisWriter);
+
+        PluginCapabilities capabilities = new()
+        {
+            Hooks = ["audioTools", "derivedAudio", "musicAnalysisWrite"],
+        };
+
+        IPluginContext context = Create(capabilities);
+
+        Assert.Same(audioTools, context.AudioTools);
+        Assert.Same(_derivedAudio.Object, context.DerivedAudio);
+        Assert.Same(analysisWriter, context.MusicAnalysisWriter);
+        _audioToolsFactory.Verify(f => f.CreateFor(PluginId), Times.Once);
+        _analysisWriterFactory.Verify(f => f.CreateFor(PluginId), Times.Once);
+    }
+
+    [Fact]
+    public void Create_NoHooksDeclared_AllThreeNull_FactoriesNeverCalled()
+    {
+        PluginCapabilities capabilities = new() { Hooks = [] };
+
+        IPluginContext context = Create(capabilities);
+
+        Assert.Null(context.AudioTools);
+        Assert.Null(context.DerivedAudio);
+        Assert.Null(context.MusicAnalysisWriter);
+        _audioToolsFactory.Verify(f => f.CreateFor(It.IsAny<Ulid>()), Times.Never);
+        _analysisWriterFactory.Verify(f => f.CreateFor(It.IsAny<Ulid>()), Times.Never);
+    }
+
+    [Fact]
+    public void Create_OnlyAudioToolsHookDeclared_OnlyAudioToolsNonNull()
+    {
+        IPluginAudioTools audioTools = Mock.Of<IPluginAudioTools>();
+        _audioToolsFactory.Setup(f => f.CreateFor(PluginId)).Returns(audioTools);
+
+        PluginCapabilities capabilities = new() { Hooks = ["audioTools"] };
+
+        IPluginContext context = Create(capabilities);
+
+        Assert.Same(audioTools, context.AudioTools);
+        Assert.Null(context.DerivedAudio);
+        Assert.Null(context.MusicAnalysisWriter);
+        _analysisWriterFactory.Verify(f => f.CreateFor(It.IsAny<Ulid>()), Times.Never);
+    }
+}

--- a/tests/NoMercy.Tests.Plugins/PluginDiIntegrationTests.cs
+++ b/tests/NoMercy.Tests.Plugins/PluginDiIntegrationTests.cs
@@ -12,6 +12,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using NoMercy.Events;
 using NoMercy.Plugins;
 using NoMercy.Plugins.Abstractions;
@@ -209,6 +210,100 @@ public class PluginDiIntegrationTests : IDisposable
         ITestService service = provider.GetRequiredService<ITestService>();
         service.Should().NotBeNull();
         service.Should().BeOfType<TestService>();
+    }
+
+    /// <summary>
+    /// <see cref="PluginServiceCollectionExtensions.AddPluginSystem" />'s
+    /// registration of <see cref="IPluginContextFactory" /> must fetch every
+    /// optional facade from the container with <c>GetService</c>, not leave it
+    /// at its constructor default - otherwise a plugin never sees a facade the
+    /// host registered, encoder and jobs included, not just the three analysis
+    /// ones.
+    /// </summary>
+    [Fact]
+    public void DiBuiltFactory_HandsDeclaredFacadesToThePlugin()
+    {
+        Mock<IPluginAudioToolsFactory> audioToolsFactory = new();
+        Mock<IPluginMusicAnalysisWriterFactory> analysisWriterFactory = new();
+        IPluginAudioTools audioTools = Mock.Of<IPluginAudioTools>();
+        IPluginMusicAnalysisWriter analysisWriter = Mock.Of<IPluginMusicAnalysisWriter>();
+        audioToolsFactory.Setup(f => f.CreateFor(It.IsAny<Ulid>())).Returns(audioTools);
+        analysisWriterFactory.Setup(f => f.CreateFor(It.IsAny<Ulid>())).Returns(analysisWriter);
+
+        ServiceCollection services = new();
+        services.AddSingleton<IEventBus, InMemoryEventBus>();
+        services.AddLogging();
+        services.AddSingleton(TestStorageHelper.CreateBackend());
+        services.AddSingleton(Mock.Of<IPluginEncoder>());
+        services.AddSingleton(Mock.Of<IPluginJobs>());
+        services.AddSingleton(Mock.Of<IPluginStorage>());
+        services.AddSingleton(Mock.Of<IPluginMusicQuery>());
+        services.AddSingleton(audioToolsFactory.Object);
+        services.AddSingleton(Mock.Of<IPluginDerivedAudio>());
+        services.AddSingleton(analysisWriterFactory.Object);
+
+        services.AddPluginSystem(_tempPluginsDir);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        IPluginContextFactory factory = provider.GetRequiredService<IPluginContextFactory>();
+
+        PluginCapabilities capabilities = new()
+        {
+            Hooks = ["encoder", "storage", "audioTools", "derivedAudio", "musicAnalysisWrite"],
+        };
+
+        IPluginContext context = factory.Create(
+            Ulid.NewUlid(),
+            _tempPluginsDir,
+            NullLogger.Instance,
+            capabilities
+        );
+
+        context.Music.Should().NotBeNull();
+        context.Encoder.Should().NotBeNull();
+        context.Storage.Should().NotBeNull();
+        context.AudioTools.Should().NotBeNull();
+        context.DerivedAudio.Should().NotBeNull();
+        context.MusicAnalysisWriter.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// A host that never calls <c>AddPluginLibraryAccess</c> or wires the
+    /// encoder/storage facades still gets a working platform - the resolve
+    /// must not throw, and every optional facade gates to null exactly as it
+    /// would when the plugin never declared the hook.
+    /// </summary>
+    [Fact]
+    public void DiBuiltFactory_WithoutFacadesStillCreatesAContext()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IEventBus, InMemoryEventBus>();
+        services.AddLogging();
+        services.AddSingleton(TestStorageHelper.CreateBackend());
+
+        services.AddPluginSystem(_tempPluginsDir);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        IPluginContextFactory factory = provider.GetRequiredService<IPluginContextFactory>();
+
+        PluginCapabilities capabilities = new()
+        {
+            Hooks = ["encoder", "storage", "audioTools", "derivedAudio", "musicAnalysisWrite"],
+        };
+
+        IPluginContext context = factory.Create(
+            Ulid.NewUlid(),
+            _tempPluginsDir,
+            NullLogger.Instance,
+            capabilities
+        );
+
+        context.Music.Should().BeNull();
+        context.Encoder.Should().BeNull();
+        context.Storage.Should().BeNull();
+        context.AudioTools.Should().BeNull();
+        context.DerivedAudio.Should().BeNull();
+        context.MusicAnalysisWriter.Should().BeNull();
     }
 
     public interface ITestService

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginAudioToolsFactoryTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginAudioToolsFactoryTests.cs
@@ -1,0 +1,93 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NoMercy.Data.Plugins;
+using NoMercy.Database;
+using NoMercy.Encoder.Composition;
+using NoMercy.Encoder.Infrastructure;
+using NoMercy.Encoder.Startup;
+using NoMercy.MediaProcessing.DerivedAudio;
+using NoMercy.Plugins;
+using NoMercy.Plugins.Abstractions;
+using NoMercy.Storage;
+
+namespace NoMercy.Tests.Repositories.Plugins;
+
+/// <summary>
+/// The factory takes its derived-audio storage through
+/// <c>[FromKeyedServices("derived-audio")]</c>, which no test that news it up
+/// by hand can get wrong - and no test that news it up by hand can prove
+/// right either. A keyed parameter that the container cannot satisfy throws
+/// only at the moment a plugin asks for its audio tools, which on a real
+/// server is the middle of an unattended sweep. So this resolves the real
+/// type out of a real container.
+/// </summary>
+public class PluginAudioToolsFactoryTests
+{
+    private static ServiceProvider BuildProvider()
+    {
+        ServiceCollection services = new();
+
+        services.AddSingleton(new EncoderOptions { FfmpegPathOverride = "ffmpeg" });
+        services.AddSingleton(new Mock<IProcessRunner>().Object);
+        services.AddSingleton(new Mock<IStorage>().Object);
+        services.AddSingleton(new Mock<IStorageDriver>().Object);
+        services.AddKeyedSingleton("derived-audio", new Mock<IStorage>().Object);
+        services.AddSingleton(new Mock<IDerivedAudioStore>().Object);
+        services.AddSingleton(new Mock<IFfmpegCapabilityProbe>().Object);
+        services.AddSingleton(new Mock<IPluginMusicAnalysisWriterFactory>().Object);
+        services.AddSingleton(new Mock<IDbContextFactory<MediaContext>>().Object);
+        services.AddSingleton<ILogger<PluginAudioTools>>(NullLogger<PluginAudioTools>.Instance);
+
+        services.AddSingleton<IPluginAudioToolsFactory, PluginAudioToolsFactory>();
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void TheRealFactory_ResolvesAndBuildsToolsForAPlugin()
+    {
+        using ServiceProvider provider = BuildProvider();
+
+        IPluginAudioToolsFactory factory = provider.GetRequiredService<IPluginAudioToolsFactory>();
+
+        IPluginAudioTools tools = factory.CreateFor(Ulid.NewUlid());
+
+        tools.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// The one-ffmpeg-at-a-time guard is a field on the instance, so a second
+    /// call for the same plugin has to hand back the same instance - a guard a
+    /// caller can get a fresh copy of guards nothing.
+    /// </summary>
+    [Fact]
+    public void TheRealFactory_CachesOneInstancePerPlugin()
+    {
+        using ServiceProvider provider = BuildProvider();
+
+        IPluginAudioToolsFactory factory = provider.GetRequiredService<IPluginAudioToolsFactory>();
+        Ulid pluginId = Ulid.NewUlid();
+
+        IPluginAudioTools first = factory.CreateFor(pluginId);
+        IPluginAudioTools second = factory.CreateFor(pluginId);
+        IPluginAudioTools other = factory.CreateFor(Ulid.NewUlid());
+
+        second.Should().BeSameAs(first);
+        other.Should().NotBeSameAs(first);
+    }
+}

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginAudioToolsTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginAudioToolsTests.cs
@@ -86,6 +86,11 @@ public class PluginAudioToolsTests : IDisposable
     private int _runCount;
     private int _putCount;
 
+    // In PutAsync order: the keys the mocked store minted and the content types
+    // it was asked to store them under.
+    private readonly List<string> _putKeys = [];
+    private readonly List<string> _putContentTypes = [];
+
     // Swapped out by the concurrency test for a task that only completes once
     // the second call has already been refused.
     private Task<ProcessResult> _runResult = Task.FromResult(
@@ -97,6 +102,12 @@ public class PluginAudioToolsTests : IDisposable
         _connection = new("Data Source=:memory:");
         _connection.Open();
 
+        // The stem rows these tests register point at derived-store keys that
+        // have no DerivedAudio parent row here - the store is a mock, so
+        // nothing ever inserted one. The cascade itself is proven against a
+        // real store in DerivedAudioStoreTests and against the schema in
+        // AnalysisRecordModelTests; what is under test here is the command
+        // ffmpeg is handed and the refusals around it.
         using (SqliteCommand foreignKeysOff = _connection.CreateCommand())
         {
             foreignKeysOff.CommandText = "PRAGMA foreign_keys = OFF;";
@@ -219,7 +230,12 @@ public class PluginAudioToolsTests : IDisposable
             )
             .ReturnsAsync(
                 (Stream _, string contentType, CancellationToken _) =>
-                    new DerivedAudioEntry($"ab{++_putCount:D62}", contentType, 4096 + _putCount)
+                {
+                    string key = $"ab{++_putCount:D62}";
+                    _putKeys.Add(key);
+                    _putContentTypes.Add(contentType);
+                    return new DerivedAudioEntry(key, contentType, 4096 + _putCount);
+                }
             );
 
         _probe.Setup(probe => probe.GetCachedReport()).Returns(Report(stemsplitModelPresent: true));
@@ -292,14 +308,14 @@ public class PluginAudioToolsTests : IDisposable
             Issues: []
         );
 
-    private PluginAudioTools CreateTools()
+    private PluginAudioTools CreateTools(TimeSpan? runTimeout = null)
     {
         Mock<IDbContextFactory<MediaContext>> contextFactory = new();
         contextFactory
             .Setup(factory => factory.CreateDbContextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => new(_options));
 
-        return new PluginAudioTools(
+        PluginAudioTools tools = new(
             _pluginId,
             _encoderOptions,
             _runner.Object,
@@ -310,7 +326,31 @@ public class PluginAudioToolsTests : IDisposable
             _writerFactory.Object,
             contextFactory.Object,
             _probe.Object
-        );
+        )
+        {
+            RunTimeout = runTimeout ?? TimeSpan.FromMinutes(10),
+        };
+
+        return tools;
+    }
+
+    /// <summary>
+    /// Fails rather than hanging the run when the thing it waits for never
+    /// happens: a spin on a flag a broken change never sets is a test suite
+    /// that stops instead of a test that reports.
+    /// </summary>
+    private static async Task WaitForAsync(Func<bool> condition, string what)
+    {
+        DateTime deadline = DateTime.UtcNow.AddSeconds(5);
+        while (!condition())
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                Assert.Fail($"timed out after 5 seconds waiting for {what}");
+            }
+
+            await Task.Yield();
+        }
     }
 
     private static string ModelFile => AppFiles.StemsplitModel + ".gguf";
@@ -513,10 +553,7 @@ public class PluginAudioToolsTests : IDisposable
 
         // The first run has to have reached the runner before the second call
         // means anything; the mock records every entry, so wait for that.
-        while (_runCount == 0)
-        {
-            await Task.Yield();
-        }
+        await WaitForAsync(() => _runCount > 0, "the first ffmpeg run to reach the runner");
 
         PluginAudioRunResult second = await tools.RunFilterGraphAsync(
             PluginAudioInput.Track(_trackId.ToString()),
@@ -629,6 +666,76 @@ public class PluginAudioToolsTests : IDisposable
 
     // --- SplitStemsAsync --------------------------------------------------
 
+    /// <summary>
+    /// ffmpeg on a stalled mount never returns on its own, so the host puts its
+    /// own clock on every run. The result is -2 rather than a refusal: the run
+    /// did start, the plugin's graph was accepted, and its callbacks saw
+    /// whatever ffmpeg printed before the clock ran out.
+    /// </summary>
+    [Fact]
+    public async Task RunFilterGraph_ReturnsMinusTwo_WhenTheRunTimesOut()
+    {
+        _runner
+            .Setup(runner =>
+                runner.RunAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string[]>(),
+                    It.IsAny<Action<string>?>(),
+                    It.IsAny<Action<string>?>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(
+                async (
+                    string _,
+                    string[] _,
+                    Action<string>? _,
+                    Action<string>? _,
+                    string? _,
+                    CancellationToken ct
+                ) =>
+                {
+                    // The real runner kills the process when its token trips;
+                    // waiting forever on the token is the same observable thing.
+                    await Task.Delay(-1, ct);
+                    return new ProcessResult(0, string.Empty, string.Empty, TimeSpan.Zero);
+                }
+            );
+
+        PluginAudioRunResult result = await CreateTools(TimeSpan.FromMilliseconds(50))
+            .RunFilterGraphAsync(
+                PluginAudioInput.Track(_trackId.ToString()),
+                new PluginFilterGraph("volume=1", Complex: false),
+                null,
+                null
+            );
+
+        result.ExitCode.Should().Be(-2);
+        result.Refusal.Should().BeNull();
+    }
+
+    /// <summary>
+    /// The build token goes into every stem's producer version, so a model or
+    /// binary upgrade can be spotted the way an analyzer upgrade is. A banner
+    /// that is not the one ffmpeg usually prints still has to produce a marker.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Stream mapping:")]
+    [InlineData("ffmpeg version ")]
+    public void FfmpegVersion_IsUnknown_WhenTheBannerCarriesNoToken(string? bannerLine)
+    {
+        PluginAudioArguments.FfmpegVersion(bannerLine).Should().Be("unknown");
+    }
+
+    [Fact]
+    public void FfmpegVersion_ReadsTheTokenOutOfARealBanner()
+    {
+        PluginAudioArguments.FfmpegVersion(VersionLine).Should().Be("9.0-NoMercy-MediaServer");
+    }
+
     [Fact]
     public async Task SplitStems_Four_IsRefused()
     {
@@ -713,6 +820,17 @@ public class PluginAudioToolsTests : IDisposable
                 stem.ProducerVersion == AppFiles.StemsplitModel + "@9.0-NoMercy-MediaServer"
             );
 
+        // The keys the mocked store minted, in the order it minted them: the
+        // vocals stem must carry the first and the accompaniment the second.
+        // Swapping them would still pass every assertion above while pointing
+        // each register row at the other stem's audio.
+        _registeredStems.Select(stem => stem.StorageKey).Should().Equal(_putKeys);
+        result.Stems.Select(stem => stem.StorageKey).Should().Equal(_putKeys);
+
+        // Opus in an Ogg container - the content type the derived store stores
+        // the stem under, and the one a client is later handed it with.
+        _putContentTypes.Should().Equal("audio/ogg", "audio/ogg");
+
         // Both temp files handed to the store are gone again afterwards.
         _deletedDerivedPaths.Should().HaveCount(2);
         _deletedDerivedPaths.Should().OnlyContain(path => path.StartsWith("tmp/"));
@@ -732,6 +850,79 @@ public class PluginAudioToolsTests : IDisposable
         result.Stems.Should().BeEmpty();
         _registeredStems.Should().BeEmpty();
         _deletedDerivedPaths.Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// Exit code 0 is ffmpeg's word, not proof. A graph that separated nothing
+    /// still exits clean, and the scratch files it never wrote would surface
+    /// from inside the store as an I/O error rather than as something a plugin
+    /// can act on.
+    /// </summary>
+    [Fact]
+    public async Task SplitStems_RefusesWhenFfmpegWroteNoOutput()
+    {
+        _derivedStorage
+            .Setup(storage =>
+                storage.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(false);
+
+        PluginStemSplitResult result = await CreateTools()
+            .SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.Full, PluginStemSet.Two);
+
+        result.Refusal.Should().Be("stemsplit produced no output");
+        result.Stems.Should().BeEmpty();
+        _registeredStems.Should().BeEmpty();
+        _store.Verify(
+            store =>
+                store.PutAsync(
+                    It.IsAny<Stream>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// A plugin sweeping a library unattended must not lose the whole sweep to
+    /// one unlucky track: a dependency that throws where nothing planned for it
+    /// becomes a refusal naming the exception's type.
+    /// </summary>
+    [Fact]
+    public async Task AThrowingDependency_BecomesARefusal()
+    {
+        _runner
+            .Setup(runner =>
+                runner.RunAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string[]>(),
+                    It.IsAny<Action<string>?>(),
+                    It.IsAny<Action<string>?>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ThrowsAsync(new IOException("the library volume went away"));
+
+        PluginAudioTools tools = CreateTools();
+
+        Func<Task<PluginAudioRunResult>> runGraph = () =>
+            tools.RunFilterGraphAsync(
+                PluginAudioInput.Track(_trackId.ToString()),
+                new PluginFilterGraph("volume=1", Complex: false),
+                null,
+                null
+            );
+
+        PluginAudioRunResult graphResult = (await runGraph.Should().NotThrowAsync()).Which;
+        graphResult.Refusal.Should().Be("the server could not complete this call: IOException");
+
+        Func<Task<PluginStemSplitResult>> split = () =>
+            tools.SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.Full, PluginStemSet.Two);
+
+        PluginStemSplitResult splitResult = (await split.Should().NotThrowAsync()).Which;
+        splitResult.Refusal.Should().Be("the server could not complete this call: IOException");
     }
 
     [Fact]

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginAudioToolsTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginAudioToolsTests.cs
@@ -67,6 +67,11 @@ public class PluginAudioToolsTests : IDisposable
 
     private readonly List<PluginTrackStem> _registeredStems = [];
     private readonly List<string> _deletedDerivedPaths = [];
+
+    // In lease order: the scratch file ffmpeg writes the vocals to, then the
+    // one it writes the accompaniment to. The names carry a random Ulid, so
+    // the argument-array assertions read them from here.
+    private readonly List<string> _leasedDerivedPaths = [];
     private readonly List<string> _stdErrLines = [VersionLine];
 
     private string[] _capturedArguments = [];
@@ -158,7 +163,13 @@ public class PluginAudioToolsTests : IDisposable
             .Setup(storage =>
                 storage.AcquireLocalPathAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
             )
-            .ReturnsAsync((string path, CancellationToken _) => new LocalPathLease(path));
+            .ReturnsAsync(
+                (string path, CancellationToken _) =>
+                {
+                    _leasedDerivedPaths.Add(path);
+                    return new LocalPathLease(path);
+                }
+            );
         _derivedStorage
             .Setup(storage =>
                 storage.CreateDirectoryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
@@ -298,13 +309,70 @@ public class PluginAudioToolsTests : IDisposable
 
     private static string ModelFile => AppFiles.StemsplitModel + ".gguf";
 
-    /// <summary>The value that follows <paramref name="flag" /> in the captured argument array.</summary>
+    /// <summary>
+    /// The value that follows the FIRST <paramref name="flag" /> in the
+    /// captured argument array. Only safe for flags that appear once - the
+    /// split command repeats <c>-map</c>, <c>-c:a</c> and the rest per output,
+    /// which is why the split tests assert the whole array instead.
+    /// </summary>
     private string? ArgumentAfter(string flag)
     {
         int index = Array.IndexOf(_capturedArguments, flag);
         return index >= 0 && index + 1 < _capturedArguments.Length
             ? _capturedArguments[index + 1]
             : null;
+    }
+
+    /// <summary>
+    /// The whole stemsplit command, with the two scratch paths the run
+    /// actually leased filled in - their names carry a random Ulid, so they
+    /// cannot be written out literally.
+    /// <para>
+    /// Asserted in full, and deliberately: a window argument in the wrong
+    /// place still satisfies "the array contains -t", which is how a window
+    /// that reached only the first output went unnoticed.
+    /// </para>
+    /// </summary>
+    private string[] ExpectedSplitArguments(params string[] windowArguments)
+    {
+        _leasedDerivedPaths.Should().HaveCount(2);
+
+        string vocalsPath = _leasedDerivedPaths[0];
+        string accompanimentPath = _leasedDerivedPaths[1];
+
+        vocalsPath.Should().MatchRegex(@"^tmp/[0-9A-Z]{26}-vocals\.opus$");
+        accompanimentPath.Should().Be(vocalsPath.Replace("-vocals.opus", "-accompaniment.opus"));
+
+        return
+        [
+            "-nostdin",
+            .. windowArguments,
+            "-i",
+            "/library/folder/track.flac",
+            "-vn",
+            "-sn",
+            "-dn",
+            "-filter_complex",
+            $"[0:a]stemsplit=model={ModelFile}[voc][acc]",
+            "-map",
+            "[voc]",
+            "-c:a",
+            "libopus",
+            "-b:a",
+            "160k",
+            "-ar",
+            "48000",
+            vocalsPath,
+            "-map",
+            "[acc]",
+            "-c:a",
+            "libopus",
+            "-b:a",
+            "160k",
+            "-ar",
+            "48000",
+            accompanimentPath,
+        ];
     }
 
     // --- RunFilterGraphAsync: the command --------------------------------
@@ -541,9 +609,7 @@ public class PluginAudioToolsTests : IDisposable
         await CreateTools()
             .SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.MixIn, PluginStemSet.Two);
 
-        _capturedArguments.Should().Contain("-t");
-        ArgumentAfter("-t").Should().Be("60");
-        _capturedArguments.Should().NotContain("-ss");
+        _capturedArguments.Should().Equal(ExpectedSplitArguments("-t", "60"));
     }
 
     [Fact]
@@ -552,9 +618,7 @@ public class PluginAudioToolsTests : IDisposable
         await CreateTools()
             .SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.MixOut, PluginStemSet.Two);
 
-        _capturedArguments.Should().Contain("-ss");
-        ArgumentAfter("-ss").Should().Be("225");
-        _capturedArguments.Should().NotContain("-t");
+        _capturedArguments.Should().Equal(ExpectedSplitArguments("-ss", "225"));
     }
 
     [Fact]
@@ -563,27 +627,26 @@ public class PluginAudioToolsTests : IDisposable
         await CreateTools()
             .SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.Full, PluginStemSet.Two);
 
-        _capturedArguments.Should().NotContain("-ss");
-        _capturedArguments.Should().NotContain("-t");
-        _capturedArguments
-            .Take(6)
-            .Should()
-            .Equal("-nostdin", "-i", "/library/folder/track.flac", "-vn", "-sn", "-dn");
-        ArgumentAfter("-filter_complex").Should().Be($"[0:a]stemsplit=model={ModelFile}[voc][acc]");
+        _capturedArguments.Should().Equal(ExpectedSplitArguments());
+        _capturedExecutable.Should().Be(FfmpegBinary);
         _capturedWorkingDirectory.Should().Be(AppFiles.FfmpegFolder);
     }
 
     [Fact]
-    public async Task SplitStems_WritesTwoOpusOutputs()
+    public async Task SplitStems_WindowIsAnInputOption_SoBothStemsGetIt()
     {
         await CreateTools()
-            .SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.Full, PluginStemSet.Two);
+            .SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.MixOut, PluginStemSet.Two);
 
-        _capturedArguments.Should().ContainInOrder("-map", "[voc]", "-c:a", "libopus");
-        _capturedArguments.Should().ContainInOrder("-map", "[acc]", "-c:a", "libopus");
-        _capturedArguments.Count(argument => argument == "160k").Should().Be(2);
-        _capturedArguments.Count(argument => argument == "48000").Should().Be(2);
-        _capturedArguments[^1].Should().EndWith("-accompaniment.opus");
+        // The regression this guards: placed after -i, a window binds to the
+        // next file named - the first output. The vocals stem would be the
+        // window and the accompaniment stem the whole track, while both were
+        // registered with the same window milliseconds. Ahead of -i it trims
+        // the decoded stream, so both output pads see the same audio.
+        int inputIndex = Array.IndexOf(_capturedArguments, "-i");
+        inputIndex.Should().BePositive();
+        Array.IndexOf(_capturedArguments, "-ss").Should().BeLessThan(inputIndex);
+        _capturedArguments.Skip(inputIndex).Should().NotContain("-ss").And.NotContain("-t");
     }
 
     [Fact]

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginAudioToolsTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginAudioToolsTests.cs
@@ -1,0 +1,665 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using NoMercy.Data.Plugins;
+using NoMercy.Database;
+using NoMercy.Database.Models.Music;
+using NoMercy.Encoder.Composition;
+using NoMercy.Encoder.Infrastructure;
+using NoMercy.Encoder.Startup;
+using NoMercy.MediaProcessing.DerivedAudio;
+using NoMercy.NmSystem.Information;
+using NoMercy.Plugins.Abstractions;
+using NoMercy.Storage;
+
+namespace NoMercy.Tests.Repositories.Plugins;
+
+/// <summary>
+/// The host side of <see cref="IPluginAudioTools" />: the exact ffmpeg command
+/// each call builds, every refusal it can hand back instead, and that a
+/// finished stem split lands both files in the derived store and both rows in
+/// the stem register. ffmpeg itself is mocked - the runner records what it was
+/// asked to run and replays stderr through the same callback the real process
+/// runner writes to.
+/// </summary>
+public class PluginAudioToolsTests : IDisposable
+{
+    private const string FfmpegBinary = "ffmpeg";
+    private const string VersionLine =
+        "ffmpeg version 9.0-NoMercy-MediaServer Copyright (c) 2000-2026 the FFmpeg developers";
+
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<MediaContext> _options;
+    private readonly Ulid _pluginId = Ulid.NewUlid();
+
+    // Five minutes, so 20 % is 60 s and 75 % is 225 s - both whole seconds, so
+    // the window arguments the tests assert on read without a decimal tail.
+    private readonly Guid _trackId = Guid.NewGuid();
+
+    // In the library, but the scan never recorded a file for it.
+    private readonly Guid _trackWithoutFileId = Guid.NewGuid();
+
+    // Has a file, but the library never recorded a duration.
+    private readonly Guid _trackWithoutDurationId = Guid.NewGuid();
+
+    private readonly Mock<IProcessRunner> _runner = new();
+    private readonly Mock<IStorage> _storage = new();
+    private readonly Mock<IStorageDriver> _driver = new();
+    private readonly Mock<IStorage> _derivedStorage = new();
+    private readonly Mock<IDerivedAudioStore> _store = new();
+    private readonly Mock<IFfmpegCapabilityProbe> _probe = new();
+    private readonly Mock<IPluginMusicAnalysisWriter> _writer = new();
+    private readonly Mock<IPluginMusicAnalysisWriterFactory> _writerFactory = new();
+
+    private readonly EncoderOptions _encoderOptions = new() { FfmpegPathOverride = FfmpegBinary };
+
+    private readonly List<PluginTrackStem> _registeredStems = [];
+    private readonly List<string> _deletedDerivedPaths = [];
+    private readonly List<string> _stdErrLines = [VersionLine];
+
+    private string[] _capturedArguments = [];
+    private string? _capturedWorkingDirectory;
+    private string? _capturedExecutable;
+    private int _runCount;
+    private int _putCount;
+
+    // Swapped out by the concurrency test for a task that only completes once
+    // the second call has already been refused.
+    private Task<ProcessResult> _runResult = Task.FromResult(
+        new ProcessResult(0, string.Empty, string.Empty, TimeSpan.Zero)
+    );
+
+    public PluginAudioToolsTests()
+    {
+        _connection = new("Data Source=:memory:");
+        _connection.Open();
+
+        using (SqliteCommand foreignKeysOff = _connection.CreateCommand())
+        {
+            foreignKeysOff.CommandText = "PRAGMA foreign_keys = OFF;";
+            foreignKeysOff.ExecuteNonQuery();
+        }
+
+        _options = new DbContextOptionsBuilder<MediaContext>().UseSqlite(_connection).Options;
+
+        using MediaContext context = new(_options);
+        context.Database.EnsureCreated();
+
+        context.Tracks.AddRange(
+            new Track
+            {
+                Id = _trackId,
+                Name = "Track A",
+                Duration = "05:00",
+                HostFolder = "/library/folder",
+                Filename = "/track.flac",
+            },
+            new Track
+            {
+                Id = _trackWithoutFileId,
+                Name = "Track B",
+                Duration = "05:00",
+                HostFolder = "",
+                Filename = "",
+            },
+            new Track
+            {
+                Id = _trackWithoutDurationId,
+                Name = "Track C",
+                Duration = "",
+                HostFolder = "/library/folder",
+                Filename = "/other.flac",
+            }
+        );
+
+        context.SaveChanges();
+
+        SetUpMocks();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private void SetUpMocks()
+    {
+        // The ffmpeg binary is on disk unless a test says otherwise.
+        _storage.Setup(storage => storage.Exists(It.IsAny<string>())).Returns(true);
+        _storage
+            .Setup(storage =>
+                storage.AcquireLocalPathAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync((string path, CancellationToken _) => new LocalPathLease(path));
+
+        _driver
+            .Setup(driver => driver.CombinePath(It.IsAny<string>(), It.IsAny<string[]>()))
+            .Returns(
+                (string parent, string[] segments) =>
+                    parent.TrimEnd('/')
+                    + "/"
+                    + string.Join("/", segments.Select(segment => segment.Trim('/')))
+            );
+
+        _derivedStorage
+            .Setup(storage =>
+                storage.AcquireLocalPathAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync((string path, CancellationToken _) => new LocalPathLease(path));
+        _derivedStorage
+            .Setup(storage =>
+                storage.CreateDirectoryAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
+            )
+            .Returns(Task.CompletedTask);
+        _derivedStorage
+            .Setup(storage =>
+                storage.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(() => new MemoryStream([1, 2, 3]));
+        _derivedStorage
+            .Setup(storage =>
+                storage.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(true);
+        _derivedStorage
+            .Setup(storage =>
+                storage.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
+            )
+            .Returns(
+                (string path, CancellationToken _) =>
+                {
+                    _deletedDerivedPaths.Add(path);
+                    return Task.CompletedTask;
+                }
+            );
+
+        _store
+            .Setup(store => store.RelativePath(It.IsAny<string>()))
+            .Returns((string key) => $"{key[..2]}/{key}");
+        _store
+            .Setup(store => store.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _store
+            .Setup(store =>
+                store.PutAsync(
+                    It.IsAny<Stream>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(
+                (Stream _, string contentType, CancellationToken _) =>
+                    new DerivedAudioEntry($"ab{++_putCount:D62}", contentType, 4096 + _putCount)
+            );
+
+        _probe.Setup(probe => probe.GetCachedReport()).Returns(Report(stemsplitModelPresent: true));
+
+        _writer
+            .Setup(writer =>
+                writer.RegisterStemAsync(It.IsAny<PluginTrackStem>(), It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(
+                (PluginTrackStem stem, CancellationToken _) =>
+                {
+                    _registeredStems.Add(stem);
+                    return PluginWriteResult.Accepted();
+                }
+            );
+        _writerFactory
+            .Setup(factory => factory.CreateFor(It.IsAny<Ulid>()))
+            .Returns(_writer.Object);
+
+        _runner
+            .Setup(runner =>
+                runner.RunAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string[]>(),
+                    It.IsAny<Action<string>?>(),
+                    It.IsAny<Action<string>?>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(
+                (
+                    string executable,
+                    string[] arguments,
+                    Action<string>? onStdOut,
+                    Action<string>? onStdErr,
+                    string? workingDirectory,
+                    CancellationToken _
+                ) =>
+                {
+                    _runCount++;
+                    _capturedExecutable = executable;
+                    _capturedArguments = arguments;
+                    _capturedWorkingDirectory = workingDirectory;
+
+                    foreach (string line in _stdErrLines)
+                    {
+                        onStdErr?.Invoke(line);
+                    }
+
+                    onStdOut?.Invoke(string.Empty);
+
+                    return _runResult;
+                }
+            );
+    }
+
+    private static CapabilityReport Report(bool stemsplitModelPresent) =>
+        new(
+            BluRayProtocol: true,
+            DvdReadProtocol: true,
+            AvailableEncoders: [],
+            MissingFilters: [],
+            MissingMuxers: [],
+            FpcalcPresent: true,
+            WhisperModelPresent: true,
+            StemsplitModelPresent: stemsplitModelPresent,
+            TesseractEngTraineddataPresent: true,
+            TesseractModelsDirectory: null,
+            Issues: []
+        );
+
+    private PluginAudioTools CreateTools()
+    {
+        Mock<IDbContextFactory<MediaContext>> contextFactory = new();
+        contextFactory
+            .Setup(factory => factory.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new(_options));
+
+        return new PluginAudioTools(
+            _pluginId,
+            _encoderOptions,
+            _runner.Object,
+            _storage.Object,
+            _driver.Object,
+            _derivedStorage.Object,
+            _store.Object,
+            _writerFactory.Object,
+            contextFactory.Object,
+            _probe.Object
+        );
+    }
+
+    private static string ModelFile => AppFiles.StemsplitModel + ".gguf";
+
+    /// <summary>The value that follows <paramref name="flag" /> in the captured argument array.</summary>
+    private string? ArgumentAfter(string flag)
+    {
+        int index = Array.IndexOf(_capturedArguments, flag);
+        return index >= 0 && index + 1 < _capturedArguments.Length
+            ? _capturedArguments[index + 1]
+            : null;
+    }
+
+    // --- RunFilterGraphAsync: the command --------------------------------
+
+    [Fact]
+    public async Task RunFilterGraph_Simple_BuildsTheAfArguments()
+    {
+        PluginAudioRunResult result = await CreateTools()
+            .RunFilterGraphAsync(
+                PluginAudioInput.Track(_trackId.ToString()),
+                new PluginFilterGraph("stereotools=mlev=0", Complex: false),
+                null,
+                null
+            );
+
+        result.Refusal.Should().BeNull();
+        result.ExitCode.Should().Be(0);
+        _capturedExecutable.Should().Be(FfmpegBinary);
+        _capturedArguments
+            .Should()
+            .Equal(
+                "-nostdin",
+                "-i",
+                "/library/folder/track.flac",
+                "-vn",
+                "-sn",
+                "-dn",
+                "-af",
+                "stereotools=mlev=0",
+                "-f",
+                "null",
+                "-"
+            );
+    }
+
+    [Fact]
+    public async Task RunFilterGraph_Complex_MapsTheInputToNull()
+    {
+        await CreateTools()
+            .RunFilterGraphAsync(
+                PluginAudioInput.Track(_trackId.ToString()),
+                new PluginFilterGraph("[0:a]asplit[a][b]", Complex: true),
+                null,
+                null
+            );
+
+        _capturedArguments
+            .Should()
+            .Equal(
+                "-nostdin",
+                "-i",
+                "/library/folder/track.flac",
+                "-vn",
+                "-sn",
+                "-dn",
+                "-filter_complex",
+                "[0:a]asplit[a][b]",
+                "-map",
+                "0:a",
+                "-f",
+                "null",
+                "-"
+            );
+    }
+
+    [Fact]
+    public async Task RunFilterGraph_ReplacesTheModelToken_AndRunsInTheFfmpegFolder()
+    {
+        await CreateTools()
+            .RunFilterGraphAsync(
+                PluginAudioInput.Track(_trackId.ToString()),
+                new PluginFilterGraph("[0:a]stemsplit=model={stemsModel}[voc][acc]", Complex: true),
+                null,
+                null
+            );
+
+        ArgumentAfter("-filter_complex").Should().Be($"[0:a]stemsplit=model={ModelFile}[voc][acc]");
+        _capturedWorkingDirectory.Should().Be(AppFiles.FfmpegFolder);
+    }
+
+    [Fact]
+    public async Task RunFilterGraph_Derived_ResolvesTheKeyThroughTheStore()
+    {
+        const string key = "abcdef0123456789";
+
+        await CreateTools()
+            .RunFilterGraphAsync(
+                PluginAudioInput.Derived(key),
+                new PluginFilterGraph("volume=1", Complex: false),
+                null,
+                null
+            );
+
+        ArgumentAfter("-i").Should().Be($"ab/{key}");
+    }
+
+    // --- RunFilterGraphAsync: the refusals -------------------------------
+
+    [Fact]
+    public async Task RunFilterGraph_RefusesWhenTheStemsModelIsAbsent()
+    {
+        _probe
+            .Setup(probe => probe.GetCachedReport())
+            .Returns(Report(stemsplitModelPresent: false));
+
+        PluginAudioRunResult result = await CreateTools()
+            .RunFilterGraphAsync(
+                PluginAudioInput.Track(_trackId.ToString()),
+                new PluginFilterGraph("[0:a]stemsplit=model={stemsModel}[voc][acc]", Complex: true),
+                null,
+                null
+            );
+
+        result.Refusal.Should().Be("the stemsplit model is not installed");
+        _runCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunFilterGraph_RefusesASecondConcurrentRun()
+    {
+        TaskCompletionSource<ProcessResult> pending = new();
+        _runResult = pending.Task;
+
+        PluginAudioTools tools = CreateTools();
+
+        Task<PluginAudioRunResult> first = tools.RunFilterGraphAsync(
+            PluginAudioInput.Track(_trackId.ToString()),
+            new PluginFilterGraph("volume=1", Complex: false),
+            null,
+            null
+        );
+
+        // The first run has to have reached the runner before the second call
+        // means anything; the mock records every entry, so wait for that.
+        while (_runCount == 0)
+        {
+            await Task.Yield();
+        }
+
+        PluginAudioRunResult second = await tools.RunFilterGraphAsync(
+            PluginAudioInput.Track(_trackId.ToString()),
+            new PluginFilterGraph("volume=1", Complex: false),
+            null,
+            null
+        );
+
+        second.Refusal.Should().Be("another ffmpeg run of this plugin is still in progress");
+
+        pending.SetResult(new ProcessResult(0, string.Empty, string.Empty, TimeSpan.Zero));
+        (await first).Refusal.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RunFilterGraph_RefusesAnUnknownTrack()
+    {
+        Guid unknownTrackId = Guid.NewGuid();
+
+        PluginAudioRunResult result = await CreateTools()
+            .RunFilterGraphAsync(
+                PluginAudioInput.Track(unknownTrackId.ToString()),
+                new PluginFilterGraph("volume=1", Complex: false),
+                null,
+                null
+            );
+
+        result.Refusal.Should().Be($"track {unknownTrackId} has no file");
+        _runCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunFilterGraph_RefusesATrackWithoutAFile()
+    {
+        PluginAudioRunResult result = await CreateTools()
+            .RunFilterGraphAsync(
+                PluginAudioInput.Track(_trackWithoutFileId.ToString()),
+                new PluginFilterGraph("volume=1", Complex: false),
+                null,
+                null
+            );
+
+        result.Refusal.Should().Be($"track {_trackWithoutFileId} has no file");
+    }
+
+    [Fact]
+    public async Task RunFilterGraph_RefusesAKeyThatIsNotInTheDerivedStore()
+    {
+        const string key = "abcdef0123456789";
+        _store
+            .Setup(store => store.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        PluginAudioRunResult result = await CreateTools()
+            .RunFilterGraphAsync(
+                PluginAudioInput.Derived(key),
+                new PluginFilterGraph("volume=1", Complex: false),
+                null,
+                null
+            );
+
+        result.Refusal.Should().Be($"storage key {key} is not in the derived store");
+    }
+
+    [Fact]
+    public async Task RunFilterGraph_RefusesWhenFfmpegIsNotInstalled()
+    {
+        _encoderOptions.FfmpegPathOverride = null;
+
+        PluginAudioRunResult result = await CreateTools()
+            .RunFilterGraphAsync(
+                PluginAudioInput.Track(_trackId.ToString()),
+                new PluginFilterGraph("volume=1", Complex: false),
+                null,
+                null
+            );
+
+        result.Refusal.Should().Be("ffmpeg is not installed");
+    }
+
+    // --- SplitStemsAsync --------------------------------------------------
+
+    [Fact]
+    public async Task SplitStems_Four_IsRefused()
+    {
+        PluginStemSplitResult result = await CreateTools()
+            .SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.Full, PluginStemSet.Four);
+
+        result.Refusal.Should().Be("four-stem splitting is not available yet");
+        _runCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SplitStems_MixIn_UsesTheFirstTwentyPercent()
+    {
+        await CreateTools()
+            .SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.MixIn, PluginStemSet.Two);
+
+        _capturedArguments.Should().Contain("-t");
+        ArgumentAfter("-t").Should().Be("60");
+        _capturedArguments.Should().NotContain("-ss");
+    }
+
+    [Fact]
+    public async Task SplitStems_MixOut_StartsAtSeventyFivePercent()
+    {
+        await CreateTools()
+            .SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.MixOut, PluginStemSet.Two);
+
+        _capturedArguments.Should().Contain("-ss");
+        ArgumentAfter("-ss").Should().Be("225");
+        _capturedArguments.Should().NotContain("-t");
+    }
+
+    [Fact]
+    public async Task SplitStems_Full_HasNoWindowArguments()
+    {
+        await CreateTools()
+            .SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.Full, PluginStemSet.Two);
+
+        _capturedArguments.Should().NotContain("-ss");
+        _capturedArguments.Should().NotContain("-t");
+        _capturedArguments
+            .Take(6)
+            .Should()
+            .Equal("-nostdin", "-i", "/library/folder/track.flac", "-vn", "-sn", "-dn");
+        ArgumentAfter("-filter_complex").Should().Be($"[0:a]stemsplit=model={ModelFile}[voc][acc]");
+        _capturedWorkingDirectory.Should().Be(AppFiles.FfmpegFolder);
+    }
+
+    [Fact]
+    public async Task SplitStems_WritesTwoOpusOutputs()
+    {
+        await CreateTools()
+            .SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.Full, PluginStemSet.Two);
+
+        _capturedArguments.Should().ContainInOrder("-map", "[voc]", "-c:a", "libopus");
+        _capturedArguments.Should().ContainInOrder("-map", "[acc]", "-c:a", "libopus");
+        _capturedArguments.Count(argument => argument == "160k").Should().Be(2);
+        _capturedArguments.Count(argument => argument == "48000").Should().Be(2);
+        _capturedArguments[^1].Should().EndWith("-accompaniment.opus");
+    }
+
+    [Fact]
+    public async Task SplitStems_RegistersBothStems_OnSuccess()
+    {
+        PluginStemSplitResult result = await CreateTools()
+            .SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.MixIn, PluginStemSet.Two);
+
+        result.Refusal.Should().BeNull();
+        result.Stems.Should().HaveCount(2);
+        result.Stems.Select(stem => stem.Kind).Should().Equal("vocals", "accompaniment");
+        result.Stems.Should().OnlyContain(stem => stem.Coverage == PluginStemCoverage.MixIn);
+        result.Stems.Select(stem => stem.StorageKey).Should().OnlyHaveUniqueItems();
+
+        _registeredStems.Select(stem => stem.Kind).Should().Equal("vocals", "accompaniment");
+        _registeredStems
+            .Should()
+            .OnlyContain(stem =>
+                stem.TrackId == _trackId
+                && stem.Format == "opus"
+                && stem.SampleRate == 48000
+                && stem.WindowStartMs == 0
+                && stem.WindowEndMs == 60000
+            );
+        _registeredStems
+            .Should()
+            .OnlyContain(stem =>
+                stem.ProducerVersion == AppFiles.StemsplitModel + "@9.0-NoMercy-MediaServer"
+            );
+
+        // Both temp files handed to the store are gone again afterwards.
+        _deletedDerivedPaths.Should().HaveCount(2);
+        _deletedDerivedPaths.Should().OnlyContain(path => path.StartsWith("tmp/"));
+    }
+
+    [Fact]
+    public async Task SplitStems_RefusesWhenStemsplitExitsNonZero()
+    {
+        _runResult = Task.FromResult(
+            new ProcessResult(3, string.Empty, string.Empty, TimeSpan.Zero)
+        );
+
+        PluginStemSplitResult result = await CreateTools()
+            .SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.Full, PluginStemSet.Two);
+
+        result.Refusal.Should().Be("stemsplit exited with 3");
+        result.Stems.Should().BeEmpty();
+        _registeredStems.Should().BeEmpty();
+        _deletedDerivedPaths.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task SplitStems_RefusesWhenTheModelIsAbsent()
+    {
+        _probe
+            .Setup(probe => probe.GetCachedReport())
+            .Returns(Report(stemsplitModelPresent: false));
+
+        PluginStemSplitResult result = await CreateTools()
+            .SplitStemsAsync(_trackId.ToString(), PluginStemCoverage.Full, PluginStemSet.Two);
+
+        result.Refusal.Should().Be("the stemsplit model is not installed");
+        _runCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SplitStems_RefusesATrackWithoutADuration()
+    {
+        PluginStemSplitResult result = await CreateTools()
+            .SplitStemsAsync(
+                _trackWithoutDurationId.ToString(),
+                PluginStemCoverage.MixIn,
+                PluginStemSet.Two
+            );
+
+        result.Refusal.Should().Be($"track {_trackWithoutDurationId} has no duration");
+        _runCount.Should().Be(0);
+    }
+}

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginAudioToolsTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginAudioToolsTests.cs
@@ -21,6 +21,7 @@ using NoMercy.Encoder.Infrastructure;
 using NoMercy.Encoder.Startup;
 using NoMercy.MediaProcessing.DerivedAudio;
 using NoMercy.NmSystem.Information;
+using NoMercy.Plugins;
 using NoMercy.Plugins.Abstractions;
 using NoMercy.Storage;
 

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginAudioToolsTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginAudioToolsTests.cs
@@ -38,6 +38,11 @@ namespace NoMercy.Tests.Repositories.Plugins;
 public class PluginAudioToolsTests : IDisposable
 {
     private const string FfmpegBinary = "ffmpeg";
+
+    // A key the derived store could have minted: 64 lowercase hex characters.
+    // Anything shorter is refused before the store is consulted.
+    private const string DerivedKey =
+        "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
     private const string VersionLine =
         "ffmpeg version 9.0-NoMercy-MediaServer Copyright (c) 2000-2026 the FFmpeg developers";
 
@@ -457,7 +462,7 @@ public class PluginAudioToolsTests : IDisposable
     [Fact]
     public async Task RunFilterGraph_Derived_ResolvesTheKeyThroughTheStore()
     {
-        const string key = "abcdef0123456789";
+        const string key = DerivedKey;
 
         await CreateTools()
             .RunFilterGraphAsync(
@@ -560,7 +565,7 @@ public class PluginAudioToolsTests : IDisposable
     [Fact]
     public async Task RunFilterGraph_RefusesAKeyThatIsNotInTheDerivedStore()
     {
-        const string key = "abcdef0123456789";
+        const string key = DerivedKey;
         _store
             .Setup(store => store.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
@@ -574,6 +579,36 @@ public class PluginAudioToolsTests : IDisposable
             );
 
         result.Refusal.Should().Be($"storage key {key} is not in the derived store");
+    }
+
+    /// <summary>
+    /// A derived key a plugin made up is refused in the same words as one the
+    /// store does not hold, and the store is never asked - answering means
+    /// slicing the key into a path, which is exactly what a traversal attempt
+    /// is counting on.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("a")]
+    [InlineData("../../etc")]
+    [InlineData("ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789")]
+    public async Task RunFilterGraph_RefusesAMalformedDerivedKey(string key)
+    {
+        PluginAudioRunResult result = await CreateTools()
+            .RunFilterGraphAsync(
+                PluginAudioInput.Derived(key),
+                new PluginFilterGraph("volume=1", Complex: false),
+                null,
+                null
+            );
+
+        result.Refusal.Should().Be($"storage key {key} is not in the derived store");
+        _runCount.Should().Be(0);
+        _store.Verify(
+            store => store.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+        _store.Verify(store => store.RelativePath(It.IsAny<string>()), Times.Never);
     }
 
     [Fact]

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginDerivedAudioTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginDerivedAudioTests.cs
@@ -114,12 +114,13 @@ public class PluginDerivedAudioTests
 
     /// <summary>
     /// <see cref="IDerivedAudioStore.RelativePath" /> slices the key to build a
-    /// path, so a null or empty key must never reach the store at all - the
-    /// facade answers "not found" / no-op on its own.
+    /// path, so a null, empty or whitespace-only key must never reach the
+    /// store at all - the facade answers "not found" / no-op on its own.
     /// </summary>
     [Theory]
     [InlineData(null)]
     [InlineData("")]
+    [InlineData(" ")]
     public async Task AnEmptyKey_NeverReachesTheStore(string? key)
     {
         Mock<IDerivedAudioStore> store = new();

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginDerivedAudioTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginDerivedAudioTests.cs
@@ -157,6 +157,51 @@ public class PluginDerivedAudioTests
     }
 
     /// <summary>
+    /// None of these members has a way to say why it could not answer, so a
+    /// store that throws reads as an absence rather than taking the plugin's
+    /// sweep down with it. <see cref="PluginDerivedAudio.PutAsync" /> is the
+    /// exception: it owes the caller the key of content it just produced, and
+    /// there is none.
+    /// </summary>
+    [Fact]
+    public async Task AThrowingStore_ReadsAsAnAbsence_ExceptOnPut()
+    {
+        Mock<IDerivedAudioStore> store = new();
+        IOException failure = new("the derived volume went away");
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(failure);
+        store
+            .Setup(s => s.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(failure);
+        store
+            .Setup(s => s.TouchAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(failure);
+        store
+            .Setup(s => s.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(failure);
+        store
+            .Setup(s =>
+                s.PutAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>())
+            )
+            .ThrowsAsync(failure);
+
+        PluginDerivedAudio facade = new(store.Object);
+
+        (await facade.ExistsAsync(SomeKey)).Should().BeFalse();
+        (await facade.OpenReadAsync(SomeKey)).Should().BeNull();
+
+        Func<Task> touch = () => facade.TouchAsync(SomeKey);
+        await touch.Should().NotThrowAsync();
+        Func<Task> delete = () => facade.DeleteAsync(SomeKey);
+        await delete.Should().NotThrowAsync();
+
+        using MemoryStream content = new([1, 2, 3]);
+        Func<Task> put = () => facade.PutAsync(content, "audio/opus");
+        await put.Should().ThrowAsync<IOException>();
+    }
+
+    /// <summary>
     /// A key is the lowercase hex of a SHA-256 digest and nothing else, so a
     /// short one, a traversal attempt, a near-miss length and the right
     /// characters in the wrong case are all refused here - before the store

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginDerivedAudioTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginDerivedAudioTests.cs
@@ -25,6 +25,15 @@ namespace NoMercy.Tests.Repositories.Plugins;
 /// </summary>
 public class PluginDerivedAudioTests
 {
+    // Only a 64-character lowercase hex string is a key PutAsync could have
+    // minted, so the forwarding tests below have to use one: anything else is
+    // refused by the facade before the store is ever reached.
+    private const string SomeKey =
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    private const string UnknownKey =
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
     [Fact]
     public async Task Put_ForwardsAndReturnsTheKey()
     {
@@ -52,18 +61,15 @@ public class PluginDerivedAudioTests
     {
         Mock<IDerivedAudioStore> store = new();
         store
-            .Setup(s => s.OpenReadAsync("unknown-key", It.IsAny<CancellationToken>()))
+            .Setup(s => s.OpenReadAsync(UnknownKey, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Stream?)null);
 
         PluginDerivedAudio facade = new(store.Object);
 
-        Stream? result = await facade.OpenReadAsync("unknown-key");
+        Stream? result = await facade.OpenReadAsync(UnknownKey);
 
         result.Should().BeNull();
-        store.Verify(
-            s => s.OpenReadAsync("unknown-key", It.IsAny<CancellationToken>()),
-            Times.Once
-        );
+        store.Verify(s => s.OpenReadAsync(UnknownKey, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -71,14 +77,14 @@ public class PluginDerivedAudioTests
     {
         Mock<IDerivedAudioStore> store = new();
         store
-            .Setup(s => s.DeleteAsync("some-key", It.IsAny<CancellationToken>()))
+            .Setup(s => s.DeleteAsync(SomeKey, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         PluginDerivedAudio facade = new(store.Object);
 
-        await facade.DeleteAsync("some-key");
+        await facade.DeleteAsync(SomeKey);
 
-        store.Verify(s => s.DeleteAsync("some-key", It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.DeleteAsync(SomeKey, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -86,30 +92,28 @@ public class PluginDerivedAudioTests
     {
         Mock<IDerivedAudioStore> store = new();
         store
-            .Setup(s => s.TouchAsync("some-key", It.IsAny<CancellationToken>()))
+            .Setup(s => s.TouchAsync(SomeKey, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         PluginDerivedAudio facade = new(store.Object);
 
-        await facade.TouchAsync("some-key");
+        await facade.TouchAsync(SomeKey);
 
-        store.Verify(s => s.TouchAsync("some-key", It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.TouchAsync(SomeKey, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task Exists_Forwards()
     {
         Mock<IDerivedAudioStore> store = new();
-        store
-            .Setup(s => s.ExistsAsync("some-key", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+        store.Setup(s => s.ExistsAsync(SomeKey, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
         PluginDerivedAudio facade = new(store.Object);
 
-        bool exists = await facade.ExistsAsync("some-key");
+        bool exists = await facade.ExistsAsync(SomeKey);
 
         exists.Should().BeTrue();
-        store.Verify(s => s.ExistsAsync("some-key", It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.ExistsAsync(SomeKey, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     /// <summary>
@@ -130,6 +134,48 @@ public class PluginDerivedAudioTests
         Stream? opened = await facade.OpenReadAsync(key!);
         await facade.TouchAsync(key!);
         await facade.DeleteAsync(key!);
+
+        exists.Should().BeFalse();
+        opened.Should().BeNull();
+
+        store.Verify(
+            s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+        store.Verify(
+            s => s.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+        store.Verify(
+            s => s.TouchAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+        store.Verify(
+            s => s.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// A key is the lowercase hex of a SHA-256 digest and nothing else, so a
+    /// short one, a traversal attempt, a near-miss length and the right
+    /// characters in the wrong case are all refused here - before the store
+    /// gets the chance to slice any of them into a path.
+    /// </summary>
+    [Theory]
+    [InlineData("a")]
+    [InlineData("../../etc")]
+    [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+    [InlineData("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")]
+    public async Task AMalformedKey_NeverReachesTheStore(string key)
+    {
+        Mock<IDerivedAudioStore> store = new();
+        PluginDerivedAudio facade = new(store.Object);
+
+        bool exists = await facade.ExistsAsync(key);
+        Stream? opened = await facade.OpenReadAsync(key);
+        await facade.TouchAsync(key);
+        await facade.DeleteAsync(key);
 
         exists.Should().BeFalse();
         opened.Should().BeNull();

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginDerivedAudioTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginDerivedAudioTests.cs
@@ -1,0 +1,153 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using FluentAssertions;
+using Moq;
+using NoMercy.Data.Plugins;
+using NoMercy.MediaProcessing.DerivedAudio;
+using NoMercy.Plugins.Abstractions;
+
+namespace NoMercy.Tests.Repositories.Plugins;
+
+/// <summary>
+/// The host side of <see cref="IPluginDerivedAudio" />: every member forwards
+/// to <see cref="IDerivedAudioStore" />, and an empty key is refused before it
+/// ever reaches the store, since <see cref="IDerivedAudioStore.RelativePath" />
+/// slices the key to build a path.
+/// </summary>
+public class PluginDerivedAudioTests
+{
+    [Fact]
+    public async Task Put_ForwardsAndReturnsTheKey()
+    {
+        Mock<IDerivedAudioStore> store = new();
+        using MemoryStream content = new([1, 2, 3]);
+        DerivedAudioEntry entry = new("abcdef1234567890", "audio/opus", 3);
+
+        store
+            .Setup(s => s.PutAsync(content, "audio/opus", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entry);
+
+        PluginDerivedAudio facade = new(store.Object);
+
+        string key = await facade.PutAsync(content, "audio/opus");
+
+        key.Should().Be("abcdef1234567890");
+        store.Verify(
+            s => s.PutAsync(content, "audio/opus", It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task OpenRead_ForwardsNullForUnknownKeys()
+    {
+        Mock<IDerivedAudioStore> store = new();
+        store
+            .Setup(s => s.OpenReadAsync("unknown-key", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Stream?)null);
+
+        PluginDerivedAudio facade = new(store.Object);
+
+        Stream? result = await facade.OpenReadAsync("unknown-key");
+
+        result.Should().BeNull();
+        store.Verify(
+            s => s.OpenReadAsync("unknown-key", It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task Delete_Forwards()
+    {
+        Mock<IDerivedAudioStore> store = new();
+        store
+            .Setup(s => s.DeleteAsync("some-key", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        PluginDerivedAudio facade = new(store.Object);
+
+        await facade.DeleteAsync("some-key");
+
+        store.Verify(s => s.DeleteAsync("some-key", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Touch_Forwards()
+    {
+        Mock<IDerivedAudioStore> store = new();
+        store
+            .Setup(s => s.TouchAsync("some-key", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        PluginDerivedAudio facade = new(store.Object);
+
+        await facade.TouchAsync("some-key");
+
+        store.Verify(s => s.TouchAsync("some-key", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Exists_Forwards()
+    {
+        Mock<IDerivedAudioStore> store = new();
+        store
+            .Setup(s => s.ExistsAsync("some-key", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        PluginDerivedAudio facade = new(store.Object);
+
+        bool exists = await facade.ExistsAsync("some-key");
+
+        exists.Should().BeTrue();
+        store.Verify(s => s.ExistsAsync("some-key", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// <see cref="IDerivedAudioStore.RelativePath" /> slices the key to build a
+    /// path, so a null or empty key must never reach the store at all - the
+    /// facade answers "not found" / no-op on its own.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task AnEmptyKey_NeverReachesTheStore(string? key)
+    {
+        Mock<IDerivedAudioStore> store = new();
+        PluginDerivedAudio facade = new(store.Object);
+
+        bool exists = await facade.ExistsAsync(key!);
+        Stream? opened = await facade.OpenReadAsync(key!);
+        await facade.TouchAsync(key!);
+        await facade.DeleteAsync(key!);
+
+        exists.Should().BeFalse();
+        opened.Should().BeNull();
+
+        store.Verify(
+            s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+        store.Verify(
+            s => s.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+        store.Verify(
+            s => s.TouchAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+        store.Verify(
+            s => s.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+    }
+}

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
@@ -12,6 +12,7 @@
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NoMercy.Data.Plugins;
 using NoMercy.Database;
@@ -504,6 +505,43 @@ public class PluginMusicAnalysisWriterTests : IDisposable
         row.FailureReason!.Length.Should().Be(1024);
     }
 
+    /// <summary>
+    /// A Failed row must never go on carrying a previous Ok row's
+    /// measurements - a caller reading a stale <c>DjAnalyzerVersion</c>
+    /// alongside <c>State = Failed</c> has to see nothing behind it, not the
+    /// last successful run's numbers.
+    /// </summary>
+    [Fact]
+    public async Task MarkFailed_AfterAnOkRow_ClearsTheMeasurements()
+    {
+        PluginMusicAnalysisWriter writer = CreateWriter(NewStoreMock().Object);
+
+        await writer.UpsertDjAnalysisAsync(ValidRecord(_trackId));
+
+        PluginWriteResult result = await writer.MarkFailedAsync(
+            _trackId,
+            4,
+            BaseAnalyzerVersion,
+            "vocal detector produced no regions"
+        );
+
+        result.Ok.Should().BeTrue();
+
+        using MediaContext context = new(_options);
+        TrackDjAnalysis row = context.TrackDjAnalysis.Single(a => a.TrackId == _trackId);
+
+        row.State.Should().Be(AudioAnalysisState.Failed);
+        row.DjAnalyzerVersion.Should().Be(4);
+        row.DownbeatIndex.Should().BeNull();
+        row.BeatsPerBar.Should().Be(4);
+        row.PhraseLengthBars.Should().Be(8);
+        row.PhraseStartsMs.Should().BeNull();
+        row.VocalRegionsMs.Should().BeNull();
+        row.BarEnergy.Should().BeNull();
+        row.CuePoints.Should().BeNull();
+        row.Chords.Should().BeNull();
+    }
+
     // --- DeleteDjAnalysisAsync -----------------------------------------------
 
     [Fact]
@@ -532,5 +570,46 @@ public class PluginMusicAnalysisWriterTests : IDisposable
             await CreateWriter(NewStoreMock().Object).DeleteDjAnalysisAsync(Guid.NewGuid());
 
         await act.Should().NotThrowAsync();
+    }
+
+    // --- PluginMusicAnalysisWriterFactory -------------------------------------
+
+    /// <summary>
+    /// The unknown-duration log line is worthless if it never reaches a real
+    /// sink: the factory has to hand every writer it builds the logger it was
+    /// given, not leave it on the writer's <c>NullLogger</c> fallback.
+    /// </summary>
+    [Fact]
+    public async Task CreateFor_GivesTheWriterTheFactorysLogger()
+    {
+        Mock<ILogger<PluginMusicAnalysisWriter>> loggerMock = new();
+
+        Mock<IDbContextFactory<MediaContext>> contextFactoryMock = new();
+        contextFactoryMock
+            .Setup(x => x.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new(_options));
+
+        PluginMusicAnalysisWriterFactory factory = new(
+            contextFactoryMock.Object,
+            NewStoreMock().Object,
+            loggerMock.Object
+        );
+
+        IPluginMusicAnalysisWriter writer = factory.CreateFor(_pluginId);
+        await writer.UpsertDjAnalysisAsync(ValidRecord(_trackUnknownDurationId));
+
+        loggerMock.Verify(
+            logger =>
+                logger.Log(
+                    LogLevel.Information,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>(
+                        (state, _) => state.ToString()!.Contains("duration is unknown")
+                    ),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+                ),
+            Times.Once
+        );
     }
 }

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
@@ -77,6 +77,12 @@ public class PluginMusicAnalysisWriterTests : IDisposable
         _connection = new("Data Source=:memory:");
         _connection.Open();
 
+        // The stem rows these tests register point at derived-store keys with no
+        // DerivedAudio parent row here - the store is a mock, so nothing ever
+        // inserted one. The cascade itself is proven against a real store in
+        // DerivedAudioStoreTests and against the schema in
+        // AnalysisRecordModelTests; what is under test here is every refusal
+        // the writer can hand back and what a valid write lands.
         using (SqliteCommand fkOff = _connection.CreateCommand())
         {
             fkOff.CommandText = "PRAGMA foreign_keys = OFF;";
@@ -366,6 +372,63 @@ public class PluginMusicAnalysisWriterTests : IDisposable
         row.BarEnergy.Should().Be("[]");
         row.CuePoints.Should().Be("[]");
         row.Chords.Should().Be("[]");
+    }
+
+    /// <summary>
+    /// Every list on the record is required. A null one would serialise to the
+    /// JSON literal <c>null</c> and land in a column the reader treats as "the
+    /// plugin stored nothing here" - a different claim from the <c>[]</c> an
+    /// empty measurement writes, and one no caller meant to make.
+    /// </summary>
+    [Theory]
+    [InlineData("phrase_starts_ms")]
+    [InlineData("vocal_regions_ms")]
+    [InlineData("bar_energy")]
+    [InlineData("cue_points")]
+    [InlineData("chords")]
+    public async Task UpsertDjAnalysisAsync_RefusesANullList(string field)
+    {
+        PluginTrackDjAnalysis valid = ValidRecord(_trackId);
+        PluginTrackDjAnalysis record = field switch
+        {
+            "phrase_starts_ms" => valid with { PhraseStartsMs = null! },
+            "vocal_regions_ms" => valid with { VocalRegionsMs = null! },
+            "bar_energy" => valid with { BarEnergy = null! },
+            "cue_points" => valid with { CuePoints = null! },
+            _ => valid with { Chords = null! },
+        };
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(record);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Be($"{field} must not be null");
+
+        using MediaContext context = new(_options);
+        context.TrackDjAnalysis.Any(analysis => analysis.TrackId == _trackId).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A plugin sweeping a library unattended must not lose the whole sweep to
+    /// one unlucky track: a dependency that throws where nothing planned for it
+    /// becomes a refusal naming the exception's type, with the exception itself
+    /// on the server's own log.
+    /// </summary>
+    [Fact]
+    public async Task AThrowingDependency_BecomesARefusal()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("the derived volume went away"));
+
+        Func<Task<PluginWriteResult>> act = () =>
+            CreateWriter(store.Object).RegisterStemAsync(ValidFullStem(_trackId, KeyOne));
+
+        PluginWriteResult result = (await act.Should().NotThrowAsync()).Which;
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Be("the server could not complete this call: IOException");
     }
 
     // --- RegisterStemAsync: refusals ---------------------------------------

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
@@ -31,6 +31,32 @@ public class PluginMusicAnalysisWriterTests : IDisposable
 {
     private const int BaseAnalyzerVersion = 1;
 
+    // Every storage key below is a 64-character lowercase hex string: the
+    // writer refuses anything the derived store could not have minted before
+    // it asks the store about it, so a readable "key-1" no longer gets that
+    // far.
+    private const string KeyOne =
+        "1111111111111111111111111111111111111111111111111111111111111111";
+
+    private const string KeyTwo =
+        "2222222222222222222222222222222222222222222222222222222222222222";
+
+    private const string KeyThree =
+        "3333333333333333333333333333333333333333333333333333333333333333";
+
+    private const string KeyFour =
+        "4444444444444444444444444444444444444444444444444444444444444444";
+
+    private const string KeyA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    private const string KeyB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    private const string KeyDelete =
+        "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+
+    private const string MissingKey =
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
     private readonly SqliteConnection _connection;
     private readonly DbContextOptions<MediaContext> _options;
     private readonly Ulid _pluginId = Ulid.NewUlid();
@@ -348,10 +374,10 @@ public class PluginMusicAnalysisWriterTests : IDisposable
     public async Task RegisterStemAsync_RefusesAnUnknownTrack()
     {
         Mock<IDerivedAudioStore> store = NewStoreMock();
-        store.Setup(s => s.ExistsAsync("key-1", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        store.Setup(s => s.ExistsAsync(KeyOne, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
         PluginWriteResult result = await CreateWriter(store.Object)
-            .RegisterStemAsync(ValidFullStem(Guid.NewGuid(), "key-1"));
+            .RegisterStemAsync(ValidFullStem(Guid.NewGuid(), KeyOne));
 
         result.Ok.Should().BeFalse();
         result.Refusal.Should().Contain("does not exist");
@@ -362,19 +388,73 @@ public class PluginMusicAnalysisWriterTests : IDisposable
     {
         // NewStoreMock's ExistsAsync answers false for every key by default.
         PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
-            .RegisterStemAsync(ValidFullStem(_trackId, "missing-key"));
+            .RegisterStemAsync(ValidFullStem(_trackId, MissingKey));
 
         result.Ok.Should().BeFalse();
         result.Refusal.Should().Contain("is not in the derived store");
+    }
+
+    /// <summary>
+    /// A key the derived store could never have minted is refused in the same
+    /// words as one it simply does not hold - a plugin gets one answer for
+    /// "that key is not mine" - and the store is not asked about it at all,
+    /// since asking means slicing it into a path.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("a")]
+    [InlineData("../../etc")]
+    [InlineData("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")]
+    public async Task RegisterStem_RefusesAMalformedKey(string key)
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        PluginWriteResult result = await CreateWriter(store.Object)
+            .RegisterStemAsync(ValidFullStem(_trackId, key));
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Be($"storage key {key} is not in the derived store");
+        store.Verify(
+            s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+    }
+
+    /// <summary>
+    /// A crash between the store's move-into-place and its register insert
+    /// leaves a content file with no <c>DerivedAudio</c> row. The store answers
+    /// <c>false</c> for that key - it is only half an entry - so the writer
+    /// refuses in words. Registering it anyway would take the stem row's
+    /// foreign key down with a <see cref="DbUpdateException" /> nobody reads.
+    /// </summary>
+    [Fact]
+    public async Task RegisterStem_RefusesAKeyWhoseFileExistsButWhoseRowDoesNot()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store.Setup(s => s.ExistsAsync(KeyOne, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        Func<Task<PluginWriteResult>> act = () =>
+            CreateWriter(store.Object).RegisterStemAsync(ValidFullStem(_trackId, KeyOne));
+
+        PluginWriteResult result = (await act.Should().NotThrowAsync()).Which;
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Be($"storage key {KeyOne} is not in the derived store");
+
+        using MediaContext context = new(_options);
+        context.TrackStems.Any(stem => stem.TrackId == _trackId).Should().BeFalse();
     }
 
     [Fact]
     public async Task RegisterStemAsync_RefusesFullCoverageWithAWindow()
     {
         Mock<IDerivedAudioStore> store = NewStoreMock();
-        store.Setup(s => s.ExistsAsync("key-2", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        store.Setup(s => s.ExistsAsync(KeyTwo, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
-        PluginTrackStem stem = ValidFullStem(_trackId, "key-2") with
+        PluginTrackStem stem = ValidFullStem(_trackId, KeyTwo) with
         {
             WindowStartMs = 0,
             WindowEndMs = 1000,
@@ -390,7 +470,7 @@ public class PluginMusicAnalysisWriterTests : IDisposable
     public async Task RegisterStemAsync_RefusesWindowedCoverageWithoutAWindow()
     {
         Mock<IDerivedAudioStore> store = NewStoreMock();
-        store.Setup(s => s.ExistsAsync("key-3", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        store.Setup(s => s.ExistsAsync(KeyThree, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
         PluginTrackStem stem = new(
             _trackId,
@@ -400,7 +480,7 @@ public class PluginMusicAnalysisWriterTests : IDisposable
             null,
             "opus",
             48000,
-            "key-3",
+            KeyThree,
             "spleeter-2stems-f16@v1"
         );
 
@@ -414,7 +494,7 @@ public class PluginMusicAnalysisWriterTests : IDisposable
     public async Task RegisterStemAsync_RefusesAWindowThatDoesNotStartBeforeItEnds()
     {
         Mock<IDerivedAudioStore> store = NewStoreMock();
-        store.Setup(s => s.ExistsAsync("key-4", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        store.Setup(s => s.ExistsAsync(KeyFour, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
         PluginTrackStem stem = new(
             _trackId,
@@ -424,7 +504,7 @@ public class PluginMusicAnalysisWriterTests : IDisposable
             1000,
             "opus",
             48000,
-            "key-4",
+            KeyFour,
             "spleeter-2stems-f16@v1"
         );
 
@@ -446,8 +526,8 @@ public class PluginMusicAnalysisWriterTests : IDisposable
 
         PluginMusicAnalysisWriter writer = CreateWriter(store.Object);
 
-        await writer.RegisterStemAsync(ValidFullStem(_trackId, "key-a"));
-        PluginWriteResult result = await writer.RegisterStemAsync(ValidFullStem(_trackId, "key-b"));
+        await writer.RegisterStemAsync(ValidFullStem(_trackId, KeyA));
+        PluginWriteResult result = await writer.RegisterStemAsync(ValidFullStem(_trackId, KeyB));
 
         result.Ok.Should().BeTrue();
 
@@ -455,7 +535,7 @@ public class PluginMusicAnalysisWriterTests : IDisposable
         context.TrackStems.Count(s => s.TrackId == _trackId).Should().Be(1);
 
         TrackStem row = context.TrackStems.Single(s => s.TrackId == _trackId);
-        row.StorageKey.Should().Be("key-b");
+        row.StorageKey.Should().Be(KeyB);
     }
 
     // --- MarkFailedAsync -----------------------------------------------------
@@ -554,7 +634,7 @@ public class PluginMusicAnalysisWriterTests : IDisposable
 
         PluginMusicAnalysisWriter writer = CreateWriter(store.Object);
         await writer.UpsertDjAnalysisAsync(ValidRecord(_trackId));
-        await writer.RegisterStemAsync(ValidFullStem(_trackId, "key-delete"));
+        await writer.RegisterStemAsync(ValidFullStem(_trackId, KeyDelete));
 
         await writer.DeleteDjAnalysisAsync(_trackId);
 

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
@@ -1,0 +1,536 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using NoMercy.Data.Plugins;
+using NoMercy.Database;
+using NoMercy.Database.Models.Music;
+using NoMercy.MediaProcessing.DerivedAudio;
+using NoMercy.Plugins.Abstractions;
+
+namespace NoMercy.Tests.Repositories.Plugins;
+
+/// <summary>
+/// The host side of <see cref="IPluginMusicAnalysisWriter" />: every refusal
+/// the writer can hand back, and that a valid write actually lands the way
+/// the record described it.
+/// </summary>
+public class PluginMusicAnalysisWriterTests : IDisposable
+{
+    private const int BaseAnalyzerVersion = 1;
+
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<MediaContext> _options;
+    private readonly Ulid _pluginId = Ulid.NewUlid();
+
+    // Has a current Ok base row and a "03:45" (225 000 ms) duration - the
+    // track most tests write a DJ row or a stem for.
+    private readonly Guid _trackId = Guid.NewGuid();
+
+    // Exists, but never got a base analysis row: exercises "no base row".
+    private readonly Guid _trackWithoutBaseId = Guid.NewGuid();
+
+    // Has a current Ok base row, but the library never recorded a duration:
+    // exercises "duration unknown, skip the ms-range check".
+    private readonly Guid _trackUnknownDurationId = Guid.NewGuid();
+
+    public PluginMusicAnalysisWriterTests()
+    {
+        _connection = new("Data Source=:memory:");
+        _connection.Open();
+
+        using (SqliteCommand fkOff = _connection.CreateCommand())
+        {
+            fkOff.CommandText = "PRAGMA foreign_keys = OFF;";
+            fkOff.ExecuteNonQuery();
+        }
+
+        _options = new DbContextOptionsBuilder<MediaContext>().UseSqlite(_connection).Options;
+
+        using MediaContext context = new(_options);
+        context.Database.EnsureCreated();
+
+        context.Tracks.AddRange(
+            new Track
+            {
+                Id = _trackId,
+                Name = "Track A",
+                Duration = "03:45",
+            },
+            new Track
+            {
+                Id = _trackWithoutBaseId,
+                Name = "Track B",
+                Duration = "03:45",
+            },
+            new Track
+            {
+                Id = _trackUnknownDurationId,
+                Name = "Track C",
+                Duration = "",
+            }
+        );
+
+        context.TrackAudioAnalysis.AddRange(
+            new TrackAudioAnalysis
+            {
+                TrackId = _trackId,
+                AnalyzerVersion = BaseAnalyzerVersion,
+                State = AudioAnalysisState.Ok,
+                AnalyzedAt = DateTime.UtcNow,
+            },
+            new TrackAudioAnalysis
+            {
+                TrackId = _trackUnknownDurationId,
+                AnalyzerVersion = BaseAnalyzerVersion,
+                State = AudioAnalysisState.Ok,
+                AnalyzedAt = DateTime.UtcNow,
+            }
+        );
+
+        context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static Mock<IDerivedAudioStore> NewStoreMock()
+    {
+        Mock<IDerivedAudioStore> mock = new();
+        mock.Setup(store => store.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        return mock;
+    }
+
+    private PluginMusicAnalysisWriter CreateWriter(IDerivedAudioStore store)
+    {
+        Mock<IDbContextFactory<MediaContext>> factory = new();
+        factory
+            .Setup(x => x.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new(_options));
+
+        return new PluginMusicAnalysisWriter(_pluginId, factory.Object, store);
+    }
+
+    private static PluginTrackDjAnalysis ValidRecord(Guid trackId) =>
+        new(
+            trackId,
+            DjAnalyzerVersion: 3,
+            BaseAnalyzerVersion: BaseAnalyzerVersion,
+            DownbeatIndex: 0,
+            BeatsPerBar: 4,
+            PhraseLengthBars: 8,
+            PhraseStartsMs: [0, 32000, 64000],
+            VocalRegionsMs:
+            [
+                [1000, 5000],
+                [9000, 15000],
+            ],
+            BarEnergy: [-20.5, -18.2, -14.0],
+            CuePoints: [new PluginCuePoint(1000, "intro", "mixIn", 0.9)],
+            Chords: [new PluginChord(0, "Am")]
+        );
+
+    private static PluginTrackStem ValidFullStem(Guid trackId, string storageKey) =>
+        new(
+            trackId,
+            "vocals",
+            PluginStemCoverage.Full,
+            null,
+            null,
+            "opus",
+            48000,
+            storageKey,
+            "spleeter-2stems-f16@v1"
+        );
+
+    // --- UpsertDjAnalysisAsync: refusals, checked in the brief's order -----
+
+    [Fact]
+    public async Task UpsertDjAnalysisAsync_RefusesAnUnknownTrack()
+    {
+        Guid unknownTrackId = Guid.NewGuid();
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(ValidRecord(unknownTrackId));
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Contain("does not exist");
+    }
+
+    [Fact]
+    public async Task UpsertDjAnalysisAsync_RefusesWhenThereIsNoBaseAnalysisAtThatVersion()
+    {
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(ValidRecord(_trackWithoutBaseId));
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Contain("no base analysis at version");
+    }
+
+    [Fact]
+    public async Task UpsertDjAnalysisAsync_RefusesBeatsPerBarBelowOne()
+    {
+        PluginTrackDjAnalysis record = ValidRecord(_trackId) with { BeatsPerBar = 0 };
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(record);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Contain("beats_per_bar");
+    }
+
+    [Fact]
+    public async Task UpsertDjAnalysisAsync_RefusesADownbeatIndexOutsideTheBeatGrid()
+    {
+        PluginTrackDjAnalysis record = ValidRecord(_trackId) with { DownbeatIndex = 4 };
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(record);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Contain("downbeat_index");
+    }
+
+    [Fact]
+    public async Task UpsertDjAnalysisAsync_RefusesAnMsValueOutsideTheTrack()
+    {
+        PluginTrackDjAnalysis record = ValidRecord(_trackId) with
+        {
+            PhraseStartsMs = [0, 32000, 500000],
+        };
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(record);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Contain("phrase_starts_ms value 500000 lies outside the track");
+    }
+
+    /// <summary>
+    /// When the library never recorded a duration, the ms-range check cannot
+    /// run at all - the value that would fail it must not be refused, only
+    /// silently skipped.
+    /// </summary>
+    [Fact]
+    public async Task UpsertDjAnalysisAsync_SkipsTheMsRangeCheckWhenTheDurationIsUnknown()
+    {
+        PluginTrackDjAnalysis record = ValidRecord(_trackUnknownDurationId) with
+        {
+            PhraseStartsMs = [0, 32000, 500000],
+        };
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(record);
+
+        result.Ok.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpsertDjAnalysisAsync_RefusesNonAscendingPhraseStarts()
+    {
+        PluginTrackDjAnalysis record = ValidRecord(_trackId) with
+        {
+            PhraseStartsMs = [0, 32000, 16000],
+        };
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(record);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Contain("phrase_starts_ms must be ascending");
+    }
+
+    [Fact]
+    public async Task UpsertDjAnalysisAsync_RefusesAnOversizedJsonColumn()
+    {
+        List<double> hugeBarEnergy = Enumerable.Repeat(-20.5, 20000).ToList();
+        PluginTrackDjAnalysis record = ValidRecord(_trackId) with { BarEnergy = hugeBarEnergy };
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(record);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Contain("bar_energy exceeds 64 kB");
+    }
+
+    // --- UpsertDjAnalysisAsync: happy paths ---------------------------------
+
+    [Fact]
+    public async Task AValidRecord_IsStoredWithTheProducerStamped()
+    {
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(ValidRecord(_trackId));
+
+        result.Ok.Should().BeTrue();
+
+        using MediaContext context = new(_options);
+        TrackDjAnalysis row = context.TrackDjAnalysis.Single(a => a.TrackId == _trackId);
+
+        row.ProducerPluginId.Should().Be(_pluginId);
+        row.State.Should().Be(AudioAnalysisState.Ok);
+        row.FailureReason.Should().BeNull();
+        row.DjAnalyzerVersion.Should().Be(3);
+        row.PhraseStartsMs.Should().Be("[0,32000,64000]");
+        row.CuePoints.Should().Contain("\"ms\":1000").And.Contain("\"direction\":\"mixIn\"");
+        row.Chords.Should().Contain("\"chord\":\"Am\"");
+    }
+
+    [Fact]
+    public async Task UpsertTwice_ReplacesTheRow()
+    {
+        PluginMusicAnalysisWriter writer = CreateWriter(NewStoreMock().Object);
+
+        await writer.UpsertDjAnalysisAsync(ValidRecord(_trackId));
+
+        PluginTrackDjAnalysis second = ValidRecord(_trackId) with
+        {
+            DjAnalyzerVersion = 4,
+            PhraseStartsMs = [0, 16000],
+        };
+        PluginWriteResult result = await writer.UpsertDjAnalysisAsync(second);
+
+        result.Ok.Should().BeTrue();
+
+        using MediaContext context = new(_options);
+        context.TrackDjAnalysis.Count(a => a.TrackId == _trackId).Should().Be(1);
+
+        TrackDjAnalysis row = context.TrackDjAnalysis.Single(a => a.TrackId == _trackId);
+        row.DjAnalyzerVersion.Should().Be(4);
+        row.PhraseStartsMs.Should().Be("[0,16000]");
+    }
+
+    [Fact]
+    public async Task EmptyLists_AreStoredAsEmptyJsonArraysNeverNull()
+    {
+        PluginTrackDjAnalysis record = ValidRecord(_trackId) with
+        {
+            PhraseStartsMs = [],
+            VocalRegionsMs = [],
+            BarEnergy = [],
+            CuePoints = [],
+            Chords = [],
+        };
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(record);
+
+        result.Ok.Should().BeTrue();
+
+        using MediaContext context = new(_options);
+        TrackDjAnalysis row = context.TrackDjAnalysis.Single(a => a.TrackId == _trackId);
+
+        row.PhraseStartsMs.Should().Be("[]");
+        row.VocalRegionsMs.Should().Be("[]");
+        row.BarEnergy.Should().Be("[]");
+        row.CuePoints.Should().Be("[]");
+        row.Chords.Should().Be("[]");
+    }
+
+    // --- RegisterStemAsync: refusals ---------------------------------------
+
+    [Fact]
+    public async Task RegisterStemAsync_RefusesAnUnknownTrack()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store.Setup(s => s.ExistsAsync("key-1", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        PluginWriteResult result = await CreateWriter(store.Object)
+            .RegisterStemAsync(ValidFullStem(Guid.NewGuid(), "key-1"));
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Contain("does not exist");
+    }
+
+    [Fact]
+    public async Task RegisterStem_RefusesAnUnknownKey()
+    {
+        // NewStoreMock's ExistsAsync answers false for every key by default.
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .RegisterStemAsync(ValidFullStem(_trackId, "missing-key"));
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Contain("is not in the derived store");
+    }
+
+    [Fact]
+    public async Task RegisterStemAsync_RefusesFullCoverageWithAWindow()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store.Setup(s => s.ExistsAsync("key-2", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        PluginTrackStem stem = ValidFullStem(_trackId, "key-2") with
+        {
+            WindowStartMs = 0,
+            WindowEndMs = 1000,
+        };
+
+        PluginWriteResult result = await CreateWriter(store.Object).RegisterStemAsync(stem);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Contain("must not specify a window");
+    }
+
+    [Fact]
+    public async Task RegisterStemAsync_RefusesWindowedCoverageWithoutAWindow()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store.Setup(s => s.ExistsAsync("key-3", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        PluginTrackStem stem = new(
+            _trackId,
+            "vocals",
+            PluginStemCoverage.MixIn,
+            null,
+            null,
+            "opus",
+            48000,
+            "key-3",
+            "spleeter-2stems-f16@v1"
+        );
+
+        PluginWriteResult result = await CreateWriter(store.Object).RegisterStemAsync(stem);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Contain("must specify both window_start_ms and window_end_ms");
+    }
+
+    [Fact]
+    public async Task RegisterStemAsync_RefusesAWindowThatDoesNotStartBeforeItEnds()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store.Setup(s => s.ExistsAsync("key-4", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        PluginTrackStem stem = new(
+            _trackId,
+            "vocals",
+            PluginStemCoverage.MixIn,
+            1000,
+            1000,
+            "opus",
+            48000,
+            "key-4",
+            "spleeter-2stems-f16@v1"
+        );
+
+        PluginWriteResult result = await CreateWriter(store.Object).RegisterStemAsync(stem);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Contain("window_start_ms must be less than window_end_ms");
+    }
+
+    // --- RegisterStemAsync: happy path --------------------------------------
+
+    [Fact]
+    public async Task RegisterStem_ReplacesTheSameStem()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        PluginMusicAnalysisWriter writer = CreateWriter(store.Object);
+
+        await writer.RegisterStemAsync(ValidFullStem(_trackId, "key-a"));
+        PluginWriteResult result = await writer.RegisterStemAsync(ValidFullStem(_trackId, "key-b"));
+
+        result.Ok.Should().BeTrue();
+
+        using MediaContext context = new(_options);
+        context.TrackStems.Count(s => s.TrackId == _trackId).Should().Be(1);
+
+        TrackStem row = context.TrackStems.Single(s => s.TrackId == _trackId);
+        row.StorageKey.Should().Be("key-b");
+    }
+
+    // --- MarkFailedAsync -----------------------------------------------------
+
+    [Fact]
+    public async Task MarkFailedAsync_RefusesAnUnknownTrack()
+    {
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .MarkFailedAsync(Guid.NewGuid(), 3, BaseAnalyzerVersion, "no audio stream found");
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Contain("does not exist");
+    }
+
+    [Fact]
+    public async Task MarkFailed_WritesAFailedRow()
+    {
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .MarkFailedAsync(_trackId, 3, BaseAnalyzerVersion, "no audio stream found");
+
+        result.Ok.Should().BeTrue();
+
+        using MediaContext context = new(_options);
+        TrackDjAnalysis row = context.TrackDjAnalysis.Single(a => a.TrackId == _trackId);
+
+        row.State.Should().Be(AudioAnalysisState.Failed);
+        row.FailureReason.Should().Be("no audio stream found");
+        row.DjAnalyzerVersion.Should().Be(3);
+        row.BaseAnalyzerVersion.Should().Be(BaseAnalyzerVersion);
+        row.ProducerPluginId.Should().Be(_pluginId);
+    }
+
+    [Fact]
+    public async Task MarkFailedAsync_TruncatesAnOverlongReasonTo1024Characters()
+    {
+        string longReason = new('x', 2000);
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .MarkFailedAsync(_trackId, 3, BaseAnalyzerVersion, longReason);
+
+        result.Ok.Should().BeTrue();
+
+        using MediaContext context = new(_options);
+        TrackDjAnalysis row = context.TrackDjAnalysis.Single(a => a.TrackId == _trackId);
+
+        row.FailureReason.Should().NotBeNull();
+        row.FailureReason!.Length.Should().Be(1024);
+    }
+
+    // --- DeleteDjAnalysisAsync -----------------------------------------------
+
+    [Fact]
+    public async Task Delete_RemovesOnlyTheDjRow()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        PluginMusicAnalysisWriter writer = CreateWriter(store.Object);
+        await writer.UpsertDjAnalysisAsync(ValidRecord(_trackId));
+        await writer.RegisterStemAsync(ValidFullStem(_trackId, "key-delete"));
+
+        await writer.DeleteDjAnalysisAsync(_trackId);
+
+        using MediaContext context = new(_options);
+        context.TrackDjAnalysis.Any(a => a.TrackId == _trackId).Should().BeFalse();
+        context.TrackStems.Any(s => s.TrackId == _trackId).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeleteDjAnalysisAsync_IsANoOpWhenNoRowExists()
+    {
+        Func<Task> act = async () =>
+            await CreateWriter(NewStoreMock().Object).DeleteDjAnalysisAsync(Guid.NewGuid());
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicQueryTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicQueryTests.cs
@@ -51,6 +51,7 @@ public class PluginMusicQueryTests : IDisposable
     private readonly Guid _needsStaleBaseTrackId = Guid.NewGuid();
     private readonly Guid _needsBaseFailedTrackId = Guid.NewGuid();
     private readonly Guid _needsPendingTrackId = Guid.NewGuid();
+    private readonly Guid _needsFailedCurrentTrackId = Guid.NewGuid();
 
     private readonly Guid _stemsWindowsMissingTrackId = Guid.NewGuid();
     private readonly Guid _stemsFullMissingFromWindowsTrackId = Guid.NewGuid();
@@ -197,7 +198,8 @@ public class PluginMusicQueryTests : IDisposable
             new Track { Id = _needsOlderVersionTrackId, Name = "Needs: older version" },
             new Track { Id = _needsStaleBaseTrackId, Name = "Needs: stale base" },
             new Track { Id = _needsBaseFailedTrackId, Name = "Needs: base failed" },
-            new Track { Id = _needsPendingTrackId, Name = "Needs: pending" }
+            new Track { Id = _needsPendingTrackId, Name = "Needs: pending" },
+            new Track { Id = _needsFailedCurrentTrackId, Name = "Needs: failed current" }
         );
 
         context.LibraryTrack.AddRange(
@@ -206,7 +208,8 @@ public class PluginMusicQueryTests : IDisposable
             new LibraryTrack { LibraryId = _djLibraryId, TrackId = _needsOlderVersionTrackId },
             new LibraryTrack { LibraryId = _djLibraryId, TrackId = _needsStaleBaseTrackId },
             new LibraryTrack { LibraryId = _djLibraryId, TrackId = _needsBaseFailedTrackId },
-            new LibraryTrack { LibraryId = _djLibraryId, TrackId = _needsPendingTrackId }
+            new LibraryTrack { LibraryId = _djLibraryId, TrackId = _needsPendingTrackId },
+            new LibraryTrack { LibraryId = _djLibraryId, TrackId = _needsFailedCurrentTrackId }
         );
 
         context.TrackAudioAnalysis.AddRange(
@@ -249,6 +252,13 @@ public class PluginMusicQueryTests : IDisposable
             new TrackAudioAnalysis
             {
                 TrackId = _needsPendingTrackId,
+                AnalyzerVersion = 1,
+                State = AudioAnalysisState.Ok,
+                AnalyzedAt = DateTime.UtcNow,
+            },
+            new TrackAudioAnalysis
+            {
+                TrackId = _needsFailedCurrentTrackId,
                 AnalyzerVersion = 1,
                 State = AudioAnalysisState.Ok,
                 AnalyzedAt = DateTime.UtcNow,
@@ -296,6 +306,21 @@ public class PluginMusicQueryTests : IDisposable
                 DjAnalyzerVersion = CurrentDjVersion,
                 BaseAnalyzerVersion = 1,
                 State = AudioAnalysisState.Pending,
+                AnalyzedAt = DateTime.UtcNow,
+            },
+            // Version and base both match, but the run itself failed. This is
+            // the terminal case: retried only when the DJ analyzer version
+            // changes, never just because the sweep runs again — a bare
+            // "!= Pending" -> "== Ok" simplification here would silently
+            // reopen endless re-analysis of tracks that will never succeed.
+            new TrackDjAnalysis
+            {
+                TrackId = _needsFailedCurrentTrackId,
+                ProducerPluginId = Ulid.NewUlid(),
+                DjAnalyzerVersion = CurrentDjVersion,
+                BaseAnalyzerVersion = 1,
+                State = AudioAnalysisState.Failed,
+                FailureReason = "vocal detector produced no regions",
                 AnalyzedAt = DateTime.UtcNow,
             }
         );
@@ -607,9 +632,10 @@ public class PluginMusicQueryTests : IDisposable
     public async Task GetDjAnalysisAsync_ReturnsOkRowsWithTypedLists()
     {
         IReadOnlyList<PluginTrackDjAnalysis> analysis = await CreateQuery()
-            .GetDjAnalysisAsync([_djOkTrackId, _djFailedTrackId]);
+            .GetDjAnalysisAsync([_djOkTrackId, _djFailedTrackId, _unanalyzedTrackId]);
 
-        // The Failed row never comes back, even though it was asked for.
+        // Neither the Failed row nor the track with no DJ row at all comes
+        // back, even though both were asked for.
         analysis.Should().ContainSingle();
         PluginTrackDjAnalysis row = analysis[0];
 
@@ -662,6 +688,10 @@ public class PluginMusicQueryTests : IDisposable
             ]);
         needing.Should().NotContain(_needsCurrentTrackId);
         needing.Should().NotContain(_needsBaseFailedTrackId);
+        // A Failed DJ row at the current DjAnalyzerVersion and a matching
+        // BaseAnalyzerVersion is a terminal verdict, not stale work: it must
+        // not be picked up again just because it isn't Ok.
+        needing.Should().NotContain(_needsFailedCurrentTrackId);
     }
 
     [Fact]
@@ -685,6 +715,9 @@ public class PluginMusicQueryTests : IDisposable
             take: 1000
         );
         windowsMissing.Should().Contain(_stemsWindowsMissingTrackId);
+        // A Full stem satisfies every required window by itself: a track
+        // with only a Full stem is not missing anything under Windows either.
+        windowsMissing.Should().NotContain(_stemsFullPresentTrackId);
 
         IReadOnlyList<Guid> fullMissing = await query.GetTracksMissingStemsAsync(
             _djLibraryId.ToString(),
@@ -729,6 +762,22 @@ public class PluginMusicQueryTests : IDisposable
             .GetTracksNeedingDjAnalysisAsync(
                 _djLibraryId.ToString(),
                 CurrentDjVersion,
+                skip: 0,
+                take: 0
+            );
+
+        clamped.Should().HaveCount(1);
+    }
+
+    /// <summary>Same clamp, the other library-scoped "needs" method.</summary>
+    [Fact]
+    public async Task Take_IsClamped_ForGetTracksMissingStemsAsyncToo()
+    {
+        IReadOnlyList<Guid> clamped = await CreateQuery()
+            .GetTracksMissingStemsAsync(
+                _djLibraryId.ToString(),
+                StemProducerVersion,
+                PluginStemPolicy.Full,
                 skip: 0,
                 take: 0
             );

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicQueryTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicQueryTests.cs
@@ -12,6 +12,7 @@
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NoMercy.Data.Plugins;
 using NoMercy.Database;
@@ -23,12 +24,37 @@ namespace NoMercy.Tests.Repositories.Plugins;
 
 public class PluginMusicQueryTests : IDisposable
 {
+    // The DJ analyzer version the "needs analysis" tests ask for. Rows built
+    // against an older or newer value exercise the version-mismatch branches.
+    private const int CurrentDjVersion = 3;
+    private const string StemProducerVersion = "spleeter-2stems-f16@v1.0.41";
+
     private readonly SqliteConnection _connection;
     private readonly DbContextOptions<MediaContext> _options;
     private readonly Ulid _libraryId = Ulid.NewUlid();
+
+    // A second library, kept separate from _libraryId, so seeding the DJ and
+    // stem fixtures below never changes what GetTracksAsync sees for
+    // _libraryId — those counts are asserted exactly by the existing tests.
+    private readonly Ulid _djLibraryId = Ulid.NewUlid();
+
     private readonly Guid _analyzedTrackId = Guid.NewGuid();
     private readonly Guid _unanalyzedTrackId = Guid.NewGuid();
     private readonly Guid _failedTrackId = Guid.NewGuid();
+
+    private readonly Guid _djOkTrackId = Guid.NewGuid();
+    private readonly Guid _djFailedTrackId = Guid.NewGuid();
+
+    private readonly Guid _needsNoRowTrackId = Guid.NewGuid();
+    private readonly Guid _needsCurrentTrackId = Guid.NewGuid();
+    private readonly Guid _needsOlderVersionTrackId = Guid.NewGuid();
+    private readonly Guid _needsStaleBaseTrackId = Guid.NewGuid();
+    private readonly Guid _needsBaseFailedTrackId = Guid.NewGuid();
+    private readonly Guid _needsPendingTrackId = Guid.NewGuid();
+
+    private readonly Guid _stemsWindowsMissingTrackId = Guid.NewGuid();
+    private readonly Guid _stemsFullMissingFromWindowsTrackId = Guid.NewGuid();
+    private readonly Guid _stemsFullPresentTrackId = Guid.NewGuid();
 
     public PluginMusicQueryTests()
     {
@@ -46,11 +72,18 @@ public class PluginMusicQueryTests : IDisposable
         using MediaContext context = new(_options);
         context.Database.EnsureCreated();
 
-        context.Libraries.Add(
+        context.Libraries.AddRange(
             new Library
             {
                 Id = _libraryId,
                 Title = "Music",
+                Type = "music",
+                AnalyzeAudio = true,
+            },
+            new Library
+            {
+                Id = _djLibraryId,
+                Title = "Dj Music",
                 Type = "music",
                 AnalyzeAudio = true,
             }
@@ -105,8 +138,325 @@ public class PluginMusicQueryTests : IDisposable
             }
         );
 
+        SeedDjAnalysisFixture(context);
+        SeedNeedsDjAnalysisFixture(context);
+        SeedStemsFixture(context);
+
         context.SaveChanges();
     }
+
+    /// <summary>Tracks for <c>GetDjAnalysisAsync</c>: one Ok row with every JSON
+    /// column populated, one Failed row that must never come back.</summary>
+    private void SeedDjAnalysisFixture(MediaContext context)
+    {
+        context.Tracks.AddRange(
+            new Track { Id = _djOkTrackId, Name = "Dj Ok" },
+            new Track { Id = _djFailedTrackId, Name = "Dj Failed" }
+        );
+
+        context.TrackDjAnalysis.AddRange(
+            new TrackDjAnalysis
+            {
+                TrackId = _djOkTrackId,
+                ProducerPluginId = Ulid.NewUlid(),
+                DjAnalyzerVersion = CurrentDjVersion,
+                BaseAnalyzerVersion = 1,
+                State = AudioAnalysisState.Ok,
+                DownbeatIndex = 0,
+                BeatsPerBar = 4,
+                PhraseLengthBars = 8,
+                PhraseStartsMs = "[0,32000,64000]",
+                VocalRegionsMs = "[[1000,5000],[9000,15000]]",
+                BarEnergy = "[-20.5,-18.2,-14.0]",
+                CuePoints = """[{"ms":1000,"type":"intro","direction":"mixIn","score":0.9}]""",
+                Chords = """[{"ms":0,"chord":"Am"}]""",
+                AnalyzedAt = DateTime.UtcNow,
+            },
+            new TrackDjAnalysis
+            {
+                TrackId = _djFailedTrackId,
+                ProducerPluginId = Ulid.NewUlid(),
+                DjAnalyzerVersion = CurrentDjVersion,
+                BaseAnalyzerVersion = 1,
+                State = AudioAnalysisState.Failed,
+                FailureReason = "vocal detector produced no regions",
+                AnalyzedAt = DateTime.UtcNow,
+            }
+        );
+    }
+
+    /// <summary>
+    /// Tracks for <c>GetTracksNeedingDjAnalysisAsync</c>, one per branch of the
+    /// "does this track already have a current DJ row" rule.
+    /// </summary>
+    private void SeedNeedsDjAnalysisFixture(MediaContext context)
+    {
+        context.Tracks.AddRange(
+            new Track { Id = _needsNoRowTrackId, Name = "Needs: no row" },
+            new Track { Id = _needsCurrentTrackId, Name = "Needs: current" },
+            new Track { Id = _needsOlderVersionTrackId, Name = "Needs: older version" },
+            new Track { Id = _needsStaleBaseTrackId, Name = "Needs: stale base" },
+            new Track { Id = _needsBaseFailedTrackId, Name = "Needs: base failed" },
+            new Track { Id = _needsPendingTrackId, Name = "Needs: pending" }
+        );
+
+        context.LibraryTrack.AddRange(
+            new LibraryTrack { LibraryId = _djLibraryId, TrackId = _needsNoRowTrackId },
+            new LibraryTrack { LibraryId = _djLibraryId, TrackId = _needsCurrentTrackId },
+            new LibraryTrack { LibraryId = _djLibraryId, TrackId = _needsOlderVersionTrackId },
+            new LibraryTrack { LibraryId = _djLibraryId, TrackId = _needsStaleBaseTrackId },
+            new LibraryTrack { LibraryId = _djLibraryId, TrackId = _needsBaseFailedTrackId },
+            new LibraryTrack { LibraryId = _djLibraryId, TrackId = _needsPendingTrackId }
+        );
+
+        context.TrackAudioAnalysis.AddRange(
+            new TrackAudioAnalysis
+            {
+                TrackId = _needsNoRowTrackId,
+                AnalyzerVersion = 1,
+                State = AudioAnalysisState.Ok,
+                AnalyzedAt = DateTime.UtcNow,
+            },
+            new TrackAudioAnalysis
+            {
+                TrackId = _needsCurrentTrackId,
+                AnalyzerVersion = 1,
+                State = AudioAnalysisState.Ok,
+                AnalyzedAt = DateTime.UtcNow,
+            },
+            new TrackAudioAnalysis
+            {
+                TrackId = _needsOlderVersionTrackId,
+                AnalyzerVersion = 1,
+                State = AudioAnalysisState.Ok,
+                AnalyzedAt = DateTime.UtcNow,
+            },
+            new TrackAudioAnalysis
+            {
+                TrackId = _needsStaleBaseTrackId,
+                AnalyzerVersion = 1,
+                State = AudioAnalysisState.Ok,
+                AnalyzedAt = DateTime.UtcNow,
+            },
+            new TrackAudioAnalysis
+            {
+                TrackId = _needsBaseFailedTrackId,
+                AnalyzerVersion = 1,
+                State = AudioAnalysisState.Failed,
+                FailureReason = "unreadable file",
+                AnalyzedAt = DateTime.UtcNow,
+            },
+            new TrackAudioAnalysis
+            {
+                TrackId = _needsPendingTrackId,
+                AnalyzerVersion = 1,
+                State = AudioAnalysisState.Ok,
+                AnalyzedAt = DateTime.UtcNow,
+            }
+        );
+
+        context.TrackDjAnalysis.AddRange(
+            // _needsCurrentTrackId: version and base both match, Ok — already
+            // has a current DJ row, so it must be the one track excluded.
+            new TrackDjAnalysis
+            {
+                TrackId = _needsCurrentTrackId,
+                ProducerPluginId = Ulid.NewUlid(),
+                DjAnalyzerVersion = CurrentDjVersion,
+                BaseAnalyzerVersion = 1,
+                State = AudioAnalysisState.Ok,
+                AnalyzedAt = DateTime.UtcNow,
+            },
+            // Older DJ analyzer than requested: stale, needs redoing.
+            new TrackDjAnalysis
+            {
+                TrackId = _needsOlderVersionTrackId,
+                ProducerPluginId = Ulid.NewUlid(),
+                DjAnalyzerVersion = CurrentDjVersion - 1,
+                BaseAnalyzerVersion = 1,
+                State = AudioAnalysisState.Ok,
+                AnalyzedAt = DateTime.UtcNow,
+            },
+            // Current DJ analyzer, but computed from a base analysis that has
+            // since moved on to a newer AnalyzerVersion than this row records.
+            new TrackDjAnalysis
+            {
+                TrackId = _needsStaleBaseTrackId,
+                ProducerPluginId = Ulid.NewUlid(),
+                DjAnalyzerVersion = CurrentDjVersion,
+                BaseAnalyzerVersion = 99,
+                State = AudioAnalysisState.Ok,
+                AnalyzedAt = DateTime.UtcNow,
+            },
+            // A run that started and never finished.
+            new TrackDjAnalysis
+            {
+                TrackId = _needsPendingTrackId,
+                ProducerPluginId = Ulid.NewUlid(),
+                DjAnalyzerVersion = CurrentDjVersion,
+                BaseAnalyzerVersion = 1,
+                State = AudioAnalysisState.Pending,
+                AnalyzedAt = DateTime.UtcNow,
+            }
+        );
+    }
+
+    /// <summary>Tracks for <c>GetTracksMissingStemsAsync</c> and <c>GetStemsAsync</c>.</summary>
+    private void SeedStemsFixture(MediaContext context)
+    {
+        context.Tracks.AddRange(
+            new Track { Id = _stemsWindowsMissingTrackId, Name = "Stems: windows missing" },
+            new Track
+            {
+                Id = _stemsFullMissingFromWindowsTrackId,
+                Name = "Stems: full missing from windows",
+            },
+            new Track { Id = _stemsFullPresentTrackId, Name = "Stems: full present" }
+        );
+
+        context.LibraryTrack.AddRange(
+            new LibraryTrack { LibraryId = _djLibraryId, TrackId = _stemsWindowsMissingTrackId },
+            new LibraryTrack
+            {
+                LibraryId = _djLibraryId,
+                TrackId = _stemsFullMissingFromWindowsTrackId,
+            },
+            new LibraryTrack { LibraryId = _djLibraryId, TrackId = _stemsFullPresentTrackId }
+        );
+
+        // Every one of these tracks has an Ok DJ row: GetTracksMissingStemsAsync
+        // only ever asks about stems for a track the DJ analyzer already ran on.
+        context.TrackDjAnalysis.AddRange(
+            new TrackDjAnalysis
+            {
+                TrackId = _stemsWindowsMissingTrackId,
+                ProducerPluginId = Ulid.NewUlid(),
+                DjAnalyzerVersion = CurrentDjVersion,
+                BaseAnalyzerVersion = 1,
+                State = AudioAnalysisState.Ok,
+                AnalyzedAt = DateTime.UtcNow,
+            },
+            new TrackDjAnalysis
+            {
+                TrackId = _stemsFullMissingFromWindowsTrackId,
+                ProducerPluginId = Ulid.NewUlid(),
+                DjAnalyzerVersion = CurrentDjVersion,
+                BaseAnalyzerVersion = 1,
+                State = AudioAnalysisState.Ok,
+                AnalyzedAt = DateTime.UtcNow,
+            },
+            new TrackDjAnalysis
+            {
+                TrackId = _stemsFullPresentTrackId,
+                ProducerPluginId = Ulid.NewUlid(),
+                DjAnalyzerVersion = CurrentDjVersion,
+                BaseAnalyzerVersion = 1,
+                State = AudioAnalysisState.Ok,
+                AnalyzedAt = DateTime.UtcNow,
+            }
+        );
+
+        string mixInKey = NewStorageKey();
+        string mixOutKey = NewStorageKey();
+        string windowsMixInKey = NewStorageKey();
+        string fullVocalsKey = NewStorageKey();
+        string fullAccompanimentKey = NewStorageKey();
+
+        context.DerivedAudio.AddRange(
+            NewDerivedAudioRow(windowsMixInKey),
+            NewDerivedAudioRow(mixInKey),
+            NewDerivedAudioRow(mixOutKey),
+            NewDerivedAudioRow(fullVocalsKey),
+            NewDerivedAudioRow(fullAccompanimentKey)
+        );
+
+        context.TrackStems.AddRange(
+            // Windows policy needs MixIn + MixOut; this track has only MixIn.
+            new TrackStem
+            {
+                Id = Ulid.NewUlid(),
+                TrackId = _stemsWindowsMissingTrackId,
+                Kind = "vocals",
+                Coverage = StemCoverage.MixIn,
+                WindowStartMs = 0,
+                WindowEndMs = 45000,
+                Format = "opus",
+                SampleRate = 48000,
+                StorageKey = windowsMixInKey,
+                ProducerVersion = StemProducerVersion,
+                CreatedAt = DateTime.UtcNow,
+            },
+            // Full policy needs a Full stem; this track has both windows but no
+            // Full row, so Full policy still calls it missing.
+            new TrackStem
+            {
+                Id = Ulid.NewUlid(),
+                TrackId = _stemsFullMissingFromWindowsTrackId,
+                Kind = "vocals",
+                Coverage = StemCoverage.MixIn,
+                WindowStartMs = 0,
+                WindowEndMs = 45000,
+                Format = "opus",
+                SampleRate = 48000,
+                StorageKey = mixInKey,
+                ProducerVersion = StemProducerVersion,
+                CreatedAt = DateTime.UtcNow,
+            },
+            new TrackStem
+            {
+                Id = Ulid.NewUlid(),
+                TrackId = _stemsFullMissingFromWindowsTrackId,
+                Kind = "vocals",
+                Coverage = StemCoverage.MixOut,
+                WindowStartMs = 135000,
+                WindowEndMs = 180000,
+                Format = "opus",
+                SampleRate = 48000,
+                StorageKey = mixOutKey,
+                ProducerVersion = StemProducerVersion,
+                CreatedAt = DateTime.UtcNow,
+            },
+            // Full policy is satisfied: a Full vocals stem exists. A second,
+            // different-kind stem proves GetStemsAsync returns every kind.
+            new TrackStem
+            {
+                Id = Ulid.NewUlid(),
+                TrackId = _stemsFullPresentTrackId,
+                Kind = "vocals",
+                Coverage = StemCoverage.Full,
+                Format = "opus",
+                SampleRate = 48000,
+                StorageKey = fullVocalsKey,
+                ProducerVersion = StemProducerVersion,
+                CreatedAt = DateTime.UtcNow,
+            },
+            new TrackStem
+            {
+                Id = Ulid.NewUlid(),
+                TrackId = _stemsFullPresentTrackId,
+                Kind = "accompaniment",
+                Coverage = StemCoverage.Full,
+                Format = "opus",
+                SampleRate = 48000,
+                StorageKey = fullAccompanimentKey,
+                ProducerVersion = StemProducerVersion,
+                CreatedAt = DateTime.UtcNow,
+            }
+        );
+    }
+
+    private static DerivedAudio NewDerivedAudioRow(string key) =>
+        new()
+        {
+            Key = key,
+            ContentType = "audio/opus",
+            Bytes = 10,
+            CreatedAt = DateTime.UtcNow,
+            LastUsedAt = DateTime.UtcNow,
+        };
+
+    private static string NewStorageKey() =>
+        Guid.NewGuid().ToString("N") + Guid.NewGuid().ToString("N");
 
     public void Dispose()
     {
@@ -121,7 +471,7 @@ public class PluginMusicQueryTests : IDisposable
             .Setup(x => x.CreateDbContextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => new(_options));
 
-        return new PluginMusicQuery(factory.Object);
+        return new PluginMusicQuery(factory.Object, NullLogger<PluginMusicQuery>.Instance);
     }
 
     [Fact]
@@ -251,5 +601,138 @@ public class PluginMusicQueryTests : IDisposable
         IReadOnlyList<PluginTrackAudioAnalysis> analysis = await CreateQuery().GetAnalysisAsync([]);
 
         analysis.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetDjAnalysisAsync_ReturnsOkRowsWithTypedLists()
+    {
+        IReadOnlyList<PluginTrackDjAnalysis> analysis = await CreateQuery()
+            .GetDjAnalysisAsync([_djOkTrackId, _djFailedTrackId]);
+
+        // The Failed row never comes back, even though it was asked for.
+        analysis.Should().ContainSingle();
+        PluginTrackDjAnalysis row = analysis[0];
+
+        row.TrackId.Should().Be(_djOkTrackId);
+        row.DjAnalyzerVersion.Should().Be(CurrentDjVersion);
+        row.BaseAnalyzerVersion.Should().Be(1);
+        row.DownbeatIndex.Should().Be(0);
+        row.BeatsPerBar.Should().Be(4);
+        row.PhraseLengthBars.Should().Be(8);
+        row.PhraseStartsMs.Should().Equal(0, 32000, 64000);
+        row.VocalRegionsMs.Should().BeEquivalentTo([new[] { 1000, 5000 }, new[] { 9000, 15000 }]);
+        row.BarEnergy.Should().Equal(-20.5, -18.2, -14.0);
+
+        row.CuePoints.Should().ContainSingle();
+        row.CuePoints[0].Ms.Should().Be(1000);
+        row.CuePoints[0].Type.Should().Be("intro");
+        row.CuePoints[0].Direction.Should().Be("mixIn");
+        row.CuePoints[0].Score.Should().Be(0.9);
+
+        row.Chords.Should().ContainSingle();
+        row.Chords[0].Ms.Should().Be(0);
+        row.Chords[0].Chord.Should().Be("Am");
+    }
+
+    [Fact]
+    public async Task GetStemsAsync_ReturnsStemsOfTheGivenTracks()
+    {
+        IReadOnlyList<PluginTrackStem> stems = await CreateQuery()
+            .GetStemsAsync([_stemsFullPresentTrackId]);
+
+        stems.Should().HaveCount(2);
+        stems.Should().OnlyContain(stem => stem.TrackId == _stemsFullPresentTrackId);
+        stems.Should().OnlyContain(stem => stem.Coverage == PluginStemCoverage.Full);
+        stems.Select(stem => stem.Kind).Should().BeEquivalentTo(["vocals", "accompaniment"]);
+    }
+
+    [Fact]
+    public async Task GetTracksNeedingDjAnalysisAsync_ReturnsTracksWithABaseVerdictAndNoCurrentDjRow()
+    {
+        IReadOnlyList<Guid> needing = await CreateQuery()
+            .GetTracksNeedingDjAnalysisAsync(_djLibraryId.ToString(), CurrentDjVersion, take: 1000);
+
+        needing
+            .Should()
+            .Contain([
+                _needsNoRowTrackId,
+                _needsOlderVersionTrackId,
+                _needsStaleBaseTrackId,
+                _needsPendingTrackId,
+            ]);
+        needing.Should().NotContain(_needsCurrentTrackId);
+        needing.Should().NotContain(_needsBaseFailedTrackId);
+    }
+
+    [Fact]
+    public async Task GetTracksNeedingDjAnalysisAsync_BadLibraryIdReturnsEmpty()
+    {
+        IReadOnlyList<Guid> needing = await CreateQuery()
+            .GetTracksNeedingDjAnalysisAsync("not-a-valid-ulid", CurrentDjVersion);
+
+        needing.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetTracksMissingStemsAsync_HonoursThePolicy()
+    {
+        PluginMusicQuery query = CreateQuery();
+
+        IReadOnlyList<Guid> windowsMissing = await query.GetTracksMissingStemsAsync(
+            _djLibraryId.ToString(),
+            StemProducerVersion,
+            PluginStemPolicy.Windows,
+            take: 1000
+        );
+        windowsMissing.Should().Contain(_stemsWindowsMissingTrackId);
+
+        IReadOnlyList<Guid> fullMissing = await query.GetTracksMissingStemsAsync(
+            _djLibraryId.ToString(),
+            StemProducerVersion,
+            PluginStemPolicy.Full,
+            take: 1000
+        );
+        fullMissing.Should().Contain(_stemsFullMissingFromWindowsTrackId);
+        fullMissing.Should().NotContain(_stemsFullPresentTrackId);
+
+        IReadOnlyList<Guid> onDemand = await query.GetTracksMissingStemsAsync(
+            _djLibraryId.ToString(),
+            StemProducerVersion,
+            PluginStemPolicy.OnDemand,
+            take: 1000
+        );
+        onDemand.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetTracksMissingStemsAsync_BadLibraryIdReturnsEmpty()
+    {
+        IReadOnlyList<Guid> missing = await CreateQuery()
+            .GetTracksMissingStemsAsync(
+                "not-a-valid-ulid",
+                StemProducerVersion,
+                PluginStemPolicy.Full
+            );
+
+        missing.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// <paramref name="take" /> is clamped to at least 1 the same way
+    /// <see cref="PluginMusicQuery.GetTracksAsync" /> clamps it, so a caller
+    /// passing 0 still gets one row rather than an empty page.
+    /// </summary>
+    [Fact]
+    public async Task Take_IsClamped_LikeGetTracksAsync()
+    {
+        IReadOnlyList<Guid> clamped = await CreateQuery()
+            .GetTracksNeedingDjAnalysisAsync(
+                _djLibraryId.ToString(),
+                CurrentDjVersion,
+                skip: 0,
+                take: 0
+            );
+
+        clamped.Should().HaveCount(1);
     }
 }

--- a/tests/NoMercy.Tests.Service/Jobs/DerivedAudioEvictionCronJobTests.cs
+++ b/tests/NoMercy.Tests.Service/Jobs/DerivedAudioEvictionCronJobTests.cs
@@ -1,0 +1,73 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using NoMercy.MediaProcessing.DerivedAudio;
+using NoMercy.NmSystem.Configuration;
+using NoMercy.Service.Jobs;
+using NoMercyQueue.Core;
+
+namespace NoMercy.Tests.Service.Jobs;
+
+/// <summary>
+/// The hourly counterpart to <see cref="DerivedAudioStore" />'s eviction
+/// policy: this job's whole job is calling it with the cap the dashboard
+/// configured and the fixed 24-hour grace window, once per run.
+/// </summary>
+public class DerivedAudioEvictionCronJobTests
+{
+    [Fact]
+    public async Task ExecuteAsync_CallsEvictAsync_WithConfiguredCapAndTwentyFourHourGrace_ExactlyOnce()
+    {
+        long originalCap = RuntimeServerSettings.Current.DerivedAudioCapBytes;
+        RuntimeServerSettings.Current.DerivedAudioCapBytes = 20L * 1024 * 1024 * 1024;
+        try
+        {
+            Mock<IDerivedAudioStore> store = new();
+            store
+                .Setup(s =>
+                    s.EvictAsync(
+                        It.IsAny<long>(),
+                        It.IsAny<TimeSpan>(),
+                        It.IsAny<CancellationToken>()
+                    )
+                )
+                .ReturnsAsync(0L);
+
+            DerivedAudioEvictionCronJob job = new(store.Object);
+
+            await job.ExecuteAsync(string.Empty);
+
+            store.Verify(
+                s =>
+                    s.EvictAsync(
+                        RuntimeServerSettings.Current.DerivedAudioCapBytes,
+                        TimeSpan.FromHours(24),
+                        It.IsAny<CancellationToken>()
+                    ),
+                Times.Once
+            );
+        }
+        finally
+        {
+            RuntimeServerSettings.Current.DerivedAudioCapBytes = originalCap;
+        }
+    }
+
+    [Fact]
+    public void CronExpression_IsHourly_AndJobNameIsSet()
+    {
+        Mock<IDerivedAudioStore> store = new();
+        DerivedAudioEvictionCronJob job = new(store.Object);
+
+        job.CronExpression.Should().Be(new CronExpressionBuilder().Hourly());
+        job.JobName.Should().Be("Derived Audio Eviction");
+    }
+}

--- a/tests/NoMercy.Tests.Service/Jobs/DjAnalysisQueryPlanTests.cs
+++ b/tests/NoMercy.Tests.Service/Jobs/DjAnalysisQueryPlanTests.cs
@@ -1,0 +1,177 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NoMercy.Database;
+using NoMercy.MediaProcessing.AudioAnalysis;
+
+namespace NoMercy.Tests.Service.Jobs;
+
+/// <summary>
+/// The automix sweep runs <see cref="DjAnalysisQueries.TracksNeedingDjAnalysis" />
+/// over the same one-row-per-track tables the base sweep does. An index that
+/// exists but is never chosen by the planner buys nothing, so this asks
+/// SQLite directly rather than trusting that the migration's indexes are used.
+/// <para>
+/// Unlike <see cref="AudioAnalysisQueries.TracksNeedingAnalysis" />, the DJ
+/// query orders its own result (the brief's given shape ends in
+/// <c>.OrderBy(trackId =&gt; trackId)</c>), so even a single, unpaged call
+/// plans as a co-routine feeding a temp b-tree. That is an accepted cost, the
+/// same one <c>AudioAnalysisQueryPlanTests</c> accepts for its paged case —
+/// what these tests hold to is that the two real tables are never scanned,
+/// only searched by index.
+/// </para>
+/// </summary>
+public class DjAnalysisQueryPlanTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<MediaContext> _options;
+
+    public DjAnalysisQueryPlanTests()
+    {
+        _connection = new("Data Source=:memory:");
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<MediaContext>().UseSqlite(_connection).Options;
+
+        using MediaContext context = new(_options);
+        context.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private string ExplainNeedsQuery()
+    {
+        using MediaContext context = new(_options);
+
+        return Explain(
+            DjAnalysisQueries
+                .TracksNeedingDjAnalysis(context, Ulid.NewUlid(), 1)
+                .Take(500)
+                .ToQueryString()
+        );
+    }
+
+    /// <summary>The query a paged host call actually issues: skip, then take.</summary>
+    private string ExplainPagedNeedsQuery()
+    {
+        using MediaContext context = new(_options);
+
+        return Explain(
+            DjAnalysisQueries
+                .TracksNeedingDjAnalysis(context, Ulid.NewUlid(), 1)
+                .Skip(500)
+                .Take(500)
+                .ToQueryString()
+        );
+    }
+
+    private string Explain(string sql)
+    {
+        // ToQueryString prefixes the statement with ".param set" lines; EXPLAIN
+        // wants the statement alone.
+        string statement = string.Join(
+            '\n',
+            sql.Split('\n').Where(line => !line.TrimStart().StartsWith(".param"))
+        );
+
+        using SqliteCommand command = _connection.CreateCommand();
+        command.CommandText = "EXPLAIN QUERY PLAN " + statement;
+
+        foreach (SqliteParameter parameter in ParametersFor(command.CommandText))
+        {
+            command.Parameters.Add(parameter);
+        }
+
+        List<string> rows = [];
+        using SqliteDataReader reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            rows.Add(reader.GetString(reader.GetOrdinal("detail")));
+        }
+
+        return string.Join('\n', rows);
+    }
+
+    private static IEnumerable<SqliteParameter> ParametersFor(string sql)
+    {
+        // Bind whatever the generated SQL asks for so EXPLAIN can prepare.
+        // Values do not affect the chosen plan.
+        return System
+            .Text.RegularExpressions.Regex.Matches(sql, @"@[A-Za-z_][A-Za-z0-9_]*")
+            .Select(match => match.Value)
+            .Distinct()
+            .Select(name => new SqliteParameter(name, 1));
+    }
+
+    /// <summary>
+    /// The real access path for both TrackDjAnalysis and TrackAudioAnalysis
+    /// (searched twice: once for the base verdict, once for the version that
+    /// produced the DJ row) is an indexed SEARCH, keyed on TrackId — the
+    /// primary key of both tables serves every one of them as a seek.
+    /// </summary>
+    [Fact]
+    public void NeedsQuery_ReachesTheAnalysisTablesByIndex()
+    {
+        string plan = ExplainNeedsQuery();
+
+        Assert.Contains("SEARCH t USING INDEX sqlite_autoindex_TrackAudioAnalysis_1", plan);
+        Assert.Contains("SEARCH t0 USING INDEX sqlite_autoindex_TrackDjAnalysis_1", plan);
+        Assert.Contains("SEARCH t1 USING INDEX sqlite_autoindex_TrackAudioAnalysis_1", plan);
+    }
+
+    /// <summary>
+    /// A scan here is the whole risk: one row per track, run by a sweep. The
+    /// only scan the plan may contain is of the co-routine's own ordered
+    /// output (<c>l0</c>) — an ephemeral table, not TrackDjAnalysis or
+    /// TrackAudioAnalysis.
+    /// </summary>
+    [Fact]
+    public void NeedsQuery_NeverScansEitherAnalysisTable()
+    {
+        string plan = ExplainNeedsQuery();
+
+        Assert.DoesNotContain("SCAN t0", plan);
+        Assert.DoesNotContain("SCAN t1", plan);
+        Assert.DoesNotContain("SCAN TrackDjAnalysis", plan);
+        Assert.DoesNotContain("SCAN TrackAudioAnalysis", plan);
+    }
+
+    [Fact]
+    public void NeedsQuery_ReachesTheLibraryJoinByIndex()
+    {
+        string plan = ExplainNeedsQuery();
+
+        Assert.Contains("SEARCH l USING COVERING INDEX sqlite_autoindex_LibraryTrack_1", plan);
+        Assert.DoesNotContain("SCAN LibraryTrack", plan);
+    }
+
+    [Fact]
+    public void PagedNeedsQuery_StillReachesEveryRealTableByIndex()
+    {
+        string plan = ExplainPagedNeedsQuery();
+
+        Assert.Contains("SEARCH l USING COVERING INDEX sqlite_autoindex_LibraryTrack_1", plan);
+        Assert.Contains("SEARCH t USING INDEX sqlite_autoindex_TrackAudioAnalysis_1", plan);
+        Assert.Contains("SEARCH t0 USING INDEX sqlite_autoindex_TrackDjAnalysis_1", plan);
+        Assert.Contains("SEARCH t1 USING INDEX sqlite_autoindex_TrackAudioAnalysis_1", plan);
+        Assert.DoesNotContain("SCAN t0", plan);
+        Assert.DoesNotContain("SCAN t1", plan);
+        Assert.DoesNotContain("SCAN LibraryTrack", plan);
+        Assert.DoesNotContain("SCAN TrackDjAnalysis", plan);
+        Assert.DoesNotContain("SCAN TrackAudioAnalysis", plan);
+    }
+}


### PR DESCRIPTION
## Why

The automix plugin needs a durable, versioned record per track that holds what a transition planner reads: the beat grid the server already measures, plus the DJ stages the plugin computes (downbeat, phrases, vocal activity, per-bar energy, cue points, chords) and where its stems live. The design settled with the owner puts the DJ stages in the plugin and the storage in the server (spec: `docs/superpowers/specs/2026-09-10-analysis-record-design.md` in nomercy-automix-plugin). This is the server slice.

## What

- **Tables** (migration `AnalysisRecord`): `TrackDjAnalysis` (one row per track, written by a plugin, its own `DjAnalyzerVersion` plus the `BaseAnalyzerVersion` it was computed against, lists as JSON text), `TrackStem` (one row per track, kind, coverage and producer, pointing at a content key), `DerivedAudio` (the register of the derived-audio store). Deleting a track cascades to both; evicting a file cascades to the stems that pointed at it. Upgrade path replayed in a test against a real SQLite file.
- **Derived-audio store** under `cache/derived/<key[0..2]>/<key>`: content-addressed (sha256), concurrent puts of the same content share one file and one row, a temp-file sweep and an orphan sweep, LRU eviction by `LastUsedAt` under a dashboard cap (`derived_audio_cap_gb`, default 50) with a 24-hour grace, applied hourly by `DerivedAudioEvictionCronJob`. Keys are validated (64 lower-case hex) before they reach the filesystem.
- **Event** `TrackAudioAnalysisCompletedEvent { TrackId, LibraryIds, AnalyzerVersion, State }` published by `MusicAnalysisJob.Persist` for Ok and Failed.
- **Plugin contracts** (ABI 10.2, additive): `IPluginAudioTools` (run a filter graph on a track or a derived file; split stems into the store and the register; one ffmpeg per plugin; windows as input options so both stems agree), `IPluginDerivedAudio`, `IPluginMusicAnalysisWriter` (validated upserts, refusals in words), gated by the hooks `audioTools`, `derivedAudio`, `musicAnalysisWrite`; four DJ read members on `IPluginMusicQuery` including the two "needs" queries (DJ record missing or stale; stems missing under a retention policy). Every contract method refuses in words and never throws across the plugin boundary.
- **DI**: `PluginServiceCollectionExtensions` built `PluginContextFactory` with the nine required arguments only, so no optional facade (`IPluginEncoder`, `IPluginJobs`, `IPluginStorage`, `IPluginMusicQuery`) ever reached a plugin through DI. Fixed here with a test through the real registration.
- **API**: the per-track analysis response gains `dj` and `stems`; the dashboard status gains `dj_analyzed`, `dj_failed`, `stems_bytes`. No new routes.
- **Docs**: `docs/plugins/music-analysis.md` for plugin authors (hooks, examples, refusal strings, queries, policies, versions, the event); `docs/README.md` as a docs index.

## Process

Twelve tasks, each implemented by a fresh subagent and reviewed for spec compliance and quality, a whole-branch review at the end, one fix wave and a scoped re-review. Every decision taken along the way is in the plan's ledger in the plugin repository.

## Tests

Build 0 warnings. Database 261, MediaProcessing 1066, Repositories 612, Plugins 578, Service 200, Api 2337, all green locally; csharpier clean. `Tests.Encoder` not run here (17 ffmpeg integration cases need the NoMercy build).

## Operator notes

- The migration runs at start-up as usual; the derived folder is created with the other cache folders.
- The cap setting appears in the dashboard configuration as `derived_audio_cap_gb`; nothing is stored under `cache/derived` until a plugin with the new hooks runs.
- Existing plugins are unaffected (additive ABI); a plugin that declares none of the new hooks sees no change except that `Music`, `Encoder`, `Storage` and `Jobs` now actually arrive when declared.

## Follow-ups (nomercy-automix-plugin issues)

R1.2 builds the plugin's stages on these contracts. The stems eviction sweep and the keyed-lock dictionary have deferred minors recorded in the plan's ledger; none block merge per the final review.
