### PR TITLE
fix(music): close the derived-audio store's edge cases and the review's follow-ups (#46)

### DIFF
--- a/docs/plugins/music-analysis.md
+++ b/docs/plugins/music-analysis.md
@@ -375,6 +375,8 @@ Checked in this order — the first failing check is the one you get back:
 | `"vocal_regions_ms entry {index} must be [start, end] with start < end"` | one entry of `vocal_regions_ms` was not a pair, or its start was not before its end | a region is exactly two values; drop the malformed one or fix the bounds the detector produced |
 | `"phrase_starts_ms must be ascending"` | the phrase boundaries were not strictly increasing | sort them before writing; two phrases cannot share a millisecond |
 | `"{field} exceeds 64 kB"` | one JSON column (`phrase_starts_ms`, `vocal_regions_ms`, `bar_energy`, `cue_points` or `chords`, checked in that order) serialized past the 64 kB column limit | this record is meant to hold bars and phrases, not a sample-accurate trace — keep arrays proportionate to track length |
+| `"the DJ record for track {id} was written concurrently; retry"` | another sweep upserted the same track at the same moment and its row is the one stored | run the track again |
+| `"the DJ record for track {id} could not be stored: {exception}"` | the write failed for a reason of its own and no row is there to explain it as a race | not a retry: the server logged the exception, so read its log first |
 
 Skipped entirely, rather than refused, when the track's duration is unknown:
 the millisecond-range check. A partial base row is normal, not a defect.
@@ -385,11 +387,14 @@ the millisecond-range check. A partial base row is normal, not a defect.
 |---|---|---|
 | `"track {id} does not exist"` | unknown `TrackId` | drop the row |
 | `"storage key {key} is not in the derived store"` | the stem was never actually written, or the key is wrong | write it through `IPluginDerivedAudio.PutAsync` (or `SplitStemsAsync`) first |
-| `"stem format {format} does not match the stored content type {contentType}"` | the row would claim a format the stored file is not (`opus` goes with `audio/ogg`, `flac` with `audio/flac`) | register the stem under the format the file was actually put with — a client is handed the file by that content type |
+| `"stem format {format} does not match the stored content type {contentType}"` | the row would claim a format the stored file is not (`opus` goes with `audio/ogg` or `audio/opus`, `flac` with `audio/flac`) | register the stem under the format the file was actually put with — a client is handed the file by that content type |
 | `"full coverage stems must not specify a window"` | `Coverage.Full` was combined with a non-null `WindowStartMs` or `WindowEndMs` | leave both null for `Full` |
 | `"windowed stems must specify both window_start_ms and window_end_ms"` | `MixIn` / `MixOut` was combined with a null window bound | set both, in milliseconds from the start of the track |
 | `"window_start_ms must be less than window_end_ms"` | the window was empty or backwards | fix the bounds — a windowed stem always covers a positive span |
 | `"stem {kind}/{coverage} for track {id} was written concurrently; retry"` | another sweep registered the same stem at the same moment, pointing at a different file | run the track again; a concurrent write of the *same* key is accepted silently, so this only appears when the two disagree |
+| `"stem {kind}/{coverage} for track {id} could not be stored: {exception}"` | the write failed for a reason of its own — a foreign key, a column constraint, the disk — and no row is there to explain it as a race | not a retry: the server logged the exception, so read its log before writing the stem again |
+| `"stems must not be null"` | `RegisterStemsAsync` was handed a null list | pass an empty list, or the stems you meant to write |
+| `"stems contains the same stem twice: {kind}/{coverage}"` | two entries of one batch address the same register row (same track, kind, coverage and producer version) | one row per (track, kind, coverage, producer version); drop the duplicate before calling |
 
 ### `IPluginMusicAnalysisWriter.MarkFailedAsync`
 

--- a/docs/plugins/music-analysis.md
+++ b/docs/plugins/music-analysis.md
@@ -385,6 +385,7 @@ the millisecond-range check. A partial base row is normal, not a defect.
 |---|---|---|
 | `"track {id} does not exist"` | unknown `TrackId` | drop the row |
 | `"storage key {key} is not in the derived store"` | the stem was never actually written, or the key is wrong | write it through `IPluginDerivedAudio.PutAsync` (or `SplitStemsAsync`) first |
+| `"stem format {format} does not match the stored content type {contentType}"` | the row would claim a format the stored file is not (`opus` goes with `audio/ogg`, `flac` with `audio/flac`) | register the stem under the format the file was actually put with — a client is handed the file by that content type |
 | `"full coverage stems must not specify a window"` | `Coverage.Full` was combined with a non-null `WindowStartMs` or `WindowEndMs` | leave both null for `Full` |
 | `"windowed stems must specify both window_start_ms and window_end_ms"` | `MixIn` / `MixOut` was combined with a null window bound | set both, in milliseconds from the start of the track |
 | `"window_start_ms must be less than window_end_ms"` | the window was empty or backwards | fix the bounds — a windowed stem always covers a positive span |
@@ -398,6 +399,23 @@ the millisecond-range check. A partial base row is normal, not a defect.
 
 `DeleteDjAnalysisAsync` never refuses; deleting a row that is not there is a
 no-op.
+
+## How the host scopes a facade
+
+Three shapes, one rule each — how much state a facade holds decides how long
+it lives:
+
+- **No per-plugin state at all** — one shared singleton for every plugin.
+  `PluginDerivedAudio` is this: it forwards to the server's own store and
+  holds nothing of its own.
+- **Stamps the plugin id but holds no state** — built per call by a factory,
+  so nothing has to be cached or invalidated.
+  `PluginMusicAnalysisWriterFactory` is this: every write is stamped with the
+  calling plugin's id, and the writer itself is cheap to build.
+- **Holds per-plugin state** — cached per plugin id by its factory, because a
+  guard a caller can get a fresh copy of guards nothing.
+  `PluginAudioToolsFactory` is this: the one-ffmpeg-at-a-time semaphore is a
+  field on the instance.
 
 ## The event to subscribe to
 

--- a/docs/plugins/music-analysis.md
+++ b/docs/plugins/music-analysis.md
@@ -11,7 +11,10 @@ where a file lives on disk, where ffmpeg is installed, or how to shell out to
 it safely — the host mediates all three.
 
 Every type mentioned here lives in `NoMercy.Plugins.Abstractions` (ABI 10.2 or
-later; see `PluginAbi.Current`).
+later; see `PluginAbi.Current`). `IPluginMusicAnalysisWriter.RegisterStemsAsync`
+joined 10.2 after the rest, with a default implementation rather than a version
+bump: an implementer written before it keeps compiling, and only the host's own
+override writes the stems all-or-nothing.
 
 ## Declaring the hooks
 
@@ -209,7 +212,7 @@ it, since the server can bump its own analyzer independently of yours. See
 [Refusals](#refusals-what-they-mean-and-what-to-do) for every way this call
 can be turned down.
 
-### `RegisterStemAsync`, `MarkFailedAsync`, `DeleteDjAnalysisAsync`
+### `RegisterStemAsync`, `RegisterStemsAsync`, `MarkFailedAsync`, `DeleteDjAnalysisAsync`
 
 `RegisterStemAsync` is what `SplitStemsAsync` calls internally; call it
 yourself only if you produced a stem file some other way (through your own
@@ -231,6 +234,14 @@ await context.MusicAnalysisWriter!.RegisterStemAsync(
     ct
 );
 ```
+
+`RegisterStemsAsync(stems, ct)` registers several stems as one write: every
+stem is validated before any row is staged, and all of them are saved in one
+transaction, so a refusal on the second stem of a pair leaves the first one
+unwritten instead of half a split in the register. Use it whenever the stems
+belong together — `SplitStemsAsync` registers its pair through it. The refusal
+you get back is the first one any stem earned, from the same list as
+`RegisterStemAsync` below.
 
 `MarkFailedAsync(trackId, djAnalyzerVersion, baseAnalyzerVersion, reason, ct)`
 records that analysis was attempted and did not produce a row — so the sweep
@@ -361,13 +372,14 @@ Checked in this order — the first failing check is the one you get back:
 | `"beats_per_bar must be at least 1, got {value}"` | `BeatsPerBar` was 0 or negative | a plugin bug — this is normally 4 |
 | `"downbeat_index value {value} lies outside the beat grid (0..{max})"` | `DownbeatIndex` was outside `0 .. BeatsPerBar − 1` | clamp it, or leave it `null` when the detector could not place the bar |
 | `"{field} value {value} lies outside the track (0..{durationMs} ms)"` | a millisecond value in `phrase_starts_ms`, `vocal_regions_ms`, `cue_points` or `chords` (checked in that order) falls before 0 or after the track's own duration | the detector measured past the end of the file, or against the wrong track's duration — re-check the source of the timestamp |
+| `"vocal_regions_ms entry {index} must be [start, end] with start < end"` | one entry of `vocal_regions_ms` was not a pair, or its start was not before its end | a region is exactly two values; drop the malformed one or fix the bounds the detector produced |
 | `"phrase_starts_ms must be ascending"` | the phrase boundaries were not strictly increasing | sort them before writing; two phrases cannot share a millisecond |
 | `"{field} exceeds 64 kB"` | one JSON column (`phrase_starts_ms`, `vocal_regions_ms`, `bar_energy`, `cue_points` or `chords`, checked in that order) serialized past the 64 kB column limit | this record is meant to hold bars and phrases, not a sample-accurate trace — keep arrays proportionate to track length |
 
 Skipped entirely, rather than refused, when the track's duration is unknown:
 the millisecond-range check. A partial base row is normal, not a defect.
 
-### `IPluginMusicAnalysisWriter.RegisterStemAsync`
+### `IPluginMusicAnalysisWriter.RegisterStemAsync` and `RegisterStemsAsync`
 
 | refusal | what it means | what to do |
 |---|---|---|
@@ -376,6 +388,7 @@ the millisecond-range check. A partial base row is normal, not a defect.
 | `"full coverage stems must not specify a window"` | `Coverage.Full` was combined with a non-null `WindowStartMs` or `WindowEndMs` | leave both null for `Full` |
 | `"windowed stems must specify both window_start_ms and window_end_ms"` | `MixIn` / `MixOut` was combined with a null window bound | set both, in milliseconds from the start of the track |
 | `"window_start_ms must be less than window_end_ms"` | the window was empty or backwards | fix the bounds — a windowed stem always covers a positive span |
+| `"stem {kind}/{coverage} for track {id} was written concurrently; retry"` | another sweep registered the same stem at the same moment, pointing at a different file | run the track again; a concurrent write of the *same* key is accepted silently, so this only appears when the two disagree |
 
 ### `IPluginMusicAnalysisWriter.MarkFailedAsync`
 

--- a/src/NoMercy.Data/Plugins/PluginAudioTools.cs
+++ b/src/NoMercy.Data/Plugins/PluginAudioTools.cs
@@ -374,37 +374,44 @@ public sealed class PluginAudioTools(
 
             IPluginMusicAnalysisWriter writer = writerFactory.CreateFor(pluginId);
 
-            List<PluginStemFile> stems = [];
-            foreach (
-                (string kind, DerivedAudioEntry entry) in new[]
-                {
-                    ("vocals", vocals),
-                    ("accompaniment", accompaniment),
-                }
-            )
-            {
-                PluginWriteResult write = await writer.RegisterStemAsync(
-                    new PluginTrackStem(
+            (string Kind, DerivedAudioEntry Entry)[] produced =
+            [
+                ("vocals", vocals),
+                ("accompaniment", accompaniment),
+            ];
+
+            // Registered as one write: a vocals row whose accompaniment was
+            // refused describes a split no renderer can use.
+            PluginWriteResult write = await writer.RegisterStemsAsync(
+                produced
+                    .Select(stem => new PluginTrackStem(
                         trackId,
-                        kind,
+                        stem.Kind,
                         coverage,
                         window.StartMs,
                         window.EndMs,
                         OpusFormat,
                         OpusSampleRate,
-                        entry.Key,
+                        stem.Entry.Key,
                         producerVersion
-                    ),
-                    ct
-                );
+                    ))
+                    .ToList(),
+                ct
+            );
 
-                if (!write.Ok)
-                {
-                    return PluginStemSplitResult.Refused(write.Refusal!);
-                }
-
-                stems.Add(new PluginStemFile(kind, coverage, entry.Key, entry.Bytes));
+            if (!write.Ok)
+            {
+                return PluginStemSplitResult.Refused(write.Refusal!);
             }
+
+            List<PluginStemFile> stems = produced
+                .Select(stem => new PluginStemFile(
+                    stem.Kind,
+                    coverage,
+                    stem.Entry.Key,
+                    stem.Entry.Bytes
+                ))
+                .ToList();
 
             return new PluginStemSplitResult(stems, null);
         }
@@ -581,6 +588,11 @@ public sealed class PluginAudioTools(
             {
                 return new(null, $"storage key {input.StorageKey} is not in the derived store");
             }
+
+            // A run has ten minutes to finish and eviction only spares what was
+            // used inside its grace window, so the key is kept alive before
+            // ffmpeg opens the file rather than after it closes it.
+            await store.TouchAsync(input.StorageKey, ct);
 
             return new(
                 await derivedStorage.AcquireLocalPathAsync(

--- a/src/NoMercy.Data/Plugins/PluginAudioTools.cs
+++ b/src/NoMercy.Data/Plugins/PluginAudioTools.cs
@@ -95,23 +95,19 @@ public sealed class PluginAudioTools(
     private readonly ILogger<PluginAudioTools> _logger =
         logger ?? NullLogger<PluginAudioTools>.Instance;
 
-    public async Task<PluginAudioRunResult> RunFilterGraphAsync(
+    public Task<PluginAudioRunResult> RunFilterGraphAsync(
         PluginAudioInput input,
         PluginFilterGraph graph,
         Action<string>? onStdOut,
         Action<string>? onStdErr,
         CancellationToken ct = default
-    )
-    {
-        try
-        {
-            return await RunFilterGraphCoreAsync(input, graph, onStdOut, onStdErr, ct);
-        }
-        catch (Exception exception) when (exception is not OperationCanceledException)
-        {
-            return PluginAudioRunResult.Refused(Unexpected(exception, nameof(RunFilterGraphAsync)));
-        }
-    }
+    ) =>
+        PluginCallGuard.RunAsync(
+            $"plugin {pluginId}: {nameof(RunFilterGraphAsync)}",
+            () => RunFilterGraphCoreAsync(input, graph, onStdOut, onStdErr, ct),
+            PluginAudioRunResult.Refused,
+            _logger
+        );
 
     private async Task<PluginAudioRunResult> RunFilterGraphCoreAsync(
         PluginAudioInput input,
@@ -175,22 +171,18 @@ public sealed class PluginAudioTools(
         }
     }
 
-    public async Task<PluginStemSplitResult> SplitStemsAsync(
+    public Task<PluginStemSplitResult> SplitStemsAsync(
         string trackId,
         PluginStemCoverage coverage,
         PluginStemSet stemSet,
         CancellationToken ct = default
-    )
-    {
-        try
-        {
-            return await SplitStemsCoreAsync(trackId, coverage, stemSet, ct);
-        }
-        catch (Exception exception) when (exception is not OperationCanceledException)
-        {
-            return PluginStemSplitResult.Refused(Unexpected(exception, nameof(SplitStemsAsync)));
-        }
-    }
+    ) =>
+        PluginCallGuard.RunAsync(
+            $"plugin {pluginId}: {nameof(SplitStemsAsync)}",
+            () => SplitStemsCoreAsync(trackId, coverage, stemSet, ct),
+            PluginStemSplitResult.Refused,
+            _logger
+        );
 
     private async Task<PluginStemSplitResult> SplitStemsCoreAsync(
         string trackId,
@@ -281,15 +273,9 @@ public sealed class PluginAudioTools(
                 ct
             );
 
-            // A lease on a path ffmpeg WRITES to. LocalPathLease documents a
-            // read-only staging contract - a future remote driver would stage
-            // the object into a temp file and drop it on dispose, which is the
-            // wrong direction for an output. It holds here because the derived
-            // store is always local storage (a LocalStorage scoped to
-            // AppFiles.DerivedAudioPath, see ServiceConfiguration.Core), so the
-            // lease hands back the real path unchanged. The day the derived
-            // store can live on a remote driver, this needs a
-            // put-from-lease helper on IStorage rather than a plain lease.
+            // A lease on a path ffmpeg WRITES to, which LocalPathLease's
+            // read-only staging contract only allows because the derived store
+            // is always local. A remote one would need a put-from-lease helper.
             await using LocalPathLease vocalsLease = await derivedStorage.AcquireLocalPathAsync(
                 vocalsTemp,
                 ct
@@ -417,12 +403,9 @@ public sealed class PluginAudioTools(
         }
         finally
         {
-            // Every way out of the block above - a refusal, a cancelled token,
-            // a throw from the store - would otherwise leave two scratch files
-            // for the derived store's eviction sweep to find hours later.
-            // CancellationToken.None deliberately: cleanup after a cancellation
-            // is exactly when it matters, and deleting a file the caller no
-            // longer wants is not work that should itself be cancellable.
+            // Every way out of the block above would otherwise strand two
+            // scratch files. CancellationToken.None deliberately: cleanup after
+            // a cancellation is exactly when it matters most.
             await DeleteTempAsync(vocalsTemp, CancellationToken.None);
             await DeleteTempAsync(accompanimentTemp, CancellationToken.None);
         }
@@ -677,25 +660,6 @@ public sealed class PluginAudioTools(
 
         double start = duration * MixOutStart;
         return new(["-ss", Seconds(start)], Milliseconds(start), Milliseconds(duration));
-    }
-
-    /// <summary>
-    /// Turns a failure nobody planned for - a mount that went away, a locked
-    /// database file - into a refusal the caller can read, and puts the real
-    /// exception on the server's own record. A plugin sweeping a library
-    /// unattended loses one track this way instead of the whole sweep.
-    /// Cancellation the caller asked for never comes through here.
-    /// </summary>
-    private string Unexpected(Exception exception, string member)
-    {
-        _logger.LogWarning(
-            exception,
-            "plugin {PluginId}: {Member} failed inside the server",
-            pluginId,
-            member
-        );
-
-        return $"the server could not complete this call: {exception.GetType().Name}";
     }
 
     /// <summary>Seconds as ffmpeg reads them: invariant, and no decimal tail when there is none.</summary>

--- a/src/NoMercy.Data/Plugins/PluginCallGuard.cs
+++ b/src/NoMercy.Data/Plugins/PluginCallGuard.cs
@@ -1,0 +1,84 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace NoMercy.Data.Plugins;
+
+/// <summary>
+/// What every plugin-facing facade does with a failure nobody planned for - a
+/// mount that went away, a locked database file. The exception is logged at
+/// Warning on the server's own record and the caller is handed a refusal, or
+/// the absence its member can express: a plugin sweeping a library unattended
+/// loses one track that way instead of its whole sweep.
+/// <para>
+/// Cancellation the caller asked for is never swallowed anywhere here.
+/// </para>
+/// </summary>
+public static class PluginCallGuard
+{
+    /// <summary>For a member that can say why it could not answer.</summary>
+    public static async Task<T> RunAsync<T>(
+        string operation,
+        Func<Task<T>> body,
+        Func<string, T> refuse,
+        ILogger logger
+    )
+    {
+        try
+        {
+            return await body();
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            LogUnexpected(logger, exception, operation);
+            return refuse($"the server could not complete this call: {exception.GetType().Name}");
+        }
+    }
+
+    /// <summary>
+    /// For a member with no refusal channel: the failure reads as the absence
+    /// the member already has a word for - false, or null.
+    /// </summary>
+    public static async Task<T> RunOrAsync<T>(
+        string operation,
+        Func<Task<T>> body,
+        T fallback,
+        ILogger logger
+    )
+    {
+        try
+        {
+            return await body();
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            LogUnexpected(logger, exception, operation);
+            return fallback;
+        }
+    }
+
+    /// <summary>For a member that returns nothing, where a failure is a no-op.</summary>
+    public static async Task RunAsync(string operation, Func<Task> body, ILogger logger)
+    {
+        try
+        {
+            await body();
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            LogUnexpected(logger, exception, operation);
+        }
+    }
+
+    private static void LogUnexpected(ILogger logger, Exception exception, string operation) =>
+        logger.LogWarning(exception, "{Operation} failed inside the server", operation);
+}

--- a/src/NoMercy.Data/Plugins/PluginDerivedAudio.cs
+++ b/src/NoMercy.Data/Plugins/PluginDerivedAudio.cs
@@ -27,17 +27,17 @@ namespace NoMercy.Data.Plugins;
 /// a file actually lives - it holds the key, and reads or writes through this
 /// facade). A key that <see cref="IPluginDerivedAudio.PutAsync" /> could not
 /// have minted - null, blank, the wrong length, the wrong characters, or the
-/// right hex in the wrong case - is refused here, before it reaches the
-/// store, since <c>RelativePath</c> slices the key apart to build a path. The
-/// store applies the same rule again on its own: this facade is not the only
-/// caller it has.
+/// right hex in the wrong case - is refused by the store, which is the only
+/// validator: it is not this facade's only caller, so a copy of the rule here
+/// would be a second rule to keep in step rather than a second line of
+/// defence.
 /// </para>
 /// <para>
 /// None of these members has a refusal channel, so both a refused key and a
 /// failure inside the server read as an absence: <see cref="ExistsAsync" />
 /// answers false, <see cref="OpenReadAsync" /> answers null, and
-/// <see cref="TouchAsync" /> and <see cref="DeleteAsync" /> do nothing. Every
-/// one of those is logged at Warning first, so the owner still has the reason.
+/// <see cref="TouchAsync" /> and <see cref="DeleteAsync" /> do nothing. A
+/// failure is logged at Warning first, so the owner still has the reason.
 /// <see cref="PutAsync" /> is the exception - it has to return the key of the
 /// content it was handed, and there is no key when the store would not take
 /// it, so that failure is logged and rethrown. Cancellation is never
@@ -75,80 +75,37 @@ public sealed class PluginDerivedAudio(
         }
     }
 
-    public async Task<bool> ExistsAsync(string key, CancellationToken ct = default)
-    {
-        if (!DerivedAudioKey.IsValid(key))
-        {
-            return false;
-        }
-
-        try
-        {
-            return await store.ExistsAsync(key, ct);
-        }
-        catch (Exception exception) when (exception is not OperationCanceledException)
-        {
-            Warn(exception, nameof(ExistsAsync));
-            return false;
-        }
-    }
-
-    public async Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default)
-    {
-        if (!DerivedAudioKey.IsValid(key))
-        {
-            return null;
-        }
-
-        try
-        {
-            return await store.OpenReadAsync(key, ct);
-        }
-        catch (Exception exception) when (exception is not OperationCanceledException)
-        {
-            Warn(exception, nameof(OpenReadAsync));
-            return null;
-        }
-    }
-
-    public async Task TouchAsync(string key, CancellationToken ct = default)
-    {
-        if (!DerivedAudioKey.IsValid(key))
-        {
-            return;
-        }
-
-        try
-        {
-            await store.TouchAsync(key, ct);
-        }
-        catch (Exception exception) when (exception is not OperationCanceledException)
-        {
-            Warn(exception, nameof(TouchAsync));
-        }
-    }
-
-    public async Task DeleteAsync(string key, CancellationToken ct = default)
-    {
-        if (!DerivedAudioKey.IsValid(key))
-        {
-            return;
-        }
-
-        try
-        {
-            await store.DeleteAsync(key, ct);
-        }
-        catch (Exception exception) when (exception is not OperationCanceledException)
-        {
-            Warn(exception, nameof(DeleteAsync));
-        }
-    }
-
-    private void Warn(Exception exception, string member) =>
-        _logger.LogWarning(
-            exception,
-            "the server could not complete a plugin's {Member} call on the derived store",
-            member
+    public Task<bool> ExistsAsync(string key, CancellationToken ct = default) =>
+        PluginCallGuard.RunOrAsync(
+            Operation(nameof(ExistsAsync)),
+            () => store.ExistsAsync(key, ct),
+            false,
+            _logger
         );
+
+    public Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default) =>
+        PluginCallGuard.RunOrAsync<Stream?>(
+            Operation(nameof(OpenReadAsync)),
+            () => store.OpenReadAsync(key, ct),
+            null,
+            _logger
+        );
+
+    public Task TouchAsync(string key, CancellationToken ct = default) =>
+        PluginCallGuard.RunAsync(
+            Operation(nameof(TouchAsync)),
+            () => store.TouchAsync(key, ct),
+            _logger
+        );
+
+    public Task DeleteAsync(string key, CancellationToken ct = default) =>
+        PluginCallGuard.RunAsync(
+            Operation(nameof(DeleteAsync)),
+            () => store.DeleteAsync(key, ct),
+            _logger
+        );
+
+    /// <summary>Which call this is, for the guard's warning line.</summary>
+    private static string Operation(string member) =>
+        $"a plugin's {member} call on the derived store";
 }

--- a/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
@@ -58,17 +58,35 @@ public class PluginMusicAnalysisWriter(
     public Task<PluginWriteResult> UpsertDjAnalysisAsync(
         PluginTrackDjAnalysis record,
         CancellationToken ct = default
-    ) => GuardAsync(nameof(UpsertDjAnalysisAsync), () => UpsertDjAnalysisCoreAsync(record, ct));
+    ) =>
+        PluginCallGuard.RunAsync(
+            Operation(nameof(UpsertDjAnalysisAsync)),
+            () => UpsertDjAnalysisCoreAsync(record, ct),
+            PluginWriteResult.Refused,
+            _logger
+        );
 
     public Task<PluginWriteResult> RegisterStemAsync(
         PluginTrackStem stem,
         CancellationToken ct = default
-    ) => GuardAsync(nameof(RegisterStemAsync), () => RegisterStemsCoreAsync([stem], ct));
+    ) =>
+        PluginCallGuard.RunAsync(
+            Operation(nameof(RegisterStemAsync)),
+            () => RegisterStemsCoreAsync([stem], ct),
+            PluginWriteResult.Refused,
+            _logger
+        );
 
     public Task<PluginWriteResult> RegisterStemsAsync(
         IReadOnlyList<PluginTrackStem> stems,
         CancellationToken ct = default
-    ) => GuardAsync(nameof(RegisterStemsAsync), () => RegisterStemsCoreAsync(stems, ct));
+    ) =>
+        PluginCallGuard.RunAsync(
+            Operation(nameof(RegisterStemsAsync)),
+            () => RegisterStemsCoreAsync(stems, ct),
+            PluginWriteResult.Refused,
+            _logger
+        );
 
     public Task<PluginWriteResult> MarkFailedAsync(
         Guid trackId,
@@ -77,9 +95,11 @@ public class PluginMusicAnalysisWriter(
         string reason,
         CancellationToken ct = default
     ) =>
-        GuardAsync(
-            nameof(MarkFailedAsync),
-            () => MarkFailedCoreAsync(trackId, djAnalyzerVersion, baseAnalyzerVersion, reason, ct)
+        PluginCallGuard.RunAsync(
+            Operation(nameof(MarkFailedAsync)),
+            () => MarkFailedCoreAsync(trackId, djAnalyzerVersion, baseAnalyzerVersion, reason, ct),
+            PluginWriteResult.Refused,
+            _logger
         );
 
     /// <summary>
@@ -88,17 +108,15 @@ public class PluginMusicAnalysisWriter(
     /// caller that asked for a row to be gone is no worse off being told
     /// nothing than being handed a driver exception.
     /// </summary>
-    public async Task DeleteDjAnalysisAsync(Guid trackId, CancellationToken ct = default)
-    {
-        try
-        {
-            await DeleteDjAnalysisCoreAsync(trackId, ct);
-        }
-        catch (Exception exception) when (exception is not OperationCanceledException)
-        {
-            LogUnexpected(exception, nameof(DeleteDjAnalysisAsync));
-        }
-    }
+    public Task DeleteDjAnalysisAsync(Guid trackId, CancellationToken ct = default) =>
+        PluginCallGuard.RunAsync(
+            Operation(nameof(DeleteDjAnalysisAsync)),
+            () => DeleteDjAnalysisCoreAsync(trackId, ct),
+            _logger
+        );
+
+    /// <summary>Which plugin's call this is, for the guard's warning line.</summary>
+    private string Operation(string member) => $"plugin {pluginId}: {member}";
 
     private async Task<PluginWriteResult> UpsertDjAnalysisCoreAsync(
         PluginTrackDjAnalysis record,
@@ -227,10 +245,9 @@ public class PluginMusicAnalysisWriter(
         }
         catch (DbUpdateException)
         {
-            // Two sweeps upserting the same track at once: both read "no row"
-            // and both tried to insert. Nothing is lost - the winner wrote the
-            // same kind of record - so the loser is told to run again rather
-            // than handed a driver exception.
+            // Two sweeps upserting one track at once both read "no row" and
+            // both insert. Nothing is lost, so the loser is told to run again
+            // rather than handed a driver exception.
             return PluginWriteResult.Refused(
                 $"the DJ record for track {record.TrackId} was written concurrently; retry"
             );
@@ -310,14 +327,32 @@ public class PluginMusicAnalysisWriter(
             return PluginWriteResult.Refused($"track {stem.TrackId} does not exist");
 
         // A key the store could never have minted gets the same answer as one
-        // it simply does not hold, but it is checked here first: asking the
-        // store means slicing the key into a path.
+        // it does not hold, but is checked first: asking the store means
+        // slicing the key into a path.
         if (
             !DerivedAudioKey.IsValid(stem.StorageKey)
             || !await store.ExistsAsync(stem.StorageKey, ct)
         )
             return PluginWriteResult.Refused(
                 $"storage key {stem.StorageKey} is not in the derived store"
+            );
+
+        string? contentType = await context
+            .DerivedAudio.AsNoTracking()
+            .Where(row => row.Key == stem.StorageKey)
+            .Select(row => row.ContentType)
+            .FirstOrDefaultAsync(ct);
+
+        if (contentType is null)
+            return PluginWriteResult.Refused(
+                $"storage key {stem.StorageKey} is not in the derived store"
+            );
+
+        // The register row is what a client is handed the stem as, so a row
+        // claiming Opus over a FLAC file is a player error hours later.
+        if (!FormatMatchesContentType(stem.Format, contentType))
+            return PluginWriteResult.Refused(
+                $"stem format {stem.Format} does not match the stored content type {contentType}"
             );
 
         if (stem.Coverage == PluginStemCoverage.Full)
@@ -339,6 +374,19 @@ public class PluginMusicAnalysisWriter(
         return null;
     }
 
+    /// <summary>
+    /// The pairings the derived store can hold today. Anything else is a
+    /// mismatch rather than an unknown: a format that cannot come out of that
+    /// container is not a row worth keeping.
+    /// </summary>
+    private static bool FormatMatchesContentType(string format, string contentType) =>
+        (format.ToLowerInvariant(), contentType.ToLowerInvariant()) switch
+        {
+            ("opus", "audio/ogg") => true,
+            ("flac", "audio/flac") => true,
+            _ => false,
+        };
+
     /// <summary>Adds or updates one stem's row on the context, without saving it.</summary>
     private static async Task StageStemAsync(
         MediaContext context,
@@ -346,7 +394,7 @@ public class PluginMusicAnalysisWriter(
         CancellationToken ct
     )
     {
-        StemCoverage coverage = ToDbCoverage(stem.Coverage);
+        StemCoverage coverage = StemCoverageMap.ToDb(stem.Coverage);
 
         TrackStem? existing = await context.TrackStems.FirstOrDefaultAsync(
             row =>
@@ -389,7 +437,7 @@ public class PluginMusicAnalysisWriter(
 
         foreach (PluginTrackStem stem in stems)
         {
-            StemCoverage coverage = ToDbCoverage(stem.Coverage);
+            StemCoverage coverage = StemCoverageMap.ToDb(stem.Coverage);
 
             TrackStem? stored = await context
                 .TrackStems.AsNoTracking()
@@ -567,40 +615,6 @@ public class PluginMusicAnalysisWriter(
     }
 
     /// <summary>
-    /// Runs one contract call and turns anything it throws into a refusal:
-    /// every caller here is a plugin sweeping unattended, and an exception
-    /// crossing the host boundary takes that whole sweep down instead of one
-    /// track. The exception type is named in the refusal so the owner can match
-    /// it against the Warning line this also writes; cancellation the caller
-    /// asked for is passed through untouched.
-    /// </summary>
-    private async Task<PluginWriteResult> GuardAsync(
-        string member,
-        Func<Task<PluginWriteResult>> call
-    )
-    {
-        try
-        {
-            return await call();
-        }
-        catch (Exception exception) when (exception is not OperationCanceledException)
-        {
-            LogUnexpected(exception, member);
-            return PluginWriteResult.Refused(
-                $"the server could not complete this call: {exception.GetType().Name}"
-            );
-        }
-    }
-
-    private void LogUnexpected(Exception exception, string member) =>
-        _logger.LogWarning(
-            exception,
-            "plugin {PluginId}: {Member} failed inside the server",
-            pluginId,
-            member
-        );
-
-    /// <summary>
     /// Every list on the record is required. A null one is a caller bug that
     /// would otherwise serialise to the JSON literal <c>null</c> and land in a
     /// column the reader reads as "the plugin stored nothing here" - which is
@@ -636,23 +650,4 @@ public class PluginMusicAnalysisWriter(
 
         return null;
     }
-
-    /// <summary>
-    /// Maps the plugin's stem-coverage enum to the database's own. An
-    /// explicit switch, the mirror of <see cref="PluginMusicQuery" />'s own
-    /// mapping the other way, rather than a cast the two enums only happen to
-    /// agree on today.
-    /// </summary>
-    private static StemCoverage ToDbCoverage(PluginStemCoverage coverage) =>
-        coverage switch
-        {
-            PluginStemCoverage.Full => StemCoverage.Full,
-            PluginStemCoverage.MixIn => StemCoverage.MixIn,
-            PluginStemCoverage.MixOut => StemCoverage.MixOut,
-            _ => throw new ArgumentOutOfRangeException(
-                nameof(coverage),
-                coverage,
-                "Unknown stem coverage"
-            ),
-        };
 }

--- a/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
@@ -11,6 +11,7 @@
 
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NoMercy.Database;
@@ -62,7 +63,12 @@ public class PluginMusicAnalysisWriter(
     public Task<PluginWriteResult> RegisterStemAsync(
         PluginTrackStem stem,
         CancellationToken ct = default
-    ) => GuardAsync(nameof(RegisterStemAsync), () => RegisterStemCoreAsync(stem, ct));
+    ) => GuardAsync(nameof(RegisterStemAsync), () => RegisterStemsCoreAsync([stem], ct));
+
+    public Task<PluginWriteResult> RegisterStemsAsync(
+        IReadOnlyList<PluginTrackStem> stems,
+        CancellationToken ct = default
+    ) => GuardAsync(nameof(RegisterStemsAsync), () => RegisterStemsCoreAsync(stems, ct));
 
     public Task<PluginWriteResult> MarkFailedAsync(
         Guid trackId,
@@ -156,6 +162,10 @@ public class PluginMusicAnalysisWriter(
                 return outOfRange;
         }
 
+        PluginWriteResult? malformedRegion = CheckVocalRegionShape(record.VocalRegionsMs);
+        if (malformedRegion is not null)
+            return malformedRegion;
+
         if (!IsAscending(record.PhraseStartsMs))
             return PluginWriteResult.Refused("phrase_starts_ms must be ascending");
 
@@ -229,13 +239,69 @@ public class PluginMusicAnalysisWriter(
         return PluginWriteResult.Accepted();
     }
 
-    private async Task<PluginWriteResult> RegisterStemCoreAsync(
+    /// <summary>
+    /// Runs between staging the rows and saving them, so a test can land a
+    /// competing write in exactly the window this method has to survive. Never
+    /// set in production.
+    /// </summary>
+    internal Func<Task>? BeforeSave { get; init; }
+
+    /// <summary>
+    /// Every stem is validated before any of them is staged, and all of them
+    /// are saved in one transaction, so a refusal on the second stem of a pair
+    /// leaves the first one unwritten rather than half a split in the register.
+    /// </summary>
+    private async Task<PluginWriteResult> RegisterStemsCoreAsync(
+        IReadOnlyList<PluginTrackStem> stems,
+        CancellationToken ct
+    )
+    {
+        if (stems.Count == 0)
+            return PluginWriteResult.Accepted();
+
+        await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
+
+        foreach (PluginTrackStem stem in stems)
+        {
+            PluginWriteResult? refusal = await CheckStemAsync(context, stem, ct);
+            if (refusal is not null)
+                return refusal;
+        }
+
+        foreach (PluginTrackStem stem in stems)
+        {
+            await StageStemAsync(context, stem, ct);
+        }
+
+        if (BeforeSave is not null)
+        {
+            await BeforeSave();
+        }
+
+        await using IDbContextTransaction transaction =
+            await context.Database.BeginTransactionAsync(ct);
+
+        try
+        {
+            await context.SaveChangesAsync(ct);
+            await transaction.CommitAsync(ct);
+        }
+        catch (DbUpdateException)
+        {
+            await transaction.RollbackAsync(ct);
+            return await ResolveConcurrentStemWriteAsync(stems, ct);
+        }
+
+        return PluginWriteResult.Accepted();
+    }
+
+    /// <summary>Why one stem cannot be written, or null when it can.</summary>
+    private async Task<PluginWriteResult?> CheckStemAsync(
+        MediaContext context,
         PluginTrackStem stem,
         CancellationToken ct
     )
     {
-        await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
-
         bool trackExists = await context
             .Tracks.AsNoTracking()
             .AnyAsync(t => t.Id == stem.TrackId, ct);
@@ -244,9 +310,8 @@ public class PluginMusicAnalysisWriter(
             return PluginWriteResult.Refused($"track {stem.TrackId} does not exist");
 
         // A key the store could never have minted gets the same answer as one
-        // it simply does not hold - a plugin has one thing to fix either way -
-        // but it is checked here first, because asking the store means slicing
-        // the key into a path.
+        // it simply does not hold, but it is checked here first: asking the
+        // store means slicing the key into a path.
         if (
             !DerivedAudioKey.IsValid(stem.StorageKey)
             || !await store.ExistsAsync(stem.StorageKey, ct)
@@ -271,6 +336,16 @@ public class PluginMusicAnalysisWriter(
                 return PluginWriteResult.Refused("window_start_ms must be less than window_end_ms");
         }
 
+        return null;
+    }
+
+    /// <summary>Adds or updates one stem's row on the context, without saving it.</summary>
+    private static async Task StageStemAsync(
+        MediaContext context,
+        PluginTrackStem stem,
+        CancellationToken ct
+    )
+    {
         StemCoverage coverage = ToDbCoverage(stem.Coverage);
 
         TrackStem? existing = await context.TrackStems.FirstOrDefaultAsync(
@@ -297,8 +372,42 @@ public class PluginMusicAnalysisWriter(
         existing.StorageKey = stem.StorageKey;
         existing.ProducerVersion = stem.ProducerVersion;
         existing.CreatedAt = DateTime.UtcNow;
+    }
 
-        await context.SaveChangesAsync(ct);
+    /// <summary>
+    /// Two sweeps registering the same stem at once both read "no row" and
+    /// both insert; the loser's save hits the unique index. When the winner
+    /// stored the same key, nothing is lost and the loser is told it landed;
+    /// when it stored another one, the caller has to run again.
+    /// </summary>
+    private async Task<PluginWriteResult> ResolveConcurrentStemWriteAsync(
+        IReadOnlyList<PluginTrackStem> stems,
+        CancellationToken ct
+    )
+    {
+        await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
+
+        foreach (PluginTrackStem stem in stems)
+        {
+            StemCoverage coverage = ToDbCoverage(stem.Coverage);
+
+            TrackStem? stored = await context
+                .TrackStems.AsNoTracking()
+                .FirstOrDefaultAsync(
+                    row =>
+                        row.TrackId == stem.TrackId
+                        && row.Kind == stem.Kind
+                        && row.Coverage == coverage
+                        && row.ProducerVersion == stem.ProducerVersion,
+                    ct
+                );
+
+            if (stored is null || stored.StorageKey != stem.StorageKey)
+                return PluginWriteResult.Refused(
+                    $"stem {stem.Kind}/{stem.Coverage} for track {stem.TrackId} was written concurrently; retry"
+                );
+        }
+
         return PluginWriteResult.Accepted();
     }
 
@@ -421,6 +530,26 @@ public class PluginMusicAnalysisWriter(
         PluginWriteResult.Refused(
             $"{field} value {value} lies outside the track (0..{(long)Math.Round(durationMs)} ms)"
         );
+
+    /// <summary>
+    /// A vocal region is exactly [start, end] with start before end. One value
+    /// reads as a region ending wherever the next one starts, and a backwards
+    /// pair as a region of negative length - both are a planner reading the
+    /// wrong seconds of a track long after the sweep that stored them.
+    /// </summary>
+    private static PluginWriteResult? CheckVocalRegionShape(IReadOnlyList<int[]> regions)
+    {
+        for (int index = 0; index < regions.Count; index++)
+        {
+            int[] region = regions[index];
+            if (region.Length != 2 || region[0] >= region[1])
+                return PluginWriteResult.Refused(
+                    $"vocal_regions_ms entry {index} must be [start, end] with start < end"
+                );
+        }
+
+        return null;
+    }
 
     /// <summary>
     /// Phrase boundaries strictly increase: two phrases cannot start at the

--- a/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
@@ -239,21 +239,57 @@ public class PluginMusicAnalysisWriter(
         existing.Chords = chordsJson;
         existing.AnalyzedAt = DateTime.UtcNow;
 
+        if (BeforeSave is not null)
+        {
+            await BeforeSave();
+        }
+
         try
         {
             await context.SaveChangesAsync(ct);
         }
-        catch (DbUpdateException)
+        catch (DbUpdateException exception)
         {
-            // Two sweeps upserting one track at once both read "no row" and
-            // both insert. Nothing is lost, so the loser is told to run again
-            // rather than handed a driver exception.
-            return PluginWriteResult.Refused(
-                $"the DJ record for track {record.TrackId} was written concurrently; retry"
-            );
+            return await ResolveFailedDjWriteAsync(record.TrackId, exception, ct);
         }
 
         return PluginWriteResult.Accepted();
+    }
+
+    /// <summary>
+    /// A save that did not land is only a race when a row is there now: two
+    /// sweeps upserting one track both read "no row" and both insert, and the
+    /// loser can simply run again. With no row, the save failed for a reason
+    /// of its own - a foreign key, a column constraint, a disk - and "retry"
+    /// would hide that for ever, so it is logged and named instead.
+    /// </summary>
+    private async Task<PluginWriteResult> ResolveFailedDjWriteAsync(
+        Guid trackId,
+        DbUpdateException exception,
+        CancellationToken ct
+    )
+    {
+        await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
+
+        bool stored = await context
+            .TrackDjAnalysis.AsNoTracking()
+            .AnyAsync(analysis => analysis.TrackId == trackId, ct);
+
+        if (stored)
+            return PluginWriteResult.Refused(
+                $"the DJ record for track {trackId} was written concurrently; retry"
+            );
+
+        _logger.LogWarning(
+            exception,
+            "plugin {PluginId}: the DJ record for track {TrackId} could not be stored",
+            pluginId,
+            trackId
+        );
+
+        return PluginWriteResult.Refused(
+            $"the DJ record for track {trackId} could not be stored: {exception.GetType().Name}"
+        );
     }
 
     /// <summary>
@@ -273,8 +309,15 @@ public class PluginMusicAnalysisWriter(
         CancellationToken ct
     )
     {
+        if (stems is null)
+            return PluginWriteResult.Refused("stems must not be null");
+
         if (stems.Count == 0)
             return PluginWriteResult.Accepted();
+
+        PluginWriteResult? duplicate = CheckForDuplicates(stems);
+        if (duplicate is not null)
+            return duplicate;
 
         await using MediaContext context = await contextFactory.CreateDbContextAsync(ct);
 
@@ -303,10 +346,10 @@ public class PluginMusicAnalysisWriter(
             await context.SaveChangesAsync(ct);
             await transaction.CommitAsync(ct);
         }
-        catch (DbUpdateException)
+        catch (DbUpdateException exception)
         {
             await transaction.RollbackAsync(ct);
-            return await ResolveConcurrentStemWriteAsync(stems, ct);
+            return await ResolveFailedStemWriteAsync(stems, exception, ct);
         }
 
         return PluginWriteResult.Accepted();
@@ -375,6 +418,26 @@ public class PluginMusicAnalysisWriter(
     }
 
     /// <summary>
+    /// One register row is addressed by (track, kind, coverage, producer), so
+    /// two entries sharing all four are one row written twice: whichever came
+    /// second would silently win, which is never what a caller meant.
+    /// </summary>
+    private static PluginWriteResult? CheckForDuplicates(IReadOnlyList<PluginTrackStem> stems)
+    {
+        HashSet<(Guid, string, PluginStemCoverage, string)> seen = [];
+
+        foreach (PluginTrackStem stem in stems)
+        {
+            if (!seen.Add((stem.TrackId, stem.Kind, stem.Coverage, stem.ProducerVersion)))
+                return PluginWriteResult.Refused(
+                    $"stems contains the same stem twice: {stem.Kind}/{stem.Coverage}"
+                );
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// The pairings the derived store can hold today. Anything else is a
     /// mismatch rather than an unknown: a format that cannot come out of that
     /// container is not a row worth keeping.
@@ -383,6 +446,7 @@ public class PluginMusicAnalysisWriter(
         (format.ToLowerInvariant(), contentType.ToLowerInvariant()) switch
         {
             ("opus", "audio/ogg") => true,
+            ("opus", "audio/opus") => true,
             ("flac", "audio/flac") => true,
             _ => false,
         };
@@ -423,13 +487,17 @@ public class PluginMusicAnalysisWriter(
     }
 
     /// <summary>
-    /// Two sweeps registering the same stem at once both read "no row" and
-    /// both insert; the loser's save hits the unique index. When the winner
-    /// stored the same key, nothing is lost and the loser is told it landed;
-    /// when it stored another one, the caller has to run again.
+    /// A save that did not land is only a race when the row is there now: two
+    /// sweeps registering one stem both read "no row" and both insert, and the
+    /// winner stored either the same key (nothing is lost, so the loser is
+    /// told it landed) or another one (the caller has to run again). With no
+    /// row at all the save failed for a reason of its own - a foreign key, a
+    /// column constraint, a disk - which is logged and named rather than
+    /// dressed up as something a retry would fix.
     /// </summary>
-    private async Task<PluginWriteResult> ResolveConcurrentStemWriteAsync(
+    private async Task<PluginWriteResult> ResolveFailedStemWriteAsync(
         IReadOnlyList<PluginTrackStem> stems,
+        DbUpdateException exception,
         CancellationToken ct
     )
     {
@@ -450,7 +518,23 @@ public class PluginMusicAnalysisWriter(
                     ct
                 );
 
-            if (stored is null || stored.StorageKey != stem.StorageKey)
+            if (stored is null)
+            {
+                _logger.LogWarning(
+                    exception,
+                    "plugin {PluginId}: stem {Kind}/{Coverage} for track {TrackId} could not be stored",
+                    pluginId,
+                    stem.Kind,
+                    stem.Coverage,
+                    stem.TrackId
+                );
+
+                return PluginWriteResult.Refused(
+                    $"stem {stem.Kind}/{stem.Coverage} for track {stem.TrackId} could not be stored: {exception.GetType().Name}"
+                );
+            }
+
+            if (stored.StorageKey != stem.StorageKey)
                 return PluginWriteResult.Refused(
                     $"stem {stem.Kind}/{stem.Coverage} for track {stem.TrackId} was written concurrently; retry"
                 );

--- a/src/NoMercy.Data/Plugins/PluginMusicQuery.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicQuery.cs
@@ -224,7 +224,7 @@ public class PluginMusicQuery(
         return rows.Select(row => new PluginTrackStem(
                 row.TrackId,
                 row.Kind,
-                ToPluginCoverage(row.Coverage),
+                StemCoverageMap.ToPlugin(row.Coverage),
                 row.WindowStartMs,
                 row.WindowEndMs,
                 row.Format,
@@ -291,25 +291,6 @@ public class PluginMusicQuery(
             .Take(Math.Clamp(take, 1, MaxPageSize))
             .ToListAsync(ct);
     }
-
-    /// <summary>
-    /// Maps the database's stem-coverage enum to the plugin's own. Kept as an
-    /// explicit switch rather than a numeric cast: the two enums happen to
-    /// share values today, but a cast would silently keep "happening to" work
-    /// if that ever stopped being true.
-    /// </summary>
-    private static PluginStemCoverage ToPluginCoverage(StemCoverage coverage) =>
-        coverage switch
-        {
-            StemCoverage.Full => PluginStemCoverage.Full,
-            StemCoverage.MixIn => PluginStemCoverage.MixIn,
-            StemCoverage.MixOut => PluginStemCoverage.MixOut,
-            _ => throw new ArgumentOutOfRangeException(
-                nameof(coverage),
-                coverage,
-                "Unknown stem coverage"
-            ),
-        };
 
     /// <summary>
     /// Deserializes one of <see cref="TrackDjAnalysis" />'s JSON text columns

--- a/src/NoMercy.Data/Plugins/StemCoverageMap.cs
+++ b/src/NoMercy.Data/Plugins/StemCoverageMap.cs
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using NoMercy.Database.Models.Music;
+using NoMercy.Plugins.Abstractions;
+
+namespace NoMercy.Data.Plugins;
+
+/// <summary>
+/// The one place the plugin's stem coverage and the database's own are
+/// translated into each other - the reader and the writer used to carry a
+/// private copy each, which is exactly how two mappings drift apart.
+/// <para>
+/// Explicit switches rather than a numeric cast: the two enums happen to
+/// share values today, and a cast would silently keep "happening to" work if
+/// that ever stopped being true.
+/// </para>
+/// </summary>
+public static class StemCoverageMap
+{
+    public static StemCoverage ToDb(PluginStemCoverage coverage) =>
+        coverage switch
+        {
+            PluginStemCoverage.Full => StemCoverage.Full,
+            PluginStemCoverage.MixIn => StemCoverage.MixIn,
+            PluginStemCoverage.MixOut => StemCoverage.MixOut,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(coverage),
+                coverage,
+                "Unknown stem coverage"
+            ),
+        };
+
+    public static PluginStemCoverage ToPlugin(StemCoverage coverage) =>
+        coverage switch
+        {
+            StemCoverage.Full => PluginStemCoverage.Full,
+            StemCoverage.MixIn => PluginStemCoverage.MixIn,
+            StemCoverage.MixOut => PluginStemCoverage.MixOut,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(coverage),
+                coverage,
+                "Unknown stem coverage"
+            ),
+        };
+}

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioEviction.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioEviction.cs
@@ -33,17 +33,8 @@ public static class DerivedAudioEviction
     )
     {
         long total = rows.Sum(row => row.Bytes);
-        if (total <= capBytes)
-        {
-            return [];
-        }
-
-        DateTime cutoff = now - grace;
         List<DerivedAudioRow> chosen = [];
-        foreach (
-            DerivedAudioRow row in rows.Where(row => row.LastUsedAt <= cutoff)
-                .OrderBy(row => row.LastUsedAt)
-        )
+        foreach (DerivedAudioRow row in Candidates(rows, capBytes, grace, now))
         {
             if (total <= capBytes)
             {
@@ -53,5 +44,27 @@ public static class DerivedAudioEviction
             total -= row.Bytes;
         }
         return chosen;
+    }
+
+    /// <summary>
+    /// Every row eviction is allowed to take, least recently used first.
+    /// <see cref="Choose" /> is this list cut off at the cap; the store walks
+    /// the whole list, because a row can be in use again by the time its turn
+    /// comes and the cap still has to be met.
+    /// </summary>
+    public static IReadOnlyList<DerivedAudioRow> Candidates(
+        IReadOnlyCollection<DerivedAudioRow> rows,
+        long capBytes,
+        TimeSpan grace,
+        DateTime now
+    )
+    {
+        if (rows.Sum(row => row.Bytes) <= capBytes)
+        {
+            return [];
+        }
+
+        DateTime cutoff = now - grace;
+        return rows.Where(row => row.LastUsedAt <= cutoff).OrderBy(row => row.LastUsedAt).ToList();
     }
 }

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioEviction.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioEviction.cs
@@ -33,8 +33,17 @@ public static class DerivedAudioEviction
     )
     {
         long total = rows.Sum(row => row.Bytes);
+        if (total <= capBytes)
+        {
+            return [];
+        }
+
+        DateTime cutoff = now - grace;
         List<DerivedAudioRow> chosen = [];
-        foreach (DerivedAudioRow row in Candidates(rows, capBytes, grace, now))
+        foreach (
+            DerivedAudioRow row in rows.Where(row => row.LastUsedAt <= cutoff)
+                .OrderBy(row => row.LastUsedAt)
+        )
         {
             if (total <= capBytes)
             {
@@ -44,27 +53,5 @@ public static class DerivedAudioEviction
             total -= row.Bytes;
         }
         return chosen;
-    }
-
-    /// <summary>
-    /// Every row eviction is allowed to take, least recently used first.
-    /// <see cref="Choose" /> is this list cut off at the cap; the store walks
-    /// the whole list, because a row can be in use again by the time its turn
-    /// comes and the cap still has to be met.
-    /// </summary>
-    public static IReadOnlyList<DerivedAudioRow> Candidates(
-        IReadOnlyCollection<DerivedAudioRow> rows,
-        long capBytes,
-        TimeSpan grace,
-        DateTime now
-    )
-    {
-        if (rows.Sum(row => row.Bytes) <= capBytes)
-        {
-            return [];
-        }
-
-        DateTime cutoff = now - grace;
-        return rows.Where(row => row.LastUsedAt <= cutoff).OrderBy(row => row.LastUsedAt).ToList();
     }
 }

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
@@ -29,8 +29,10 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
     private readonly ILogger<DerivedAudioStore> _logger;
 
     // Serializes puts, touches and deletes of one key inside this store, which
-    // is a process-wide singleton. One SemaphoreSlim per distinct key is kept
-    // for its lifetime: that key space is small next to a media library.
+    // is a process-wide singleton. A semaphore is only ever created for a key
+    // the register actually holds - an unknown key is answered before this is
+    // touched - so the dictionary is bounded by stored content, not by what
+    // callers ask about.
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
 
     /// <param name="storage">An <see cref="IStorage" /> scoped to <c>AppFiles.DerivedAudioPath</c>; every path below is relative to it.</param>
@@ -234,7 +236,7 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
 
     public async Task TouchAsync(string key, CancellationToken ct = default)
     {
-        if (!DerivedAudioKey.IsValid(key))
+        if (!DerivedAudioKey.IsValid(key) || !await HasRegisterRowAsync(key, ct))
         {
             return;
         }
@@ -242,14 +244,29 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
         await UnderKeyLockAsync(key, () => TouchRowAsync(key, ct), ct);
     }
 
+    /// <summary>
+    /// A key with no register row is nothing to delete: a content file without
+    /// one is the half-written state a crash leaves behind, and the orphan
+    /// sweep in <see cref="EvictAsync" /> is what frees that.
+    /// </summary>
     public async Task DeleteAsync(string key, CancellationToken ct = default)
     {
-        if (!DerivedAudioKey.IsValid(key))
+        if (!DerivedAudioKey.IsValid(key) || !await HasRegisterRowAsync(key, ct))
         {
             return;
         }
 
         await UnderKeyLockAsync(key, () => DeleteEntryAsync(key, ct), ct);
+    }
+
+    /// <summary>
+    /// Asked before the key's semaphore is created, so a well-formed key
+    /// nothing ever stored leaves no lock behind in the dictionary.
+    /// </summary>
+    private async Task<bool> HasRegisterRowAsync(string key, CancellationToken ct)
+    {
+        await using MediaContext context = await _contextFactory.CreateDbContextAsync(ct);
+        return await context.DerivedAudio.AsNoTracking().AnyAsync(row => row.Key == key, ct);
     }
 
     /// <summary>
@@ -271,10 +288,9 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             rows = await context.DerivedAudio.AsNoTracking().ToListAsync(ct);
         }
 
-        long total = rows.Sum(row => row.Bytes);
         long freed = 0;
         foreach (
-            DerivedAudioRow row in DerivedAudioEviction.Candidates(
+            DerivedAudioRow row in DerivedAudioEviction.Choose(
                 rows,
                 capBytes,
                 grace,
@@ -282,11 +298,6 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             )
         )
         {
-            if (total <= capBytes)
-            {
-                break;
-            }
-
             ct.ThrowIfCancellationRequested();
 
             if (BeforeDelete is not null)
@@ -294,14 +305,9 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
                 await BeforeDelete();
             }
 
-            long? evicted = await DeleteIfStillColdAsync(row.Key, grace, ct);
-            if (evicted is null)
-            {
-                continue;
-            }
-
-            freed += evicted.Value;
-            total -= evicted.Value;
+            // A victim that turned out to be in use again is left alone, which
+            // can leave the store over its cap until the next run.
+            freed += await DeleteIfStillColdAsync(row.Key, grace, ct) ?? 0;
         }
 
         await SweepStaleTempFilesAsync(grace, ct);

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
@@ -191,12 +191,12 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             {
                 // Lost a cross-instance race to register the row; the winner's
                 // row is already there — bump it instead of failing the caller.
-                await TouchAsync(key, ct);
+                await TouchRowAsync(key, ct);
             }
         }
         else
         {
-            await TouchAsync(key, ct);
+            await TouchRowAsync(key, ct);
         }
 
         return new DerivedAudioEntry(key, contentType, bytes);
@@ -235,7 +235,8 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
         {
             return null;
         }
-        await TouchAsync(key, ct);
+
+        await UnderKeyLockAsync(key, () => TouchRowAsync(key, ct), ct);
         return await _storage.OpenReadAsync(RelativePath(key), ct);
     }
 
@@ -246,10 +247,7 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             return;
         }
 
-        await using MediaContext context = await _contextFactory.CreateDbContextAsync(ct);
-        await context
-            .DerivedAudio.Where(row => row.Key == key)
-            .ExecuteUpdateAsync(set => set.SetProperty(row => row.LastUsedAt, DateTime.UtcNow), ct);
+        await UnderKeyLockAsync(key, () => TouchRowAsync(key, ct), ct);
     }
 
     public async Task DeleteAsync(string key, CancellationToken ct = default)
@@ -259,13 +257,15 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             return;
         }
 
-        if (await _storage.ExistsAsync(RelativePath(key), ct))
-        {
-            await _storage.DeleteAsync(RelativePath(key), ct);
-        }
-        await using MediaContext context = await _contextFactory.CreateDbContextAsync(ct);
-        await context.DerivedAudio.Where(row => row.Key == key).ExecuteDeleteAsync(ct);
+        await UnderKeyLockAsync(key, () => DeleteEntryAsync(key, ct), ct);
     }
+
+    /// <summary>
+    /// Runs between choosing a victim and deleting it, so a test can make a
+    /// key busy in exactly the window this method guards against. Never set
+    /// in production.
+    /// </summary>
+    internal Func<Task>? BeforeDelete { get; init; }
 
     public async Task<long> EvictAsync(
         long capBytes,
@@ -279,9 +279,10 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             rows = await context.DerivedAudio.AsNoTracking().ToListAsync(ct);
         }
 
+        long total = rows.Sum(row => row.Bytes);
         long freed = 0;
         foreach (
-            DerivedAudioRow row in DerivedAudioEviction.Choose(
+            DerivedAudioRow row in DerivedAudioEviction.Candidates(
                 rows,
                 capBytes,
                 grace,
@@ -289,9 +290,26 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             )
         )
         {
+            if (total <= capBytes)
+            {
+                break;
+            }
+
             ct.ThrowIfCancellationRequested();
-            await DeleteAsync(row.Key, ct);
-            freed += row.Bytes;
+
+            if (BeforeDelete is not null)
+            {
+                await BeforeDelete();
+            }
+
+            long? evicted = await DeleteIfStillColdAsync(row.Key, grace, ct);
+            if (evicted is null)
+            {
+                continue;
+            }
+
+            freed += evicted.Value;
+            total -= evicted.Value;
         }
 
         await SweepStaleTempFilesAsync(grace, ct);
@@ -302,6 +320,85 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             _logger.LogInformation("Derived audio eviction freed {Freed} bytes", freed);
         }
         return freed;
+    }
+
+    /// <summary>
+    /// Deletes one victim under the same per-key lock a put takes, and only
+    /// after re-reading its row: eviction chose from a snapshot, and a key
+    /// read or touched since then is in use again - deleting it would pull the
+    /// file out from under an ffmpeg run that is already reading it. Null when
+    /// the key was left alone, the bytes freed when it went.
+    /// </summary>
+    private async Task<long?> DeleteIfStillColdAsync(
+        string key,
+        TimeSpan grace,
+        CancellationToken ct
+    )
+    {
+        SemaphoreSlim keyLock = _locks.GetOrAdd(key, static _ => new SemaphoreSlim(1, 1));
+        await keyLock.WaitAsync(ct);
+        try
+        {
+            DerivedAudioRow? row;
+            await using (MediaContext context = await _contextFactory.CreateDbContextAsync(ct))
+            {
+                row = await context
+                    .DerivedAudio.AsNoTracking()
+                    .FirstOrDefaultAsync(candidate => candidate.Key == key, ct);
+            }
+
+            if (row is null || row.LastUsedAt > DateTime.UtcNow - grace)
+            {
+                return null;
+            }
+
+            await DeleteEntryAsync(key, ct);
+            return row.Bytes;
+        }
+        finally
+        {
+            keyLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// The per-key lock <see cref="PutAsync" /> takes, around a touch or a
+    /// delete: a touch that lands while eviction is deleting the same key
+    /// leaves a register row pointing at a file that is already gone.
+    /// </summary>
+    private async Task UnderKeyLockAsync(string key, Func<Task> body, CancellationToken ct)
+    {
+        SemaphoreSlim keyLock = _locks.GetOrAdd(key, static _ => new SemaphoreSlim(1, 1));
+        await keyLock.WaitAsync(ct);
+        try
+        {
+            await body();
+        }
+        finally
+        {
+            keyLock.Release();
+        }
+    }
+
+    /// <summary>The touch itself, with the key's lock already held.</summary>
+    private async Task TouchRowAsync(string key, CancellationToken ct)
+    {
+        await using MediaContext context = await _contextFactory.CreateDbContextAsync(ct);
+        await context
+            .DerivedAudio.Where(row => row.Key == key)
+            .ExecuteUpdateAsync(set => set.SetProperty(row => row.LastUsedAt, DateTime.UtcNow), ct);
+    }
+
+    /// <summary>The delete itself, with the key's lock already held.</summary>
+    private async Task DeleteEntryAsync(string key, CancellationToken ct)
+    {
+        if (await _storage.ExistsAsync(RelativePath(key), ct))
+        {
+            await _storage.DeleteAsync(RelativePath(key), ct);
+        }
+
+        await using MediaContext context = await _contextFactory.CreateDbContextAsync(ct);
+        await context.DerivedAudio.Where(row => row.Key == key).ExecuteDeleteAsync(ct);
     }
 
     // The mirror of the tmp/ sweep, one step further along: a crash between

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
@@ -28,13 +28,9 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
     private readonly IDbContextFactory<MediaContext> _contextFactory;
     private readonly ILogger<DerivedAudioStore> _logger;
 
-    // Serializes concurrent PutAsync calls for the same key within this store
-    // instance. The store is registered as a process-wide singleton, so two
-    // jobs producing the same stem or rendered segment racing through PutAsync
-    // is the expected case, not an edge case. One SemaphoreSlim accumulates
-    // per distinct key for the store's lifetime — acceptable because the key
-    // space is bounded by distinct content ever produced, which is small next
-    // to a media library.
+    // Serializes puts, touches and deletes of one key inside this store, which
+    // is a process-wide singleton. One SemaphoreSlim per distinct key is kept
+    // for its lifetime: that key space is small next to a media library.
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
 
     /// <param name="storage">An <see cref="IStorage" /> scoped to <c>AppFiles.DerivedAudioPath</c>; every path below is relative to it.</param>
@@ -108,13 +104,9 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
         }
     }
 
-    // Split out of PutAsync so the per-key lock covers only the exists/move/
-    // register sequence, not the hashing above it. Even with the lock, a
-    // second store instance (a second process, or a second DI resolution
-    // that is not actually a singleton) can still race here, so both the
-    // move and the insert additionally treat "someone else already did this"
-    // as success rather than letting the caller fail: the content is stored
-    // and registered either way, which is the contract PutAsync promises.
+    // Split out so the per-key lock covers only the exists/move/register
+    // sequence, not the hashing. A second store instance can still race here,
+    // so both the move and the insert treat "already done" as success.
     private async Task<DerivedAudioEntry> StoreAndRegisterAsync(
         string tempPath,
         string key,

--- a/src/NoMercy.MediaProcessing/Jobs/MediaJobs/MusicAnalysisJob.cs
+++ b/src/NoMercy.MediaProcessing/Jobs/MediaJobs/MusicAnalysisJob.cs
@@ -203,24 +203,40 @@ public class MusicAnalysisJob : IShouldQueue
 
         await mediaContext.SaveChangesAsync();
 
-        // Read here rather than carried on the job: the membership can change
-        // between queueing and running, and a subscriber deciding retention
-        // per library needs the state the verdict was actually written under.
-        List<Ulid> libraryIds = await mediaContext
-            .LibraryTrack.AsNoTracking()
-            .Where(libraryTrack => libraryTrack.TrackId == TrackId)
-            .Select(libraryTrack => libraryTrack.LibraryId)
-            .Distinct()
-            .ToListAsync();
+        // The verdict is stored by now, so nothing below may fail the job: the
+        // queue would dead-letter a job whose row landed, and the sweep would
+        // keep re-analysing a track that already has its answer. A subscriber
+        // that never hears about it is worth less than a row that is never
+        // written.
+        try
+        {
+            // Read here rather than carried on the job: the membership can change
+            // between queueing and running, and a subscriber deciding retention
+            // per library needs the state the verdict was actually written under.
+            List<Ulid> libraryIds = await mediaContext
+                .LibraryTrack.AsNoTracking()
+                .Where(libraryTrack => libraryTrack.TrackId == TrackId)
+                .Select(libraryTrack => libraryTrack.LibraryId)
+                .Distinct()
+                .ToListAsync();
 
-        await _eventBus.PublishAsync(
-            new TrackAudioAnalysisCompletedEvent
-            {
-                TrackId = TrackId,
-                AnalyzerVersion = row.AnalyzerVersion,
-                State = row.State.ToString(),
-                LibraryIds = libraryIds,
-            }
-        );
+            await _eventBus.PublishAsync(
+                new TrackAudioAnalysisCompletedEvent
+                {
+                    TrackId = TrackId,
+                    AnalyzerVersion = row.AnalyzerVersion,
+                    State = row.State.ToString(),
+                    LibraryIds = libraryIds,
+                }
+            );
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                ex,
+                "audio analysis for track {TrackId} was stored but its completion event could not be published",
+                TrackId
+            );
+        }
     }
 }

--- a/src/NoMercy.Plugins.Abstractions/IPluginMusicAnalysisWriter.cs
+++ b/src/NoMercy.Plugins.Abstractions/IPluginMusicAnalysisWriter.cs
@@ -40,6 +40,36 @@ public interface IPluginMusicAnalysisWriter
     Task<PluginWriteResult> RegisterStemAsync(PluginTrackStem stem, CancellationToken ct = default);
 
     /// <summary>
+    /// Adds or replaces several stems as one write: either every row lands or
+    /// none does. The stems of one split only mean something together - a
+    /// vocals row whose accompaniment was refused describes a track no
+    /// renderer can mix - so the host validates all of them before it writes
+    /// any of them, in one transaction.
+    /// <para>
+    /// Default-implemented so an implementer written against an older ABI
+    /// keeps compiling. That fallback registers the stems one at a time and
+    /// stops at the first refusal, which is weaker than the host's own
+    /// all-or-nothing write.
+    /// </para>
+    /// </summary>
+    async Task<PluginWriteResult> RegisterStemsAsync(
+        IReadOnlyList<PluginTrackStem> stems,
+        CancellationToken ct = default
+    )
+    {
+        foreach (PluginTrackStem stem in stems)
+        {
+            PluginWriteResult result = await RegisterStemAsync(stem, ct);
+            if (!result.Ok)
+            {
+                return result;
+            }
+        }
+
+        return PluginWriteResult.Accepted();
+    }
+
+    /// <summary>
     /// Records that analysis was attempted and did not produce a row, so a
     /// sweep can tell "not analysed yet" from "analysed and failed" instead
     /// of retrying the same broken file for ever.

--- a/src/NoMercy.Plugins.Abstractions/PluginAbi.cs
+++ b/src/NoMercy.Plugins.Abstractions/PluginAbi.cs
@@ -18,6 +18,8 @@ public static class PluginAbi
     // loads — which is what IsCompatible's "minor may be lower" rule means.
     // 10.2 added IPluginAudioTools, IPluginDerivedAudio, IPluginMusicAnalysisWriter and the
     // DJ members of IPluginMusicQuery. Additive; the context members default to null.
+    // IPluginMusicAnalysisWriter.RegisterStemsAsync joined 10.2 with a default implementation,
+    // so it needs no bump: an implementer written before it keeps compiling.
     public static Version Current { get; } = new(10, 2);
 
     public static bool IsCompatible(string? targetAbi)

--- a/src/NoMercy.Plugins/IPluginAudioToolsFactory.cs
+++ b/src/NoMercy.Plugins/IPluginAudioToolsFactory.cs
@@ -23,6 +23,12 @@ namespace NoMercy.Plugins;
 /// <c>PluginHookCapability.AudioTools</c> question the plugin host answers
 /// before asking for them, not something this factory re-checks.
 /// </para>
+/// <para>
+/// The host's one rule for facade lifetimes: a facade with per-plugin state
+/// is cached per plugin id by its factory, one that only stamps the plugin id
+/// is built per call, and one with no per-plugin state at all is a single
+/// shared instance.
+/// </para>
 /// </summary>
 public interface IPluginAudioToolsFactory
 {

--- a/src/NoMercy.Plugins/IPluginMusicAnalysisWriterFactory.cs
+++ b/src/NoMercy.Plugins/IPluginMusicAnalysisWriterFactory.cs
@@ -22,6 +22,12 @@ namespace NoMercy.Plugins;
 /// checks before handing the writer out at all, not something this factory
 /// re-checks per call.
 /// </para>
+/// <para>
+/// The host's one rule for facade lifetimes: a facade with per-plugin state
+/// is cached per plugin id by its factory, one that only stamps the plugin id
+/// - this writer - is built per call, and one with no per-plugin state at all
+/// is a single shared instance.
+/// </para>
 /// </summary>
 public interface IPluginMusicAnalysisWriterFactory
 {

--- a/tests/NoMercy.Tests.MediaProcessing/AudioAnalysis/MusicAnalysisJobTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/AudioAnalysis/MusicAnalysisJobTests.cs
@@ -318,6 +318,34 @@ public class MusicAnalysisJobTests : IDisposable
         );
     }
 
+    /// <summary>
+    /// The verdict is already stored by the time the event goes out, so a bus
+    /// that throws there must not take the job down with it: the queue would
+    /// dead-letter a job whose row landed, and every later sweep would see a
+    /// track that has its answer already.
+    /// </summary>
+    [Fact]
+    public async Task AVerdictIsKept_WhenTheEventCannotBePublished()
+    {
+        Mock<IEventBus> bus = new();
+        bus.Setup(b =>
+                b.PublishAsync(
+                    It.IsAny<TrackAudioAnalysisCompletedEvent>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ThrowsAsync(new InvalidOperationException("the bus is gone"));
+
+        MusicAnalysisJob job = CreateJob(SampleResult(), eventBus: bus);
+
+        await job.Handle();
+
+        TrackAudioAnalysis? row = ReadRow();
+
+        Assert.NotNull(row);
+        Assert.Equal(AudioAnalysisState.Ok, row.State);
+    }
+
     [Fact]
     public async Task AFailedVerdict_PublishesACompletedEvent()
     {

--- a/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
@@ -279,7 +279,8 @@ public sealed class DerivedAudioStoreTests : IDisposable
     /// between reading it and acting on it: a key read or touched in that
     /// window is in use again, and deleting it pulls the file out from under
     /// the run that just took it. The victim is re-checked under the same
-    /// per-key lock a put takes, and the next-coldest key goes instead.
+    /// per-key lock a put takes and left alone, while the other victims the
+    /// rule chose still go.
     /// </summary>
     [Fact]
     public async Task Evict_SkipsAKeyTouchedAfterTheSnapshot()
@@ -323,7 +324,9 @@ public sealed class DerivedAudioStoreTests : IDisposable
             await seeder.TouchAsync(oldest.Key);
         });
 
-        long freed = await store.EvictAsync(2 * oldest.Bytes, TimeSpan.FromHours(1));
+        // One file's worth of cap, so the rule chooses the two coldest keys:
+        // the touched one is skipped and the other still goes.
+        long freed = await store.EvictAsync(oldest.Bytes, TimeSpan.FromHours(1));
 
         touched.Should().BeTrue();
         freed.Should().Be(middle.Bytes);
@@ -356,13 +359,20 @@ public sealed class DerivedAudioStoreTests : IDisposable
                 .ExecuteUpdateAsync(set => set.SetProperty(row => row.LastUsedAt, cold));
         }
 
-        Task<long> evicting = store.EvictAsync(capBytes: 0, grace: TimeSpan.FromHours(1));
-        Task first = await Task.WhenAny(evicting, Task.Delay(TimeSpan.FromSeconds(10)));
+        // The deadline is the sweep's own token: a wait on a lock it already
+        // holds ends as a cancellation the assertion below reports, and
+        // nothing is left running behind a test that failed.
+        using CancellationTokenSource deadline = new(TimeSpan.FromSeconds(10));
+        Func<Task<long>> evicting = () =>
+            store.EvictAsync(capBytes: 0, grace: TimeSpan.FromHours(1), ct: deadline.Token);
 
-        first
-            .Should()
-            .BeSameAs(evicting, "eviction must not wait on the per-key lock it already holds");
-        (await evicting).Should().Be(entry.Bytes);
+        long freed = (
+            await evicting
+                .Should()
+                .NotThrowAsync("eviction must not wait on the per-key lock it already holds")
+        ).Which;
+
+        freed.Should().Be(entry.Bytes);
         (await store.ExistsAsync(entry.Key)).Should().BeFalse();
     }
 

--- a/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
@@ -440,6 +440,8 @@ public sealed class DerivedAudioStoreTests : IDisposable
     [InlineData("a")]
     [InlineData("../../etc")]
     [InlineData("ab/../../etc/passwd")]
+    [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+    [InlineData("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")]
     public async Task AnInvalidKey_IsNotFound_AndNeverTouchesTheDisk(string key)
     {
         IDerivedAudioStore store = Store();

--- a/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
@@ -101,7 +101,9 @@ public sealed class DerivedAudioStoreTests : IDisposable
         };
     }
 
-    private IDerivedAudioStore Store()
+    private IDerivedAudioStore Store() => StoreWith(null);
+
+    private DerivedAudioStore StoreWith(Func<Task>? beforeDelete)
     {
         LocalStorageDriver driver = new();
         StoragePathGuard guard = new([_root], driver);
@@ -110,7 +112,10 @@ public sealed class DerivedAudioStoreTests : IDisposable
             storage,
             _contextFactory,
             NullLogger<DerivedAudioStore>.Instance
-        );
+        )
+        {
+            BeforeDelete = beforeDelete,
+        };
     }
 
     [Fact]
@@ -267,6 +272,64 @@ public sealed class DerivedAudioStoreTests : IDisposable
         (await read.TrackStems.AsNoTracking().AnyAsync(stem => stem.StorageKey == oldest.Key))
             .Should()
             .BeFalse();
+    }
+
+    /// <summary>
+    /// Eviction picks its victims from a snapshot, and a plan can go stale
+    /// between reading it and acting on it: a key read or touched in that
+    /// window is in use again, and deleting it pulls the file out from under
+    /// the run that just took it. The victim is re-checked under the same
+    /// per-key lock a put takes, and the next-coldest key goes instead.
+    /// </summary>
+    [Fact]
+    public async Task Evict_SkipsAKeyTouchedAfterTheSnapshot()
+    {
+        IDerivedAudioStore seeder = Store();
+        DerivedAudioEntry oldest = await seeder.PutAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes("oldest content")),
+            "audio/opus"
+        );
+        DerivedAudioEntry middle = await seeder.PutAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes("middle content")),
+            "audio/opus"
+        );
+        DerivedAudioEntry newest = await seeder.PutAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes("newest content")),
+            "audio/opus"
+        );
+
+        DateTime now = DateTime.UtcNow;
+        await using (MediaContext context = new(_options))
+        {
+            await context
+                .DerivedAudio.Where(row => row.Key == oldest.Key)
+                .ExecuteUpdateAsync(set => set.SetProperty(row => row.LastUsedAt, now.AddDays(-3)));
+            await context
+                .DerivedAudio.Where(row => row.Key == middle.Key)
+                .ExecuteUpdateAsync(set => set.SetProperty(row => row.LastUsedAt, now.AddDays(-2)));
+            await context
+                .DerivedAudio.Where(row => row.Key == newest.Key)
+                .ExecuteUpdateAsync(set => set.SetProperty(row => row.LastUsedAt, now.AddDays(-1)));
+        }
+
+        bool touched = false;
+        DerivedAudioStore store = StoreWith(async () =>
+        {
+            if (touched)
+            {
+                return;
+            }
+            touched = true;
+            await seeder.TouchAsync(oldest.Key);
+        });
+
+        long freed = await store.EvictAsync(2 * oldest.Bytes, TimeSpan.FromHours(1));
+
+        touched.Should().BeTrue();
+        freed.Should().Be(middle.Bytes);
+        (await store.ExistsAsync(oldest.Key)).Should().BeTrue();
+        (await store.ExistsAsync(middle.Key)).Should().BeFalse();
+        (await store.ExistsAsync(newest.Key)).Should().BeTrue();
     }
 
     /// <summary>

--- a/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
@@ -333,6 +333,40 @@ public sealed class DerivedAudioStoreTests : IDisposable
     }
 
     /// <summary>
+    /// The victim's delete runs with the key's lock already held, so it must
+    /// not take that lock again: a <see cref="SemaphoreSlim" /> is not
+    /// re-entrant and the second wait would never return. Asserted against a
+    /// deadline, so a regression here reports as a failed test rather than as
+    /// a test run that stops.
+    /// </summary>
+    [Fact]
+    public async Task Evict_OfASingleKey_Completes()
+    {
+        IDerivedAudioStore store = Store();
+        DerivedAudioEntry entry = await store.PutAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes("the only content")),
+            "audio/opus"
+        );
+
+        DateTime cold = DateTime.UtcNow.AddDays(-2);
+        await using (MediaContext context = new(_options))
+        {
+            await context
+                .DerivedAudio.Where(row => row.Key == entry.Key)
+                .ExecuteUpdateAsync(set => set.SetProperty(row => row.LastUsedAt, cold));
+        }
+
+        Task<long> evicting = store.EvictAsync(capBytes: 0, grace: TimeSpan.FromHours(1));
+        Task first = await Task.WhenAny(evicting, Task.Delay(TimeSpan.FromSeconds(10)));
+
+        first
+            .Should()
+            .BeSameAs(evicting, "eviction must not wait on the per-key lock it already holds");
+        (await evicting).Should().Be(entry.Bytes);
+        (await store.ExistsAsync(entry.Key)).Should().BeFalse();
+    }
+
+    /// <summary>
     /// The mirror of the tmp/ sweep, one step further along the put: a crash
     /// between the move into place and the register insert leaves a content
     /// file no key addresses and no policy counts. Only this sweep frees it,

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginAudioToolsTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginAudioToolsTests.cs
@@ -91,6 +91,10 @@ public class PluginAudioToolsTests : IDisposable
     private readonly List<string> _putKeys = [];
     private readonly List<string> _putContentTypes = [];
 
+    // What the host did, in the order it did it: "touch" for a derived input's
+    // keep-alive, "run" for the ffmpeg process itself.
+    private readonly List<string> _callOrder = [];
+
     // Swapped out by the concurrency test for a task that only completes once
     // the second call has already been refused.
     private Task<ProcessResult> _runResult = Task.FromResult(
@@ -221,6 +225,15 @@ public class PluginAudioToolsTests : IDisposable
             .Setup(store => store.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         _store
+            .Setup(store => store.TouchAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(
+                (string _, CancellationToken _) =>
+                {
+                    _callOrder.Add("touch");
+                    return Task.CompletedTask;
+                }
+            );
+        _store
             .Setup(store =>
                 store.PutAsync(
                     It.IsAny<Stream>(),
@@ -251,6 +264,20 @@ public class PluginAudioToolsTests : IDisposable
                     return PluginWriteResult.Accepted();
                 }
             );
+        _writer
+            .Setup(writer =>
+                writer.RegisterStemsAsync(
+                    It.IsAny<IReadOnlyList<PluginTrackStem>>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(
+                (IReadOnlyList<PluginTrackStem> stems, CancellationToken _) =>
+                {
+                    _registeredStems.AddRange(stems);
+                    return PluginWriteResult.Accepted();
+                }
+            );
         _writerFactory
             .Setup(factory => factory.CreateFor(It.IsAny<Ulid>()))
             .Returns(_writer.Object);
@@ -277,6 +304,7 @@ public class PluginAudioToolsTests : IDisposable
                 ) =>
                 {
                     _runCount++;
+                    _callOrder.Add("run");
                     _capturedExecutable = executable;
                     _capturedArguments = arguments;
                     _capturedWorkingDirectory = workingDirectory;
@@ -513,6 +541,30 @@ public class PluginAudioToolsTests : IDisposable
             );
 
         ArgumentAfter("-i").Should().Be($"ab/{key}");
+    }
+
+    /// <summary>
+    /// A graph reading a derived file can run for ten minutes; the eviction
+    /// sweep runs hourly and only spares what was used inside its grace
+    /// window. The key is touched before ffmpeg is started, so the file cannot
+    /// be evicted out from under the run that is reading it.
+    /// </summary>
+    [Fact]
+    public async Task RunFilterGraph_OnADerivedInput_TouchesTheKeyFirst()
+    {
+        await CreateTools()
+            .RunFilterGraphAsync(
+                PluginAudioInput.Derived(DerivedKey),
+                new PluginFilterGraph("volume=1", Complex: false),
+                null,
+                null
+            );
+
+        _callOrder.Should().Equal("touch", "run");
+        _store.Verify(
+            store => store.TouchAsync(DerivedKey, It.IsAny<CancellationToken>()),
+            Times.Once
+        );
     }
 
     // --- RunFilterGraphAsync: the refusals -------------------------------
@@ -803,6 +855,29 @@ public class PluginAudioToolsTests : IDisposable
         result.Stems.Select(stem => stem.Kind).Should().Equal("vocals", "accompaniment");
         result.Stems.Should().OnlyContain(stem => stem.Coverage == PluginStemCoverage.MixIn);
         result.Stems.Select(stem => stem.StorageKey).Should().OnlyHaveUniqueItems();
+
+        // One write, both stems: a split whose second register row is refused
+        // must not leave the first one behind, so the pair goes in together.
+        _writer.Verify(
+            writer =>
+                writer.RegisterStemsAsync(
+                    It.Is<IReadOnlyList<PluginTrackStem>>(stems =>
+                        stems.Count == 2
+                        && stems[0].Kind == "vocals"
+                        && stems[1].Kind == "accompaniment"
+                    ),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+        _writer.Verify(
+            writer =>
+                writer.RegisterStemAsync(
+                    It.IsAny<PluginTrackStem>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
 
         _registeredStems.Select(stem => stem.Kind).Should().Equal("vocals", "accompaniment");
         _registeredStems

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginCallGuardTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginCallGuardTests.cs
@@ -1,0 +1,116 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NoMercy.Data.Plugins;
+using NoMercy.Plugins.Abstractions;
+
+namespace NoMercy.Tests.Repositories.Plugins;
+
+/// <summary>
+/// The one guard every plugin-facing facade runs its calls through: a failure
+/// nobody planned for becomes a refusal in the caller's own words, and the
+/// cancellation a caller asked for is the one thing that still reaches it.
+/// </summary>
+public class PluginCallGuardTests
+{
+    [Fact]
+    public async Task AThrowingCall_BecomesARefusalNamingTheExceptionType()
+    {
+        Mock<ILogger> logger = new();
+
+        PluginWriteResult result = await PluginCallGuard.RunAsync(
+            "plugin 1: WriteSomething",
+            () => throw new IOException("the volume went away"),
+            PluginWriteResult.Refused,
+            logger.Object
+        );
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Be("the server could not complete this call: IOException");
+        logger.Verify(
+            log =>
+                log.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<IOException>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task ACancelledCall_Propagates()
+    {
+        Func<Task<PluginWriteResult>> guarded = () =>
+            PluginCallGuard.RunAsync<PluginWriteResult>(
+                "plugin 1: WriteSomething",
+                () => throw new OperationCanceledException(),
+                PluginWriteResult.Refused,
+                NullLogger.Instance
+            );
+
+        await guarded.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task AMemberWithoutARefusalChannel_FallsBackToTheSuppliedValue()
+    {
+        bool exists = await PluginCallGuard.RunOrAsync(
+            "a plugin's ExistsAsync call",
+            () => throw new IOException("the volume went away"),
+            false,
+            NullLogger.Instance
+        );
+
+        exists.Should().BeFalse();
+
+        Stream? opened = await PluginCallGuard.RunOrAsync<Stream?>(
+            "a plugin's OpenReadAsync call",
+            () => throw new IOException("the volume went away"),
+            null,
+            NullLogger.Instance
+        );
+
+        opened.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AVoidMember_SwallowsToANoOp()
+    {
+        Func<Task> guarded = () =>
+            PluginCallGuard.RunAsync(
+                "a plugin's TouchAsync call",
+                () => throw new IOException("the volume went away"),
+                NullLogger.Instance
+            );
+
+        await guarded.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task ACallThatSucceeds_IsHandedBackUntouched()
+    {
+        PluginWriteResult result = await PluginCallGuard.RunAsync(
+            "plugin 1: WriteSomething",
+            () => Task.FromResult(PluginWriteResult.Accepted()),
+            PluginWriteResult.Refused,
+            NullLogger.Instance
+        );
+
+        result.Ok.Should().BeTrue();
+    }
+}

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginDerivedAudioTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginDerivedAudioTests.cs
@@ -19,15 +19,14 @@ namespace NoMercy.Tests.Repositories.Plugins;
 
 /// <summary>
 /// The host side of <see cref="IPluginDerivedAudio" />: every member forwards
-/// to <see cref="IDerivedAudioStore" />, and an empty key is refused before it
-/// ever reaches the store, since <see cref="IDerivedAudioStore.RelativePath" />
-/// slices the key to build a path.
+/// to <see cref="IDerivedAudioStore" />, which is the only key validator -
+/// a key it could not have minted comes back as an absence from there, not
+/// from a second copy of the rule in the facade.
 /// </summary>
 public class PluginDerivedAudioTests
 {
-    // Only a 64-character lowercase hex string is a key PutAsync could have
-    // minted, so the forwarding tests below have to use one: anything else is
-    // refused by the facade before the store is ever reached.
+    // A 64-character lowercase hex string: the shape PutAsync mints, which is
+    // what the forwarding tests below hand the store.
     private const string SomeKey =
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
@@ -117,17 +116,26 @@ public class PluginDerivedAudioTests
     }
 
     /// <summary>
-    /// <see cref="IDerivedAudioStore.RelativePath" /> slices the key to build a
-    /// path, so a null, empty or whitespace-only key must never reach the
-    /// store at all - the facade answers "not found" / no-op on its own.
+    /// The store is the only key validator - it answers "not found" for a key
+    /// <see cref="IDerivedAudioStore.PutAsync" /> could not have minted and
+    /// never builds a path out of one. The facade forwards and hands back
+    /// whatever the store said, rather than keeping a second copy of the rule
+    /// that would have to be kept in step with it.
     /// </summary>
     [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
-    public async Task AnEmptyKey_NeverReachesTheStore(string? key)
+    public async Task AnEmptyKey_IsForwardedToTheStore(string? key)
     {
         Mock<IDerivedAudioStore> store = new();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        store
+            .Setup(s => s.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Stream?)null);
+
         PluginDerivedAudio facade = new(store.Object);
 
         bool exists = await facade.ExistsAsync(key!);
@@ -138,22 +146,10 @@ public class PluginDerivedAudioTests
         exists.Should().BeFalse();
         opened.Should().BeNull();
 
-        store.Verify(
-            s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never
-        );
-        store.Verify(
-            s => s.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never
-        );
-        store.Verify(
-            s => s.TouchAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never
-        );
-        store.Verify(
-            s => s.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never
-        );
+        store.Verify(s => s.ExistsAsync(key!, It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.OpenReadAsync(key!, It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.TouchAsync(key!, It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.DeleteAsync(key!, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     /// <summary>
@@ -204,17 +200,26 @@ public class PluginDerivedAudioTests
     /// <summary>
     /// A key is the lowercase hex of a SHA-256 digest and nothing else, so a
     /// short one, a traversal attempt, a near-miss length and the right
-    /// characters in the wrong case are all refused here - before the store
-    /// gets the chance to slice any of them into a path.
+    /// characters in the wrong case all come back as an absence - decided by
+    /// the store, which is where that rule lives, and forwarded unchanged.
+    /// <c>DerivedAudioStoreTests.AnInvalidKey_IsNotFound_AndNeverTouchesTheDisk</c>
+    /// is what proves none of them ever becomes a path.
     /// </summary>
     [Theory]
     [InlineData("a")]
     [InlineData("../../etc")]
     [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
     [InlineData("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")]
-    public async Task AMalformedKey_NeverReachesTheStore(string key)
+    public async Task AMalformedKey_IsForwardedAndReadsAsAnAbsence(string key)
     {
         Mock<IDerivedAudioStore> store = new();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        store
+            .Setup(s => s.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Stream?)null);
+
         PluginDerivedAudio facade = new(store.Object);
 
         bool exists = await facade.ExistsAsync(key);
@@ -225,21 +230,9 @@ public class PluginDerivedAudioTests
         exists.Should().BeFalse();
         opened.Should().BeNull();
 
-        store.Verify(
-            s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never
-        );
-        store.Verify(
-            s => s.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never
-        );
-        store.Verify(
-            s => s.TouchAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never
-        );
-        store.Verify(
-            s => s.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never
-        );
+        store.Verify(s => s.ExistsAsync(key, It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.OpenReadAsync(key, It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.TouchAsync(key, It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.DeleteAsync(key, It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
@@ -19,6 +19,7 @@ using NoMercy.Database;
 using NoMercy.Database.Models.Music;
 using NoMercy.MediaProcessing.DerivedAudio;
 using NoMercy.Plugins.Abstractions;
+using DerivedAudioRow = NoMercy.Database.Models.Music.DerivedAudio;
 
 namespace NoMercy.Tests.Repositories.Plugins;
 
@@ -56,6 +57,11 @@ public class PluginMusicAnalysisWriterTests : IDisposable
 
     private const string MissingKey =
         "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+    // Registered as audio/flac, so an Opus stem pointing at it is a register
+    // row that lies about what a client will be handed.
+    private const string KeyFlac =
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
     private readonly SqliteConnection _connection;
     private readonly DbContextOptions<MediaContext> _options;
@@ -132,8 +138,29 @@ public class PluginMusicAnalysisWriterTests : IDisposable
             }
         );
 
+        // The register rows behind the keys these tests hand the writer: it
+        // reads each one's content type to check the stem's format against it.
+        // Opus in Ogg everywhere except KeyFlac, which is what the mismatch
+        // test points an Opus stem at.
+        foreach (string key in new[] { KeyOne, KeyTwo, KeyThree, KeyFour, KeyA, KeyB, KeyDelete })
+        {
+            context.DerivedAudio.Add(DerivedAudioRowFor(key, "audio/ogg"));
+        }
+
+        context.DerivedAudio.Add(DerivedAudioRowFor(KeyFlac, "audio/flac"));
+
         context.SaveChanges();
     }
+
+    private static DerivedAudioRow DerivedAudioRowFor(string key, string contentType) =>
+        new()
+        {
+            Key = key,
+            ContentType = contentType,
+            Bytes = 4096,
+            CreatedAt = DateTime.UtcNow,
+            LastUsedAt = DateTime.UtcNow,
+        };
 
     public void Dispose()
     {
@@ -811,6 +838,31 @@ public class PluginMusicAnalysisWriterTests : IDisposable
             .Select(stem => stem.StorageKey)
             .Should()
             .Equal(KeyB, KeyA);
+    }
+
+    /// <summary>
+    /// The register row is what a client is later handed the stem as, so a row
+    /// claiming Opus over a FLAC file is a player error hours after the sweep
+    /// that wrote it. The stored content type is the authority.
+    /// </summary>
+    [Fact]
+    public async Task RegisterStem_RefusesAFormatThatDoesNotMatchTheFile()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        PluginWriteResult result = await CreateWriter(store.Object)
+            .RegisterStemAsync(ValidFullStem(_trackId, KeyFlac));
+
+        result.Ok.Should().BeFalse();
+        result
+            .Refusal.Should()
+            .Be("stem format opus does not match the stored content type audio/flac");
+
+        using MediaContext context = new(_options);
+        context.TrackStems.Any(stem => stem.TrackId == _trackId).Should().BeFalse();
     }
 
     // --- MarkFailedAsync -----------------------------------------------------

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
@@ -58,6 +58,11 @@ public class PluginMusicAnalysisWriterTests : IDisposable
     private const string MissingKey =
         "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 
+    // Registered as audio/opus rather than audio/ogg: the other MIME a
+    // third-party plugin may have put an Opus file under.
+    private const string KeyOpusMime =
+        "0000000000000000000000000000000000000000000000000000000000000000";
+
     // Registered as audio/flac, so an Opus stem pointing at it is a register
     // row that lies about what a client will be handed.
     private const string KeyFlac =
@@ -148,6 +153,7 @@ public class PluginMusicAnalysisWriterTests : IDisposable
         }
 
         context.DerivedAudio.Add(DerivedAudioRowFor(KeyFlac, "audio/flac"));
+        context.DerivedAudio.Add(DerivedAudioRowFor(KeyOpusMime, "audio/opus"));
 
         context.SaveChanges();
     }
@@ -178,7 +184,8 @@ public class PluginMusicAnalysisWriterTests : IDisposable
 
     private PluginMusicAnalysisWriter CreateWriter(
         IDerivedAudioStore store,
-        Func<Task>? beforeSave = null
+        Func<Task>? beforeSave = null,
+        ILogger<PluginMusicAnalysisWriter>? logger = null
     )
     {
         Mock<IDbContextFactory<MediaContext>> factory = new();
@@ -186,11 +193,40 @@ public class PluginMusicAnalysisWriterTests : IDisposable
             .Setup(x => x.CreateDbContextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => new(_options));
 
-        return new PluginMusicAnalysisWriter(_pluginId, factory.Object, store)
+        return new PluginMusicAnalysisWriter(_pluginId, factory.Object, store, logger)
         {
             BeforeSave = beforeSave,
         };
     }
+
+    /// <summary>
+    /// Foreign keys are off for this class - most tests point stem rows at a
+    /// mocked store's keys - so a test that wants a real constraint failure
+    /// turns them back on for its own run. The pragma is per connection and
+    /// takes effect outside a transaction, which is where it is set here.
+    /// </summary>
+    private void EnableForeignKeys()
+    {
+        using SqliteCommand pragma = _connection.CreateCommand();
+        pragma.CommandText = "PRAGMA foreign_keys = ON;";
+        pragma.ExecuteNonQuery();
+    }
+
+    private static void VerifyWarningLogged(
+        Mock<ILogger<PluginMusicAnalysisWriter>> logger,
+        string contains
+    ) =>
+        logger.Verify(
+            log =>
+                log.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains(contains)),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+                ),
+            Times.Once
+        );
 
     /// <summary>
     /// The row a second sweep gets in first with, written through its own
@@ -863,6 +899,132 @@ public class PluginMusicAnalysisWriterTests : IDisposable
 
         using MediaContext context = new(_options);
         context.TrackStems.Any(stem => stem.TrackId == _trackId).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Not every <see cref="DbUpdateException" /> is a race. When the re-read
+    /// finds no competing row, the save failed for a reason of its own - a
+    /// foreign key, a column constraint, a disk - and telling the caller to
+    /// retry would hide it for ever. It is named and logged instead.
+    /// </summary>
+    [Fact]
+    public async Task RegisterStem_LogsAndRefusesANonRaceDatabaseError()
+    {
+        EnableForeignKeys();
+
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        Mock<ILogger<PluginMusicAnalysisWriter>> logger = new();
+
+        PluginMusicAnalysisWriter writer = CreateWriter(
+            store.Object,
+            async () =>
+            {
+                // The file the stem row points at goes away between the check
+                // and the save: the row's foreign key has nothing to land on.
+                await using MediaContext other = new(_options);
+                await other.DerivedAudio.Where(row => row.Key == KeyA).ExecuteDeleteAsync();
+            },
+            logger.Object
+        );
+
+        PluginWriteResult result = await writer.RegisterStemAsync(ValidFullStem(_trackId, KeyA));
+
+        result.Ok.Should().BeFalse();
+        result
+            .Refusal.Should()
+            .Be($"stem vocals/Full for track {_trackId} could not be stored: DbUpdateException");
+        VerifyWarningLogged(logger, "could not be stored");
+
+        using MediaContext context = new(_options);
+        context.TrackStems.Any(stem => stem.TrackId == _trackId).Should().BeFalse();
+    }
+
+    /// <summary>The same split on the DJ record's own save.</summary>
+    [Fact]
+    public async Task UpsertDjAnalysis_LogsAndRefusesANonRaceDatabaseError()
+    {
+        EnableForeignKeys();
+
+        Mock<ILogger<PluginMusicAnalysisWriter>> logger = new();
+
+        PluginMusicAnalysisWriter writer = CreateWriter(
+            NewStoreMock().Object,
+            async () =>
+            {
+                // The track goes away between the read and the save, so the
+                // DJ row's foreign key has nothing to land on either.
+                await using MediaContext other = new(_options);
+                await other.Tracks.Where(track => track.Id == _trackId).ExecuteDeleteAsync();
+            },
+            logger.Object
+        );
+
+        PluginWriteResult result = await writer.UpsertDjAnalysisAsync(ValidRecord(_trackId));
+
+        result.Ok.Should().BeFalse();
+        result
+            .Refusal.Should()
+            .Be($"the DJ record for track {_trackId} could not be stored: DbUpdateException");
+        VerifyWarningLogged(logger, "could not be stored");
+    }
+
+    [Fact]
+    public async Task RegisterStems_RefusesANullList()
+    {
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .RegisterStemsAsync(null!);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Be("stems must not be null");
+    }
+
+    /// <summary>
+    /// Two entries addressing one register row: whichever came second would
+    /// silently win, so the batch is refused before anything is staged rather
+    /// than storing a stem the caller did not mean to keep.
+    /// </summary>
+    [Fact]
+    public async Task RegisterStems_RefusesTheSameStemTwice()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        PluginTrackStem first = ValidFullStem(_trackId, KeyA);
+        PluginTrackStem second = ValidFullStem(_trackId, KeyB);
+
+        PluginWriteResult result = await CreateWriter(store.Object)
+            .RegisterStemsAsync([first, second]);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Be("stems contains the same stem twice: vocals/Full");
+
+        using MediaContext context = new(_options);
+        context.TrackStems.Any(stem => stem.TrackId == _trackId).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// <c>audio/opus</c> is as real a MIME for an Opus file as the
+    /// <c>audio/ogg</c> the host's own splits write, so a plugin that put its
+    /// file under it is not claiming the wrong format.
+    /// </summary>
+    [Fact]
+    public async Task RegisterStem_AcceptsTheOtherOpusContentType()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        PluginWriteResult result = await CreateWriter(store.Object)
+            .RegisterStemAsync(ValidFullStem(_trackId, KeyOpusMime));
+
+        result.Ok.Should().BeTrue();
     }
 
     // --- MarkFailedAsync -----------------------------------------------------

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
@@ -149,14 +149,45 @@ public class PluginMusicAnalysisWriterTests : IDisposable
         return mock;
     }
 
-    private PluginMusicAnalysisWriter CreateWriter(IDerivedAudioStore store)
+    private PluginMusicAnalysisWriter CreateWriter(
+        IDerivedAudioStore store,
+        Func<Task>? beforeSave = null
+    )
     {
         Mock<IDbContextFactory<MediaContext>> factory = new();
         factory
             .Setup(x => x.CreateDbContextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => new(_options));
 
-        return new PluginMusicAnalysisWriter(_pluginId, factory.Object, store);
+        return new PluginMusicAnalysisWriter(_pluginId, factory.Object, store)
+        {
+            BeforeSave = beforeSave,
+        };
+    }
+
+    /// <summary>
+    /// The row a second sweep gets in first with, written through its own
+    /// context so the writer under test meets it as a unique-index violation
+    /// rather than as something it staged itself.
+    /// </summary>
+    private async Task InsertStemRowAsync(string storageKey)
+    {
+        await using MediaContext other = new(_options);
+        other.TrackStems.Add(
+            new TrackStem
+            {
+                Id = Ulid.NewUlid(),
+                TrackId = _trackId,
+                Kind = "vocals",
+                Coverage = StemCoverage.Full,
+                Format = "opus",
+                SampleRate = 48000,
+                StorageKey = storageKey,
+                ProducerVersion = "spleeter-2stems-f16@v1",
+                CreatedAt = DateTime.UtcNow,
+            }
+        );
+        await other.SaveChangesAsync();
     }
 
     private static PluginTrackDjAnalysis ValidRecord(Guid trackId) =>
@@ -271,6 +302,53 @@ public class PluginMusicAnalysisWriterTests : IDisposable
             .UpsertDjAnalysisAsync(record);
 
         result.Ok.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A vocal region is a pair, and the planner reads it as one: a single
+    /// value would be read as a region ending where the next one starts, and
+    /// a backwards pair as a region of negative length. Both are refused
+    /// rather than stored for a renderer to trip over hours later.
+    /// </summary>
+    [Fact]
+    public async Task UpsertDjAnalysisAsync_RefusesAOneElementVocalRegion()
+    {
+        PluginTrackDjAnalysis record = ValidRecord(_trackId) with
+        {
+            VocalRegionsMs =
+            [
+                [1000, 5000],
+                [9000],
+            ],
+        };
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(record);
+
+        result.Ok.Should().BeFalse();
+        result
+            .Refusal.Should()
+            .Be("vocal_regions_ms entry 1 must be [start, end] with start < end");
+    }
+
+    [Fact]
+    public async Task UpsertDjAnalysisAsync_RefusesAnInvertedVocalRegion()
+    {
+        PluginTrackDjAnalysis record = ValidRecord(_trackId) with
+        {
+            VocalRegionsMs =
+            [
+                [5000, 1000],
+            ],
+        };
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(record);
+
+        result.Ok.Should().BeFalse();
+        result
+            .Refusal.Should()
+            .Be("vocal_regions_ms entry 0 must be [start, end] with start < end");
     }
 
     [Fact]
@@ -599,6 +677,140 @@ public class PluginMusicAnalysisWriterTests : IDisposable
 
         TrackStem row = context.TrackStems.Single(s => s.TrackId == _trackId);
         row.StorageKey.Should().Be(KeyB);
+    }
+
+    /// <summary>
+    /// Two sweeps registering the same stem at once both read "no row" and
+    /// both insert; the loser's save hits the unique index. Nothing is lost -
+    /// the winner wrote the same row, pointing at the same file - so the loser
+    /// is told it landed rather than handed a driver exception.
+    /// </summary>
+    [Fact]
+    public async Task RegisterStem_TreatsAConcurrentIdenticalWriteAsAccepted()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        bool raced = false;
+        PluginMusicAnalysisWriter writer = CreateWriter(
+            store.Object,
+            async () =>
+            {
+                if (raced)
+                {
+                    return;
+                }
+                raced = true;
+                await InsertStemRowAsync(KeyA);
+            }
+        );
+
+        PluginWriteResult result = await writer.RegisterStemAsync(ValidFullStem(_trackId, KeyA));
+
+        raced.Should().BeTrue();
+        result.Ok.Should().BeTrue();
+
+        using MediaContext context = new(_options);
+        context.TrackStems.Count(stem => stem.TrackId == _trackId).Should().Be(1);
+        context.TrackStems.Single(stem => stem.TrackId == _trackId).StorageKey.Should().Be(KeyA);
+    }
+
+    /// <summary>
+    /// The same race, but the winner stored a different file under the same
+    /// stem. Reporting that as accepted would leave the caller believing its
+    /// own key is registered, so this one is refused in words instead.
+    /// </summary>
+    [Fact]
+    public async Task RegisterStem_RefusesWhenTheConcurrentWriteStoredAnotherKey()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        bool raced = false;
+        PluginMusicAnalysisWriter writer = CreateWriter(
+            store.Object,
+            async () =>
+            {
+                if (raced)
+                {
+                    return;
+                }
+                raced = true;
+                await InsertStemRowAsync(KeyB);
+            }
+        );
+
+        PluginWriteResult result = await writer.RegisterStemAsync(ValidFullStem(_trackId, KeyA));
+
+        result.Ok.Should().BeFalse();
+        result
+            .Refusal.Should()
+            .Be($"stem vocals/Full for track {_trackId} was written concurrently; retry");
+    }
+
+    /// <summary>
+    /// A split produces two stems that only mean something together: a vocals
+    /// row whose accompaniment was refused describes a track the renderer
+    /// cannot mix. Every stem is validated before any row is staged, and the
+    /// save is one transaction, so a refusal leaves the register untouched.
+    /// </summary>
+    [Fact]
+    public async Task RegisterStems_WritesNothingWhenOneStemIsRefused()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        PluginTrackStem vocals = ValidFullStem(_trackId, KeyA);
+        PluginTrackStem accompaniment = ValidFullStem(_trackId, KeyB) with
+        {
+            Kind = "accompaniment",
+            WindowStartMs = 0,
+            WindowEndMs = 60000,
+        };
+
+        PluginWriteResult result = await CreateWriter(store.Object)
+            .RegisterStemsAsync([vocals, accompaniment]);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Be("full coverage stems must not specify a window");
+
+        using MediaContext context = new(_options);
+        context.TrackStems.Any(stem => stem.TrackId == _trackId).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RegisterStems_WritesBothWhenValid()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        PluginTrackStem vocals = ValidFullStem(_trackId, KeyA);
+        PluginTrackStem accompaniment = ValidFullStem(_trackId, KeyB) with
+        {
+            Kind = "accompaniment",
+        };
+
+        PluginWriteResult result = await CreateWriter(store.Object)
+            .RegisterStemsAsync([vocals, accompaniment]);
+
+        result.Ok.Should().BeTrue();
+
+        using MediaContext context = new(_options);
+        context.TrackStems.Count(stem => stem.TrackId == _trackId).Should().Be(2);
+        context
+            .TrackStems.Where(stem => stem.TrackId == _trackId)
+            .OrderBy(stem => stem.Kind)
+            .Select(stem => stem.StorageKey)
+            .Should()
+            .Equal(KeyB, KeyA);
     }
 
     // --- MarkFailedAsync -----------------------------------------------------

--- a/tests/NoMercy.Tests.Repositories/Plugins/StemCoverageMapTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/StemCoverageMapTests.cs
@@ -1,0 +1,70 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using FluentAssertions;
+using NoMercy.Data.Plugins;
+using NoMercy.Database.Models.Music;
+using NoMercy.Plugins.Abstractions;
+
+namespace NoMercy.Tests.Repositories.Plugins;
+
+/// <summary>
+/// The one place the plugin's stem coverage and the database's own are
+/// translated into each other. Both directions are pinned here so a kind
+/// added to one enum and forgotten on the other fails a test instead of
+/// throwing inside a plugin's sweep.
+/// </summary>
+public class StemCoverageMapTests
+{
+    [Theory]
+    [InlineData(PluginStemCoverage.Full)]
+    [InlineData(PluginStemCoverage.MixIn)]
+    [InlineData(PluginStemCoverage.MixOut)]
+    public void EveryCoverage_RoundTrips(PluginStemCoverage coverage)
+    {
+        StemCoverage stored = StemCoverageMap.ToDb(coverage);
+
+        StemCoverageMap.ToPlugin(stored).Should().Be(coverage);
+    }
+
+    [Fact]
+    public void EveryPluginCoverage_IsMapped()
+    {
+        foreach (PluginStemCoverage coverage in Enum.GetValues<PluginStemCoverage>())
+        {
+            Func<StemCoverage> map = () => StemCoverageMap.ToDb(coverage);
+
+            map.Should().NotThrow($"{coverage} has no database coverage to map to");
+        }
+    }
+
+    [Fact]
+    public void EveryStoredCoverage_IsMapped()
+    {
+        foreach (StemCoverage coverage in Enum.GetValues<StemCoverage>())
+        {
+            Func<PluginStemCoverage> map = () => StemCoverageMap.ToPlugin(coverage);
+
+            map.Should().NotThrow($"{coverage} has no plugin coverage to map to");
+        }
+    }
+
+    /// <summary>
+    /// The mapper can only stay total if the two enums carry the same members:
+    /// a kind added to one side alone would otherwise be caught here rather
+    /// than by an <see cref="ArgumentOutOfRangeException" /> mid-sweep.
+    /// </summary>
+    [Fact]
+    public void BothEnums_CarryTheSameMembers()
+    {
+        Enum.GetNames<PluginStemCoverage>().Should().BeEquivalentTo(Enum.GetNames<StemCoverage>());
+    }
+}


### PR DESCRIPTION
## Why

Follow-up to #45, closing #46: the edge cases the review found inside the new, not yet exercised code paths, plus the quality findings of the merge review. No existing user or table is affected; every change is in the derived-audio store, the plugin facades and their tests.

## What (issue #46)

1. **Eviction re-checks a key under its lock before deleting.** A victim chosen from the snapshot is re-read under the same per-key lock a put takes; a key touched since the snapshot, or now inside the grace window, is left alone. `OpenReadAsync`/`TouchAsync` take the lock around their touch, so a touch cannot interleave with a delete.
2. **ffmpeg reading a derived file keeps it alive.** `PluginAudioTools` touches a derived input's key before acquiring the local-path lease, so the 24-hour grace covers a run.
3. **A concurrent identical stem registration is benign** (re-read, same key → accepted; different key → refusal with a retry hint). A `DbUpdateException` that is not a race (no competing row: a foreign key, a NOT NULL, a full disk) is logged and refused as `could not be stored: <exception type>` instead of masquerading as a retry; the DJ-record upsert makes the same distinction.
4. **Both stems register or neither.** `IPluginMusicAnalysisWriter.RegisterStemsAsync` (additive, default-implemented) writes the pair in one transaction; the audio tools use it. ABI stays 10.2.
5. **Vocal regions are validated**: exactly `[start, end]` with `start < end`.
6. **A stored verdict is never reported as a failed job**: the library lookup and the completion-event publish after `SaveChangesAsync` are guarded and logged, never rethrown.

## What (merge review)

- One `StemCoverageMap` for `PluginStemCoverage` ↔ `StemCoverage`, with a test that both enums keep the same member names.
- One `PluginCallGuard` for every public member of the three facades (the writer's delete included; `PluginDerivedAudio.PutAsync` keeps rethrowing as documented).
- Key validation lives in the store only; the facade forwards.
- One documented rule for how the host scopes a facade (shared singleton / per call / cached per plugin), in the plugin doc and on the two factory interfaces.
- `RegisterStemAsync` refuses a stem whose `Format` does not match the file's registered content type (`opus` ↔ `audio/ogg` or `audio/opus`, `flac` ↔ `audio/flac`). A batch refuses a null list and a duplicate stem within the batch before staging anything.
- Eviction picks its victims through the one choosing rule (`DerivedAudioEviction.Choose`) and re-checks each under its key lock; a victim touched since the snapshot is skipped, so the cap may only be met on the next run. `TouchAsync`/`DeleteAsync` check the register row before taking a key lock, so unknown keys create no locks; `DeleteAsync` on a file without a register row is a no-op and the orphan sweep frees it.
- Six long comments trimmed.

Out of scope, as said on #46: a shared cap-based eviction primitive across `BenchmarkJobTracker`, `LiveTranscodeService` and `CacheController` (unrelated code).

## Tests

Build 0 warnings. Database 261, MediaProcessing 1071, Repositories 631, Plugins 578, Service 200, Api 2337, all green locally; csharpier clean. New tests pin the eviction re-check (a hook touches the key between snapshot and delete), the single-key eviction completing under a deadline, the concurrent stem registration, the all-or-nothing pair, the vocal-region refusals, the guarded publish, the mapper's enum parity and the format/content-type check.

Closes #46.
