### PR TITLE
fix(music): close the touch/open-read window and refuse malformed plugin input in words (#48)

### DIFF
--- a/src/NoMercy.Data/Plugins/PluginAudioTools.cs
+++ b/src/NoMercy.Data/Plugins/PluginAudioTools.cs
@@ -75,8 +75,8 @@ public sealed class PluginAudioTools(
     /// <summary>The derived store's own scratch folder; its eviction sweep also cleans it.</summary>
     private const string TempFolder = "tmp";
 
-    // The format and content type themselves come from StemFormats, the one
-    // place the pairing a register row is checked against is written down.
+    // Format and content type live in StemFormats; only the sample rate is
+    // this encoder's own.
     private const int OpusSampleRate = 48000;
 
     /// <summary>The share of a track a mix into it draws from.</summary>

--- a/src/NoMercy.Data/Plugins/PluginAudioTools.cs
+++ b/src/NoMercy.Data/Plugins/PluginAudioTools.cs
@@ -103,7 +103,8 @@ public sealed class PluginAudioTools(
         CancellationToken ct = default
     ) =>
         PluginCallGuard.RunAsync(
-            $"plugin {pluginId}: {nameof(RunFilterGraphAsync)}",
+            pluginId.ToString(),
+            nameof(RunFilterGraphAsync),
             () => RunFilterGraphCoreAsync(input, graph, onStdOut, onStdErr, ct),
             PluginAudioRunResult.Refused,
             _logger
@@ -178,7 +179,8 @@ public sealed class PluginAudioTools(
         CancellationToken ct = default
     ) =>
         PluginCallGuard.RunAsync(
-            $"plugin {pluginId}: {nameof(SplitStemsAsync)}",
+            pluginId.ToString(),
+            nameof(SplitStemsAsync),
             () => SplitStemsCoreAsync(trackId, coverage, stemSet, ct),
             PluginStemSplitResult.Refused,
             _logger

--- a/src/NoMercy.Data/Plugins/PluginAudioTools.cs
+++ b/src/NoMercy.Data/Plugins/PluginAudioTools.cs
@@ -75,8 +75,8 @@ public sealed class PluginAudioTools(
     /// <summary>The derived store's own scratch folder; its eviction sweep also cleans it.</summary>
     private const string TempFolder = "tmp";
 
-    private const string OpusContentType = "audio/ogg";
-    private const string OpusFormat = "opus";
+    // The format and content type themselves come from StemFormats, the one
+    // place the pairing a register row is checked against is written down.
     private const int OpusSampleRate = 48000;
 
     /// <summary>The share of a track a mix into it draws from.</summary>
@@ -376,7 +376,7 @@ public sealed class PluginAudioTools(
                         coverage,
                         window.StartMs,
                         window.EndMs,
-                        OpusFormat,
+                        StemFormats.Opus,
                         OpusSampleRate,
                         stem.Entry.Key,
                         producerVersion
@@ -421,7 +421,7 @@ public sealed class PluginAudioTools(
         DerivedAudioEntry entry;
         await using (Stream content = await derivedStorage.OpenReadAsync(tempPath, ct))
         {
-            entry = await store.PutAsync(content, OpusContentType, ct);
+            entry = await store.PutAsync(content, StemFormats.OggContentType, ct);
         }
 
         return entry;

--- a/src/NoMercy.Data/Plugins/PluginCallGuard.cs
+++ b/src/NoMercy.Data/Plugins/PluginCallGuard.cs
@@ -22,12 +22,21 @@ namespace NoMercy.Data.Plugins;
 /// <para>
 /// Cancellation the caller asked for is never swallowed anywhere here.
 /// </para>
+/// <para>
+/// Which plugin and which member are logged as two structured properties
+/// rather than one sentence, so a log pipeline can answer "everything this
+/// plugin did" without parsing the message. The derived-audio facade is one
+/// object every plugin shares and has no plugin of its own to name; it passes
+/// <c>"shared"</c> rather than leaving the property out, because a missing
+/// field reads as a gap in the pipeline.
+/// </para>
 /// </summary>
 public static class PluginCallGuard
 {
     /// <summary>For a member that can say why it could not answer.</summary>
     public static async Task<T> RunAsync<T>(
-        string operation,
+        string pluginId,
+        string member,
         Func<Task<T>> body,
         Func<string, T> refuse,
         ILogger logger
@@ -39,7 +48,7 @@ public static class PluginCallGuard
         }
         catch (Exception exception) when (exception is not OperationCanceledException)
         {
-            LogUnexpected(logger, exception, operation);
+            LogUnexpected(logger, exception, pluginId, member);
             return refuse($"the server could not complete this call: {exception.GetType().Name}");
         }
     }
@@ -49,7 +58,8 @@ public static class PluginCallGuard
     /// the member already has a word for - false, or null.
     /// </summary>
     public static async Task<T> RunOrAsync<T>(
-        string operation,
+        string pluginId,
+        string member,
         Func<Task<T>> body,
         T fallback,
         ILogger logger
@@ -61,13 +71,18 @@ public static class PluginCallGuard
         }
         catch (Exception exception) when (exception is not OperationCanceledException)
         {
-            LogUnexpected(logger, exception, operation);
+            LogUnexpected(logger, exception, pluginId, member);
             return fallback;
         }
     }
 
     /// <summary>For a member that returns nothing, where a failure is a no-op.</summary>
-    public static async Task RunAsync(string operation, Func<Task> body, ILogger logger)
+    public static async Task RunAsync(
+        string pluginId,
+        string member,
+        Func<Task> body,
+        ILogger logger
+    )
     {
         try
         {
@@ -75,10 +90,20 @@ public static class PluginCallGuard
         }
         catch (Exception exception) when (exception is not OperationCanceledException)
         {
-            LogUnexpected(logger, exception, operation);
+            LogUnexpected(logger, exception, pluginId, member);
         }
     }
 
-    private static void LogUnexpected(ILogger logger, Exception exception, string operation) =>
-        logger.LogWarning(exception, "{Operation} failed inside the server", operation);
+    private static void LogUnexpected(
+        ILogger logger,
+        Exception exception,
+        string pluginId,
+        string member
+    ) =>
+        logger.LogWarning(
+            exception,
+            "plugin {PluginId}: {Member} failed inside the server",
+            pluginId,
+            member
+        );
 }

--- a/src/NoMercy.Data/Plugins/PluginDerivedAudio.cs
+++ b/src/NoMercy.Data/Plugins/PluginDerivedAudio.cs
@@ -77,7 +77,8 @@ public sealed class PluginDerivedAudio(
 
     public Task<bool> ExistsAsync(string key, CancellationToken ct = default) =>
         PluginCallGuard.RunOrAsync(
-            Operation(nameof(ExistsAsync)),
+            SharedPluginId,
+            nameof(ExistsAsync),
             () => store.ExistsAsync(key, ct),
             false,
             _logger
@@ -85,7 +86,8 @@ public sealed class PluginDerivedAudio(
 
     public Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default) =>
         PluginCallGuard.RunOrAsync<Stream?>(
-            Operation(nameof(OpenReadAsync)),
+            SharedPluginId,
+            nameof(OpenReadAsync),
             () => store.OpenReadAsync(key, ct),
             null,
             _logger
@@ -93,19 +95,24 @@ public sealed class PluginDerivedAudio(
 
     public Task TouchAsync(string key, CancellationToken ct = default) =>
         PluginCallGuard.RunAsync(
-            Operation(nameof(TouchAsync)),
+            SharedPluginId,
+            nameof(TouchAsync),
             () => store.TouchAsync(key, ct),
             _logger
         );
 
     public Task DeleteAsync(string key, CancellationToken ct = default) =>
         PluginCallGuard.RunAsync(
-            Operation(nameof(DeleteAsync)),
+            SharedPluginId,
+            nameof(DeleteAsync),
             () => store.DeleteAsync(key, ct),
             _logger
         );
 
-    /// <summary>Which call this is, for the guard's warning line.</summary>
-    private static string Operation(string member) =>
-        $"a plugin's {member} call on the derived store";
+    /// <summary>
+    /// One facade serves every plugin, so there is no plugin to name in the
+    /// guard's warning line. It says so rather than leaving the property out:
+    /// a missing field reads as a gap in the pipeline.
+    /// </summary>
+    private const string SharedPluginId = "shared";
 }

--- a/src/NoMercy.Data/Plugins/PluginDerivedAudio.cs
+++ b/src/NoMercy.Data/Plugins/PluginDerivedAudio.cs
@@ -70,7 +70,15 @@ public sealed class PluginDerivedAudio(
         }
         catch (Exception exception) when (exception is not OperationCanceledException)
         {
-            _logger.LogWarning(exception, "the derived store could not accept a plugin's content");
+            // The one log line here the guard does not write, so it carries
+            // the same two properties by hand rather than being the one entry
+            // a pipeline filtering on them cannot see.
+            _logger.LogWarning(
+                exception,
+                "plugin {PluginId}: {Member} failed inside the server",
+                SharedPluginId,
+                nameof(PutAsync)
+            );
             throw;
         }
     }

--- a/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
@@ -164,6 +164,13 @@ public class PluginMusicAnalysisWriter(
                 $"downbeat_index value {downbeatIndex} lies outside the beat grid (0..{record.BeatsPerBar - 1})"
             );
 
+        // Before anything reads through the lists: a null entry inside one of
+        // them is what a plugin written against a looser language hands over,
+        // and every loop below dereferences its entries.
+        PluginWriteResult? missingEntry = CheckEntriesPresent(record);
+        if (missingEntry is not null)
+            return missingEntry;
+
         double? durationSeconds = PluginMusicQuery.ParseDurationSeconds(track.Duration);
 
         if (durationSeconds is null)
@@ -362,6 +369,15 @@ public class PluginMusicAnalysisWriter(
         CancellationToken ct
     )
     {
+        // Before anything else per stem: nothing below can read a member that
+        // is not there. The format is the one that used to throw outright -
+        // the content-type pairing lowercases it - and a null kind or producer
+        // version would only surface hours later as a DbUpdateException
+        // against a column that does not take one.
+        PluginWriteResult? missingMember = CheckStemMembersPresent(stem);
+        if (missingMember is not null)
+            return missingMember;
+
         bool trackExists = await context
             .Tracks.AsNoTracking()
             .AnyAsync(t => t.Id == stem.TrackId, ct);
@@ -413,6 +429,31 @@ public class PluginMusicAnalysisWriter(
             if (stem.WindowStartMs.Value >= stem.WindowEndMs.Value)
                 return PluginWriteResult.Refused("window_start_ms must be less than window_end_ms");
         }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Every string member of a stem is required, and whitespace is as absent
+    /// as null: a kind of <c>"   "</c> addresses a row nothing will ever find
+    /// again.
+    /// <para>
+    /// The storage key is deliberately not named here. It keeps the refusal it
+    /// already had - <c>storage key {key} is not in the derived store</c> - so
+    /// that a key which is missing, invented or stale gets a plugin one answer
+    /// rather than three.
+    /// </para>
+    /// </summary>
+    private static PluginWriteResult? CheckStemMembersPresent(PluginTrackStem stem)
+    {
+        if (string.IsNullOrWhiteSpace(stem.Format))
+            return PluginWriteResult.Refused("format must not be empty");
+
+        if (string.IsNullOrWhiteSpace(stem.Kind))
+            return PluginWriteResult.Refused("kind must not be empty");
+
+        if (string.IsNullOrWhiteSpace(stem.ProducerVersion))
+            return PluginWriteResult.Refused("producer_version must not be empty");
 
         return null;
     }
@@ -674,7 +715,7 @@ public class PluginMusicAnalysisWriter(
         for (int index = 0; index < regions.Count; index++)
         {
             int[] region = regions[index];
-            if (region.Length != 2 || region[0] >= region[1])
+            if (region is null || region.Length != 2 || region[0] >= region[1])
                 return PluginWriteResult.Refused(
                     $"vocal_regions_ms entry {index} must be [start, end] with start < end"
                 );
@@ -720,6 +761,44 @@ public class PluginMusicAnalysisWriter(
 
         if (record.Chords is null)
             return PluginWriteResult.Refused("chords must not be null");
+
+        return null;
+    }
+
+    /// <summary>
+    /// The same rule one level down: every entry inside those lists is
+    /// required too. A null one is read through by the range check, the shape
+    /// check and the serializer alike, so it is named here before any of them
+    /// runs - a refusal a plugin author can act on, rather than the
+    /// <see cref="NullReferenceException" /> the guard would hand back as
+    /// "the server could not complete this call".
+    /// <para>
+    /// A null vocal region is reported as the malformed region it is, in the
+    /// same words a one-element or backwards pair gets: from the caller's side
+    /// there is one rule, and the entry does not keep it.
+    /// </para>
+    /// </summary>
+    private static PluginWriteResult? CheckEntriesPresent(PluginTrackDjAnalysis record)
+    {
+        for (int index = 0; index < record.VocalRegionsMs.Count; index++)
+        {
+            if (record.VocalRegionsMs[index] is null)
+                return PluginWriteResult.Refused(
+                    $"vocal_regions_ms entry {index} must be [start, end] with start < end"
+                );
+        }
+
+        for (int index = 0; index < record.CuePoints.Count; index++)
+        {
+            if (record.CuePoints[index] is null)
+                return PluginWriteResult.Refused($"cue_points entry {index} must not be null");
+        }
+
+        for (int index = 0; index < record.Chords.Count; index++)
+        {
+            if (record.Chords[index] is null)
+                return PluginWriteResult.Refused($"chords entry {index} must not be null");
+        }
 
         return null;
     }

--- a/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
@@ -269,6 +269,22 @@ public class PluginMusicAnalysisWriter(
     /// loser can simply run again. With no row, the save failed for a reason
     /// of its own - a foreign key, a column constraint, a disk - and "retry"
     /// would hide that for ever, so it is logged and named instead.
+    /// <para>
+    /// This is the keyed half of the server's two rules for a lost write. The
+    /// row is addressed by an identifier, not by its content, so the writer
+    /// that won the race may have stored something quite different from what
+    /// this call meant to store: the loser re-reads the row and either accepts
+    /// an identical one or refuses and asks the caller to run again. It never
+    /// assumes the two writes agreed.
+    /// </para>
+    /// <para>
+    /// The other half is the content-addressed one, in
+    /// <c>DerivedAudioStore.StoreAndRegisterAsync</c>: a key there IS the hash
+    /// of the bytes, so a lost race means the winner wrote the same content
+    /// and the loser can report success without reading anything back. Both
+    /// halves agree on the third case, which is the one below - a failure with
+    /// no competing row is a real error, logged and named.
+    /// </para>
     /// </summary>
     private async Task<PluginWriteResult> ResolveFailedDjWriteAsync(
         Guid trackId,
@@ -409,7 +425,7 @@ public class PluginMusicAnalysisWriter(
 
         // The register row is what a client is handed the stem as, so a row
         // claiming Opus over a FLAC file is a player error hours later.
-        if (!FormatMatchesContentType(stem.Format, contentType))
+        if (!StemFormats.Matches(stem.Format, contentType))
             return PluginWriteResult.Refused(
                 $"stem format {stem.Format} does not match the stored content type {contentType}"
             );
@@ -478,20 +494,6 @@ public class PluginMusicAnalysisWriter(
         return null;
     }
 
-    /// <summary>
-    /// The pairings the derived store can hold today. Anything else is a
-    /// mismatch rather than an unknown: a format that cannot come out of that
-    /// container is not a row worth keeping.
-    /// </summary>
-    private static bool FormatMatchesContentType(string format, string contentType) =>
-        (format.ToLowerInvariant(), contentType.ToLowerInvariant()) switch
-        {
-            ("opus", "audio/ogg") => true,
-            ("opus", "audio/opus") => true,
-            ("flac", "audio/flac") => true,
-            _ => false,
-        };
-
     /// <summary>Adds or updates one stem's row on the context, without saving it.</summary>
     private static async Task StageStemAsync(
         MediaContext context,
@@ -535,6 +537,17 @@ public class PluginMusicAnalysisWriter(
     /// row at all the save failed for a reason of its own - a foreign key, a
     /// column constraint, a disk - which is logged and named rather than
     /// dressed up as something a retry would fix.
+    /// <para>
+    /// The keyed half of the two rules again, and the comparison it needs is
+    /// visible here: one stem row is addressed by (track, kind, coverage,
+    /// producer), which says nothing about which content landed under it, so
+    /// the storage keys are what decide whether the race cost anything.
+    /// </para>
+    /// <para>
+    /// The content-addressed half, <c>DerivedAudioStore.StoreAndRegisterAsync</c>,
+    /// needs no such comparison: its key is the hash of the bytes, so a lost
+    /// race there cannot have stored anything else.
+    /// </para>
     /// </summary>
     private async Task<PluginWriteResult> ResolveFailedStemWriteAsync(
         IReadOnlyList<PluginTrackStem> stems,

--- a/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
+++ b/src/NoMercy.Data/Plugins/PluginMusicAnalysisWriter.cs
@@ -60,7 +60,8 @@ public class PluginMusicAnalysisWriter(
         CancellationToken ct = default
     ) =>
         PluginCallGuard.RunAsync(
-            Operation(nameof(UpsertDjAnalysisAsync)),
+            pluginId.ToString(),
+            nameof(UpsertDjAnalysisAsync),
             () => UpsertDjAnalysisCoreAsync(record, ct),
             PluginWriteResult.Refused,
             _logger
@@ -71,7 +72,8 @@ public class PluginMusicAnalysisWriter(
         CancellationToken ct = default
     ) =>
         PluginCallGuard.RunAsync(
-            Operation(nameof(RegisterStemAsync)),
+            pluginId.ToString(),
+            nameof(RegisterStemAsync),
             () => RegisterStemsCoreAsync([stem], ct),
             PluginWriteResult.Refused,
             _logger
@@ -82,7 +84,8 @@ public class PluginMusicAnalysisWriter(
         CancellationToken ct = default
     ) =>
         PluginCallGuard.RunAsync(
-            Operation(nameof(RegisterStemsAsync)),
+            pluginId.ToString(),
+            nameof(RegisterStemsAsync),
             () => RegisterStemsCoreAsync(stems, ct),
             PluginWriteResult.Refused,
             _logger
@@ -96,7 +99,8 @@ public class PluginMusicAnalysisWriter(
         CancellationToken ct = default
     ) =>
         PluginCallGuard.RunAsync(
-            Operation(nameof(MarkFailedAsync)),
+            pluginId.ToString(),
+            nameof(MarkFailedAsync),
             () => MarkFailedCoreAsync(trackId, djAnalyzerVersion, baseAnalyzerVersion, reason, ct),
             PluginWriteResult.Refused,
             _logger
@@ -110,13 +114,11 @@ public class PluginMusicAnalysisWriter(
     /// </summary>
     public Task DeleteDjAnalysisAsync(Guid trackId, CancellationToken ct = default) =>
         PluginCallGuard.RunAsync(
-            Operation(nameof(DeleteDjAnalysisAsync)),
+            pluginId.ToString(),
+            nameof(DeleteDjAnalysisAsync),
             () => DeleteDjAnalysisCoreAsync(trackId, ct),
             _logger
         );
-
-    /// <summary>Which plugin's call this is, for the guard's warning line.</summary>
-    private string Operation(string member) => $"plugin {pluginId}: {member}";
 
     private async Task<PluginWriteResult> UpsertDjAnalysisCoreAsync(
         PluginTrackDjAnalysis record,

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
@@ -218,9 +218,25 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
         return await context.DerivedAudio.AsNoTracking().AnyAsync(row => row.Key == key, ct);
     }
 
+    /// <summary>
+    /// The pre-check outside the lock is what keeps a key nothing ever stored
+    /// from minting a semaphore; the re-check inside it is what survives an
+    /// eviction that took the entry while this call was queued behind it.
+    /// <para>
+    /// Only the stream outlives the lock. That is safe: the touch above it has
+    /// already moved <c>LastUsedAt</c> inside the grace window, so the next
+    /// eviction's own re-check under this same lock finds the key warm and
+    /// leaves it alone while the caller is still reading.
+    /// </para>
+    /// </summary>
     public async Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default)
     {
         if (!DerivedAudioKey.IsValid(key))
+        {
+            return null;
+        }
+
+        if (!await HasRegisterRowAsync(key, ct))
         {
             return null;
         }
@@ -230,10 +246,35 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             return null;
         }
 
-        await UnderKeyLockAsync(key, () => TouchRowAsync(key, ct), ct);
-        return await _storage.OpenReadAsync(RelativePath(key), ct);
+        await RunAfterPreCheckAsync();
+
+        return await UnderKeyLockAsync<Stream?>(
+            key,
+            async () =>
+            {
+                if (!await HasRegisterRowAsync(key, ct))
+                {
+                    return null;
+                }
+
+                if (!await _storage.ExistsAsync(RelativePath(key), ct))
+                {
+                    return null;
+                }
+
+                await TouchRowAsync(key, ct);
+                return await _storage.OpenReadAsync(RelativePath(key), ct);
+            },
+            ct
+        );
     }
 
+    /// <summary>
+    /// Both halves of the same guard as <see cref="OpenReadAsync" />: the
+    /// cheap pre-check keeps unknown keys out of the lock dictionary, and the
+    /// re-check under the lock makes sure the row a touch is about to bump is
+    /// still there after the wait.
+    /// </summary>
     public async Task TouchAsync(string key, CancellationToken ct = default)
     {
         if (!DerivedAudioKey.IsValid(key) || !await HasRegisterRowAsync(key, ct))
@@ -241,8 +282,32 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             return;
         }
 
-        await UnderKeyLockAsync(key, () => TouchRowAsync(key, ct), ct);
+        await RunAfterPreCheckAsync();
+
+        await UnderKeyLockAsync(
+            key,
+            async () =>
+            {
+                if (!await HasRegisterRowAsync(key, ct))
+                {
+                    return;
+                }
+
+                await TouchRowAsync(key, ct);
+            },
+            ct
+        );
     }
+
+    /// <summary>
+    /// Runs after the pre-check outside the lock and before the lock itself,
+    /// so a test can land an eviction in exactly the window the re-check under
+    /// the lock guards against. Never set in production.
+    /// </summary>
+    internal Func<Task>? AfterPreCheck { get; init; }
+
+    private Task RunAfterPreCheckAsync() =>
+        AfterPreCheck is null ? Task.CompletedTask : AfterPreCheck();
 
     /// <summary>
     /// A key with no register row is nothing to delete: a content file without
@@ -364,13 +429,25 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
     /// delete: a touch that lands while eviction is deleting the same key
     /// leaves a register row pointing at a file that is already gone.
     /// </summary>
-    private async Task UnderKeyLockAsync(string key, Func<Task> body, CancellationToken ct)
+    private Task UnderKeyLockAsync(string key, Func<Task> body, CancellationToken ct) =>
+        UnderKeyLockAsync<bool>(
+            key,
+            async () =>
+            {
+                await body();
+                return true;
+            },
+            ct
+        );
+
+    /// <summary>The same lock around a body that answers with something.</summary>
+    private async Task<T> UnderKeyLockAsync<T>(string key, Func<Task<T>> body, CancellationToken ct)
     {
         SemaphoreSlim keyLock = _locks.GetOrAdd(key, static _ => new SemaphoreSlim(1, 1));
         await keyLock.WaitAsync(ct);
         try
         {
-            await body();
+            return await body();
         }
         finally
         {

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
@@ -9,12 +9,12 @@
 //  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
 // -----------------------------------------------------------------------------
 
-using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NoMercy.Database;
 using NoMercy.Storage;
+using NoMercy.Storage.Common;
 using DerivedAudioRow = NoMercy.Database.Models.Music.DerivedAudio;
 
 namespace NoMercy.MediaProcessing.DerivedAudio;
@@ -29,11 +29,11 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
     private readonly ILogger<DerivedAudioStore> _logger;
 
     // Serializes puts, touches and deletes of one key inside this store, which
-    // is a process-wide singleton. A semaphore is only ever created for a key
-    // the register actually holds - an unknown key is answered before this is
-    // touched - so the dictionary is bounded by stored content, not by what
-    // callers ask about.
-    private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
+    // is a process-wide singleton. A key is only ever locked once the register
+    // is known to hold it - an unknown key is answered before this is touched -
+    // so the lock table is bounded by stored content, not by what callers ask
+    // about.
+    private readonly KeyedAsyncLock _locks = new();
 
     /// <param name="storage">An <see cref="IStorage" /> scoped to <c>AppFiles.DerivedAudioPath</c>; every path below is relative to it.</param>
     /// <param name="contextFactory">Creates a fresh <see cref="MediaContext" /> per operation.</param>
@@ -94,16 +94,8 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             key = Convert.ToHexStringLower(hash.GetHashAndReset());
         }
 
-        SemaphoreSlim keyLock = _locks.GetOrAdd(key, static _ => new SemaphoreSlim(1, 1));
-        await keyLock.WaitAsync(ct);
-        try
-        {
-            return await StoreAndRegisterAsync(tempPath, key, contentType, bytes, ct);
-        }
-        finally
-        {
-            keyLock.Release();
-        }
+        using IDisposable keyLock = await _locks.AcquireAsync(key, ct);
+        return await StoreAndRegisterAsync(tempPath, key, contentType, bytes, ct);
     }
 
     // Split out so the per-key lock covers only the exists/move/register
@@ -220,7 +212,7 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
 
     /// <summary>
     /// The pre-check outside the lock is what keeps a key nothing ever stored
-    /// from minting a semaphore; the re-check inside it is what survives an
+    /// from taking a lock at all; the re-check inside it is what survives an
     /// eviction that took the entry while this call was queued behind it.
     /// <para>
     /// Only the stream outlives the lock. That is safe: the touch above it has
@@ -325,8 +317,8 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
     }
 
     /// <summary>
-    /// Asked before the key's semaphore is created, so a well-formed key
-    /// nothing ever stored leaves no lock behind in the dictionary.
+    /// Asked before the key is ever locked, so a well-formed key nothing ever
+    /// stored leaves no entry behind in the lock table.
     /// </summary>
     private async Task<bool> HasRegisterRowAsync(string key, CancellationToken ct)
     {
@@ -398,30 +390,23 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
         CancellationToken ct
     )
     {
-        SemaphoreSlim keyLock = _locks.GetOrAdd(key, static _ => new SemaphoreSlim(1, 1));
-        await keyLock.WaitAsync(ct);
-        try
-        {
-            DerivedAudioRow? row;
-            await using (MediaContext context = await _contextFactory.CreateDbContextAsync(ct))
-            {
-                row = await context
-                    .DerivedAudio.AsNoTracking()
-                    .FirstOrDefaultAsync(candidate => candidate.Key == key, ct);
-            }
+        using IDisposable keyLock = await _locks.AcquireAsync(key, ct);
 
-            if (row is null || row.LastUsedAt > DateTime.UtcNow - grace)
-            {
-                return null;
-            }
-
-            await DeleteEntryAsync(key, ct);
-            return row.Bytes;
-        }
-        finally
+        DerivedAudioRow? row;
+        await using (MediaContext context = await _contextFactory.CreateDbContextAsync(ct))
         {
-            keyLock.Release();
+            row = await context
+                .DerivedAudio.AsNoTracking()
+                .FirstOrDefaultAsync(candidate => candidate.Key == key, ct);
         }
+
+        if (row is null || row.LastUsedAt > DateTime.UtcNow - grace)
+        {
+            return null;
+        }
+
+        await DeleteEntryAsync(key, ct);
+        return row.Bytes;
     }
 
     /// <summary>
@@ -443,16 +428,8 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
     /// <summary>The same lock around a body that answers with something.</summary>
     private async Task<T> UnderKeyLockAsync<T>(string key, Func<Task<T>> body, CancellationToken ct)
     {
-        SemaphoreSlim keyLock = _locks.GetOrAdd(key, static _ => new SemaphoreSlim(1, 1));
-        await keyLock.WaitAsync(ct);
-        try
-        {
-            return await body();
-        }
-        finally
-        {
-            keyLock.Release();
-        }
+        using IDisposable keyLock = await _locks.AcquireAsync(key, ct);
+        return await body();
     }
 
     /// <summary>The touch itself, with the key's lock already held.</summary>

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
@@ -241,6 +241,14 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
     /// eviction's own re-check under this same lock finds the key warm and
     /// leaves it alone while the caller is still reading.
     /// </para>
+    /// <para>
+    /// Asking for the register row twice - once in the pre-check, once under
+    /// the lock - costs a read two database round-trips. That is acceptable
+    /// here: both are a single indexed lookup against a local SQLite file,
+    /// they are dwarfed by the file open and the ffmpeg run that follows, and
+    /// the alternative is either handing back a key eviction already took or
+    /// minting a lock entry for every key a caller invents.
+    /// </para>
     /// </summary>
     public async Task<Stream?> OpenReadAsync(string key, CancellationToken ct = default)
     {
@@ -497,7 +505,10 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
         {
             ct.ThrowIfCancellationRequested();
             string name = entry.Path.Split('/')[^1];
-            if (entry.IsDirectory && name.Length == 2 && name != TempFolder)
+            // The length check alone excludes tmp/: a shard is the first two
+            // characters of a key, and "tmp" is three. Whatever is in there
+            // belongs to SweepStaleTempFilesAsync, which has its own rules.
+            if (entry.IsDirectory && name.Length == 2)
             {
                 contentFolders.Add(entry.Path);
             }

--- a/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/DerivedAudioStore.cs
@@ -98,9 +98,27 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
         return await StoreAndRegisterAsync(tempPath, key, contentType, bytes, ct);
     }
 
-    // Split out so the per-key lock covers only the exists/move/register
-    // sequence, not the hashing. A second store instance can still race here,
-    // so both the move and the insert treat "already done" as success.
+    /// <summary>
+    /// Split out so the per-key lock covers only the exists/move/register
+    /// sequence, not the hashing. A second store instance can still race here,
+    /// so both the move and the insert treat "already done" as success.
+    /// <para>
+    /// That is the content-addressed half of the server's two rules for a lost
+    /// write. A key here IS the bytes: whoever won the race wrote exactly what
+    /// this call was going to write, so there is nothing to reconcile and
+    /// nothing for the caller to redo. The loser bumps the winner's row and
+    /// reports success.
+    /// </para>
+    /// <para>
+    /// The other half is the keyed one, in
+    /// <c>PluginMusicAnalysisWriter.ResolveFailedDjWriteAsync</c> and
+    /// <c>ResolveFailedStemWriteAsync</c>: a row addressed by an identifier
+    /// rather than by its content may hold something else entirely, so the
+    /// loser re-reads it and either accepts an identical row or refuses. Both
+    /// halves agree on the third case - a failure with no competing row is a
+    /// real error, logged and named, never dressed up as a retry.
+    /// </para>
+    /// </summary>
     private async Task<DerivedAudioEntry> StoreAndRegisterAsync(
         string tempPath,
         string key,
@@ -175,8 +193,11 @@ public sealed class DerivedAudioStore : IDerivedAudioStore
             }
             catch (DbUpdateException)
             {
-                // Lost a cross-instance race to register the row; the winner's
-                // row is already there — bump it instead of failing the caller.
+                // Lost a cross-instance race to register the row. The key is
+                // the hash of the content, so the winner's row describes the
+                // same bytes this call just wrote — bump it instead of failing
+                // the caller. See the summary above for why the keyed writes
+                // in PluginMusicAnalysisWriter cannot assume that.
                 await TouchRowAsync(key, ct);
             }
         }

--- a/src/NoMercy.MediaProcessing/DerivedAudio/StemFormats.cs
+++ b/src/NoMercy.MediaProcessing/DerivedAudio/StemFormats.cs
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+namespace NoMercy.MediaProcessing.DerivedAudio;
+
+/// <summary>
+/// What a stem may be, and what it may be stored as.
+/// <para>
+/// The producer that writes a stem and the writer that registers one both
+/// need this vocabulary, and they used to hold a copy each: the encoder's own
+/// "opus"/"audio/ogg" constants on one side, a pairing switch on the other.
+/// Two copies of one table drift, and the drift only shows up as a client
+/// being handed a file that is not what its register row claims - hours after
+/// the sweep that stored it.
+/// </para>
+/// </summary>
+public static class StemFormats
+{
+    /// <summary>The format the stem splitter writes today.</summary>
+    public const string Opus = "opus";
+
+    /// <summary>The lossless format a producer may write instead.</summary>
+    public const string Flac = "flac";
+
+    /// <summary>Opus in an Ogg container - what <c>PutAsync</c> is handed.</summary>
+    public const string OggContentType = "audio/ogg";
+
+    /// <summary>The other MIME a third-party producer may put Opus under.</summary>
+    public const string OpusContentType = "audio/opus";
+
+    /// <summary>FLAC.</summary>
+    public const string FlacContentType = "audio/flac";
+
+    /// <summary>
+    /// True only for a pairing the derived store can actually hold. Anything
+    /// else is a mismatch rather than an unknown: a format that cannot come
+    /// out of that container is not a register row worth keeping.
+    /// <para>
+    /// Case is not what a caller is refused over - a producer writing "OPUS"
+    /// means the same format - but the pair itself is.
+    /// </para>
+    /// </summary>
+    public static bool Matches(string format, string contentType)
+    {
+        if (Is(format, Opus))
+        {
+            return Is(contentType, OggContentType) || Is(contentType, OpusContentType);
+        }
+
+        if (Is(format, Flac))
+        {
+            return Is(contentType, FlacContentType);
+        }
+
+        return false;
+    }
+
+    private static bool Is(string value, string expected) =>
+        string.Equals(value, expected, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/NoMercy.Storage/Common/KeyedAsyncLock.cs
+++ b/src/NoMercy.Storage/Common/KeyedAsyncLock.cs
@@ -1,0 +1,71 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+
+namespace NoMercy.Storage.Common;
+
+/// <summary>
+/// One async lock per key: work on different keys runs side by side, work on
+/// the same key queues up.
+/// <para>
+/// A key's semaphore is never removed. Removing one races a concurrent
+/// <see cref="ConcurrentDictionary{TKey,TValue}.GetOrAdd(TKey,Func{TKey,TValue})" />
+/// into minting a second gate for the same key - which is exactly the
+/// serialization this exists to guarantee - so callers keep the dictionary
+/// bounded by asking only about keys they actually hold work for.
+/// </para>
+/// <para>
+/// It lives in <c>NoMercy.Storage</c> because that is the lowest assembly
+/// every caller can reach: <c>NoMercy.NmSystem</c> already references this
+/// one, so a home there would be out of reach for storage itself.
+/// </para>
+/// </summary>
+public sealed class KeyedAsyncLock
+{
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _gates = new(
+        StringComparer.Ordinal
+    );
+
+    /// <summary>
+    /// Waits for <paramref name="key" /> and hands back the release: dispose
+    /// it - a <c>using</c> does - to let the next caller in.
+    /// </summary>
+    /// <exception cref="OperationCanceledException">
+    /// <paramref name="ct" /> was cancelled while waiting. The key is left
+    /// exactly as it was, so the holder's release still reaches whoever is
+    /// next in line.
+    /// </exception>
+    public async Task<IDisposable> AcquireAsync(string key, CancellationToken ct = default)
+    {
+        SemaphoreSlim gate = _gates.GetOrAdd(key, static _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct);
+        return new Release(gate);
+    }
+
+    /// <summary>
+    /// The held key, as the only thing a caller can do with it: give it back.
+    /// Disposing twice releases once - a <c>using</c> inside a method that
+    /// also releases by hand is a permit count this lock never had.
+    /// </summary>
+    private sealed class Release(SemaphoreSlim gate) : IDisposable
+    {
+        private int _released;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _released, 1) == 0)
+            {
+                gate.Release();
+            }
+        }
+    }
+}

--- a/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
@@ -9,11 +9,13 @@
 //  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
 // -----------------------------------------------------------------------------
 
+using System.Data.Common;
 using System.Security.Cryptography;
 using System.Text;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NoMercy.Database;
@@ -103,19 +105,84 @@ public sealed class DerivedAudioStoreTests : IDisposable
 
     private IDerivedAudioStore Store() => StoreWith(null);
 
-    private DerivedAudioStore StoreWith(Func<Task>? beforeDelete)
+    private DerivedAudioStore StoreWith(Func<Task>? beforeDelete) =>
+        StoreWith(beforeDelete, null, null);
+
+    private DerivedAudioStore StoreWith(
+        Func<Task>? beforeDelete,
+        Func<Task>? afterPreCheck,
+        RecordingInterceptor? recorder
+    )
     {
         LocalStorageDriver driver = new();
         StoragePathGuard guard = new([_root], driver);
         IStorage storage = new LocalStorage(driver, guard);
         return new DerivedAudioStore(
             storage,
-            _contextFactory,
+            FactoryRecording(recorder),
             NullLogger<DerivedAudioStore>.Instance
         )
         {
             BeforeDelete = beforeDelete,
+            AfterPreCheck = afterPreCheck,
         };
+    }
+
+    /// <summary>
+    /// The shared factory, or one whose contexts report every statement they
+    /// run to <paramref name="recorder" /> - the same in-memory database
+    /// either way.
+    /// </summary>
+    private IDbContextFactory<MediaContext> FactoryRecording(RecordingInterceptor? recorder)
+    {
+        if (recorder is null)
+        {
+            return _contextFactory;
+        }
+
+        DbContextOptions<MediaContext> options = new DbContextOptionsBuilder<MediaContext>()
+            .UseSqlite(_connection)
+            .AddInterceptors(recorder)
+            .Options;
+
+        Mock<IDbContextFactory<MediaContext>> factory = new();
+        factory
+            .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new MediaContext(options));
+        factory.Setup(f => f.CreateDbContext()).Returns(() => new MediaContext(options));
+        return factory.Object;
+    }
+
+    /// <summary>
+    /// Records the statements a store runs, because the difference the
+    /// re-check under the key lock makes is otherwise invisible: an UPDATE
+    /// against a row eviction has already deleted changes nothing a later
+    /// read could see.
+    /// </summary>
+    private sealed class RecordingInterceptor : DbCommandInterceptor
+    {
+        public List<string> Commands { get; } = [];
+
+        public override InterceptionResult<int> NonQueryExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<int> result
+        )
+        {
+            Commands.Add(command.CommandText);
+            return base.NonQueryExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default
+        )
+        {
+            Commands.Add(command.CommandText);
+            return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
+        }
     }
 
     [Fact]
@@ -178,6 +245,62 @@ public sealed class DerivedAudioStoreTests : IDisposable
     public async Task OpenRead_OfAnUnknownKey_IsNull()
     {
         Stream? stream = await Store().OpenReadAsync(new string('a', 64));
+
+        stream.Should().BeNull();
+    }
+
+    /// <summary>
+    /// The pre-check that keeps an unknown key from minting a semaphore saw a
+    /// register row, and eviction took the entry while this call was still
+    /// waiting for the key lock. The touch must not run at all then - the row
+    /// it would bump is gone, and the window between the pre-check and the
+    /// lock is exactly what the re-check under the lock closes.
+    /// </summary>
+    [Fact]
+    public async Task Touch_UnderTheLock_DoesNothingWhenEvictionWonTheRace()
+    {
+        IDerivedAudioStore evictor = Store();
+        DerivedAudioEntry entry = await evictor.PutAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes("content eviction is about to take")),
+            "audio/opus"
+        );
+
+        RecordingInterceptor recorder = new();
+        DerivedAudioStore store = StoreWith(
+            null,
+            async () =>
+            {
+                await evictor.DeleteAsync(entry.Key);
+                recorder.Commands.Clear();
+            },
+            recorder
+        );
+
+        await store.TouchAsync(entry.Key);
+
+        recorder
+            .Commands.Should()
+            .NotContain(command => command.Contains("UPDATE", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// The same race one member along: the file the reader was about to open
+    /// went with the row, so the caller is told there is nothing rather than
+    /// handed the <see cref="FileNotFoundException" /> an open of a deleted
+    /// path throws.
+    /// </summary>
+    [Fact]
+    public async Task OpenRead_UnderTheLock_ReturnsNullWhenEvictionWonTheRace()
+    {
+        IDerivedAudioStore evictor = Store();
+        DerivedAudioEntry entry = await evictor.PutAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes("content the reader just missed")),
+            "audio/opus"
+        );
+
+        DerivedAudioStore store = StoreWith(null, () => evictor.DeleteAsync(entry.Key), null);
+
+        Stream? stream = await store.OpenReadAsync(entry.Key);
 
         stream.Should().BeNull();
     }

--- a/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
@@ -250,7 +250,7 @@ public sealed class DerivedAudioStoreTests : IDisposable
     }
 
     /// <summary>
-    /// The pre-check that keeps an unknown key from minting a semaphore saw a
+    /// The pre-check that keeps an unknown key out of the lock table saw a
     /// register row, and eviction took the entry while this call was still
     /// waiting for the key lock. The touch must not run at all then - the row
     /// it would bump is gone, and the window between the pre-check and the
@@ -460,8 +460,8 @@ public sealed class DerivedAudioStoreTests : IDisposable
 
     /// <summary>
     /// The victim's delete runs with the key's lock already held, so it must
-    /// not take that lock again: a <see cref="SemaphoreSlim" /> is not
-    /// re-entrant and the second wait would never return. Asserted against a
+    /// not take that lock again: the keyed lock is not re-entrant and the
+    /// second wait would never return. Asserted against a
     /// deadline, so a regression here reports as a failed test rather than as
     /// a test run that stops.
     /// </summary>

--- a/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
@@ -502,9 +502,7 @@ public sealed class DerivedAudioStoreTests : IDisposable
     /// <summary>
     /// The mirror of the tmp/ sweep, one step further along the put: a crash
     /// between the move into place and the register insert leaves a content
-    /// file no key addresses and no policy counts. Only this sweep frees it,
-    /// and only after the grace window, so it cannot race a put that is
-    /// between its own move and insert right now.
+    /// file no key addresses and no policy counts. Only this sweep frees it.
     /// </summary>
     [Fact]
     public async Task Evict_RemovesAContentFileThatHasNoRegisterRow()
@@ -515,22 +513,70 @@ public sealed class DerivedAudioStoreTests : IDisposable
             "audio/opus"
         );
 
-        string staleKey = new('c', 64);
-        string freshKey = new('d', 64);
-        Directory.CreateDirectory(Path.Combine(_root, staleKey[..2]));
-        Directory.CreateDirectory(Path.Combine(_root, freshKey[..2]));
-        string stalePath = Path.Combine(_root, staleKey[..2], staleKey);
-        string freshPath = Path.Combine(_root, freshKey[..2], freshKey);
-        await File.WriteAllBytesAsync(stalePath, Encoding.UTF8.GetBytes("orphaned by a crash"));
-        await File.WriteAllBytesAsync(freshPath, Encoding.UTF8.GetBytes("still being registered"));
-        File.SetLastWriteTimeUtc(stalePath, DateTime.UtcNow.AddDays(-2));
-        File.SetLastWriteTimeUtc(freshPath, DateTime.UtcNow);
+        string stalePath = PlantOrphan(new string('c', 64), DateTime.UtcNow.AddDays(-2));
 
         await store.EvictAsync(capBytes: long.MaxValue, grace: TimeSpan.FromHours(1));
 
         File.Exists(stalePath).Should().BeFalse();
-        File.Exists(freshPath).Should().BeTrue();
         (await store.ExistsAsync(kept.Key)).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The grace window is the whole reason this sweep is safe: a put that is
+    /// between its own move-into-place and its register insert right now looks
+    /// exactly like an orphan. A file younger than the window is left alone,
+    /// so the sweep can never pull content out from under a put in flight.
+    /// </summary>
+    [Fact]
+    public async Task Evict_LeavesAnOrphanInsideTheGraceWindow()
+    {
+        IDerivedAudioStore store = Store();
+
+        string freshPath = PlantOrphan(new string('d', 64), DateTime.UtcNow);
+
+        await store.EvictAsync(capBytes: long.MaxValue, grace: TimeSpan.FromHours(1));
+
+        File.Exists(freshPath).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Only the two-character shards a key's path is built from are content
+    /// folders. Anything else under the derived root belongs to something
+    /// else - tmp/ has its own sweep with its own rules - and this one must
+    /// not walk into it, whatever it holds and however old.
+    /// </summary>
+    [Fact]
+    public async Task Evict_IgnoresFoldersThatAreNotTwoCharacters()
+    {
+        IDerivedAudioStore store = Store();
+
+        string outsidePath = PlantStaleFile("abc", new string('e', 64));
+        string tempLikePath = PlantStaleFile("tmpx", new string('f', 64));
+
+        await store.EvictAsync(capBytes: long.MaxValue, grace: TimeSpan.FromHours(1));
+
+        File.Exists(outsidePath).Should().BeTrue();
+        File.Exists(tempLikePath).Should().BeTrue();
+    }
+
+    /// <summary>A content file under its own shard, with no register row.</summary>
+    private string PlantOrphan(string key, DateTime lastWriteUtc)
+    {
+        Directory.CreateDirectory(Path.Combine(_root, key[..2]));
+        string path = Path.Combine(_root, key[..2], key);
+        File.WriteAllBytes(path, Encoding.UTF8.GetBytes("orphaned by a crash"));
+        File.SetLastWriteTimeUtc(path, lastWriteUtc);
+        return path;
+    }
+
+    /// <summary>A file under a folder that is not a shard, old enough to be swept if it were.</summary>
+    private string PlantStaleFile(string folder, string name)
+    {
+        Directory.CreateDirectory(Path.Combine(_root, folder));
+        string path = Path.Combine(_root, folder, name);
+        File.WriteAllBytes(path, Encoding.UTF8.GetBytes("not this sweep's business"));
+        File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddDays(-2));
+        return path;
     }
 
     [Fact]

--- a/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/DerivedAudioStoreTests.cs
@@ -158,6 +158,12 @@ public sealed class DerivedAudioStoreTests : IDisposable
     /// re-check under the key lock makes is otherwise invisible: an UPDATE
     /// against a row eviction has already deleted changes nothing a later
     /// read could see.
+    /// <para>
+    /// The assertion built on this reads EF Core's emitted statement text, not
+    /// the store's own code, so a touch reimplemented in anything but an
+    /// ExecuteUpdateAsync - a tracked save, a raw command, a different verb -
+    /// needs the assertion re-derived rather than trusted.
+    /// </para>
     /// </summary>
     private sealed class RecordingInterceptor : DbCommandInterceptor
     {
@@ -542,8 +548,14 @@ public sealed class DerivedAudioStoreTests : IDisposable
     /// <summary>
     /// Only the two-character shards a key's path is built from are content
     /// folders. Anything else under the derived root belongs to something
-    /// else - tmp/ has its own sweep with its own rules - and this one must
-    /// not walk into it, whatever it holds and however old.
+    /// else and this one must not walk into it, whatever it holds and however
+    /// old.
+    /// <para>
+    /// tmp/ is the case that matters: the length check alone excludes it - a
+    /// shard is two characters and "tmp" is three - and a fresh file in there
+    /// proves the orphan sweep leaves it to the temp sweep, which keeps it for
+    /// its own grace window rather than reading it as an unregistered key.
+    /// </para>
     /// </summary>
     [Fact]
     public async Task Evict_IgnoresFoldersThatAreNotTwoCharacters()
@@ -553,10 +565,18 @@ public sealed class DerivedAudioStoreTests : IDisposable
         string outsidePath = PlantStaleFile("abc", new string('e', 64));
         string tempLikePath = PlantStaleFile("tmpx", new string('f', 64));
 
+        // Fresh, so the temp sweep keeps it too: what is under test is that
+        // the orphan sweep never considered it in the first place.
+        Directory.CreateDirectory(Path.Combine(_root, "tmp"));
+        string tempPath = Path.Combine(_root, "tmp", new string('a', 64));
+        await File.WriteAllBytesAsync(tempPath, Encoding.UTF8.GetBytes("a put still in flight"));
+        File.SetLastWriteTimeUtc(tempPath, DateTime.UtcNow);
+
         await store.EvictAsync(capBytes: long.MaxValue, grace: TimeSpan.FromHours(1));
 
         File.Exists(outsidePath).Should().BeTrue();
         File.Exists(tempLikePath).Should().BeTrue();
+        File.Exists(tempPath).Should().BeTrue();
     }
 
     /// <summary>A content file under its own shard, with no register row.</summary>
@@ -687,6 +707,31 @@ public sealed class DerivedAudioStoreTests : IDisposable
 
         File.Exists(Path.Combine(_root, entry.Key[..2], entry.Key)).Should().BeTrue();
         (await store.ExistsAsync(entry.Key)).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// And a read of that same half-entry answers the same way, rather than
+    /// handing back bytes the store will not admit to holding: the orphan
+    /// sweep is free to delete that file underneath the reader, and a caller
+    /// told "here it is" by one member and "there is none" by the next has no
+    /// way to tell which one to believe.
+    /// </summary>
+    [Fact]
+    public async Task OpenRead_IsNullForAFileWithoutARegisterRow()
+    {
+        IDerivedAudioStore store = Store();
+        DerivedAudioEntry entry = await store.PutAsync(
+            new MemoryStream(Encoding.UTF8.GetBytes("orphan content")),
+            "audio/opus"
+        );
+
+        await using (MediaContext context = new(_options))
+        {
+            await context.DerivedAudio.Where(row => row.Key == entry.Key).ExecuteDeleteAsync();
+        }
+
+        File.Exists(Path.Combine(_root, entry.Key[..2], entry.Key)).Should().BeTrue();
+        (await store.OpenReadAsync(entry.Key)).Should().BeNull();
     }
 
     [Fact]

--- a/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/StemFormatsTests.cs
+++ b/tests/NoMercy.Tests.MediaProcessing/DerivedAudio/StemFormatsTests.cs
@@ -1,0 +1,59 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using FluentAssertions;
+using NoMercy.MediaProcessing.DerivedAudio;
+
+namespace NoMercy.Tests.MediaProcessing.DerivedAudio;
+
+/// <summary>
+/// The one table saying which stem format may be stored under which content
+/// type. A register row that claims Opus over a FLAC file is a player error
+/// hours later, so the pairing is checked rather than assumed - and checked in
+/// one place, because two copies of it drift.
+/// </summary>
+[Trait("Category", "Unit")]
+public class StemFormatsTests
+{
+    [Theory]
+    [InlineData("opus", "audio/ogg", true)]
+    [InlineData("opus", "audio/opus", true)]
+    [InlineData("flac", "audio/flac", true)]
+    [InlineData("opus", "audio/flac", false)]
+    [InlineData("flac", "audio/ogg", false)]
+    [InlineData("flac", "audio/opus", false)]
+    [InlineData("mp3", "audio/mpeg", false)]
+    [InlineData("opus", "audio/mpeg", false)]
+    [InlineData("", "audio/ogg", false)]
+    public void Matches_AnswersThePairingTable(string format, string contentType, bool expected) =>
+        StemFormats.Matches(format, contentType).Should().Be(expected);
+
+    /// <summary>
+    /// Case is not what a plugin is refused over: a third-party producer that
+    /// writes "OPUS" and "AUDIO/OGG" means the same pair.
+    /// </summary>
+    [Theory]
+    [InlineData("OPUS", "audio/ogg")]
+    [InlineData("opus", "AUDIO/OGG")]
+    [InlineData("Flac", "Audio/Flac")]
+    public void Matches_IgnoresCase(string format, string contentType) =>
+        StemFormats.Matches(format, contentType).Should().BeTrue();
+
+    [Fact]
+    public void TheVocabularyIsTheOneTheStoreWrites()
+    {
+        StemFormats.Opus.Should().Be("opus");
+        StemFormats.Flac.Should().Be("flac");
+        StemFormats.OggContentType.Should().Be("audio/ogg");
+        StemFormats.OpusContentType.Should().Be("audio/opus");
+        StemFormats.FlacContentType.Should().Be("audio/flac");
+    }
+}

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginCallGuardTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginCallGuardTests.cs
@@ -25,13 +25,16 @@ namespace NoMercy.Tests.Repositories.Plugins;
 /// </summary>
 public class PluginCallGuardTests
 {
+    private const string PluginId = "01HZY0000000000000000000AA";
+
     [Fact]
     public async Task AThrowingCall_BecomesARefusalNamingTheExceptionType()
     {
         Mock<ILogger> logger = new();
 
         PluginWriteResult result = await PluginCallGuard.RunAsync(
-            "plugin 1: WriteSomething",
+            PluginId,
+            "WriteSomething",
             () => throw new IOException("the volume went away"),
             PluginWriteResult.Refused,
             logger.Object
@@ -57,7 +60,8 @@ public class PluginCallGuardTests
     {
         Func<Task<PluginWriteResult>> guarded = () =>
             PluginCallGuard.RunAsync<PluginWriteResult>(
-                "plugin 1: WriteSomething",
+                PluginId,
+                "WriteSomething",
                 () => throw new OperationCanceledException(),
                 PluginWriteResult.Refused,
                 NullLogger.Instance
@@ -70,7 +74,8 @@ public class PluginCallGuardTests
     public async Task AMemberWithoutARefusalChannel_FallsBackToTheSuppliedValue()
     {
         bool exists = await PluginCallGuard.RunOrAsync(
-            "a plugin's ExistsAsync call",
+            "shared",
+            "ExistsAsync",
             () => throw new IOException("the volume went away"),
             false,
             NullLogger.Instance
@@ -79,7 +84,8 @@ public class PluginCallGuardTests
         exists.Should().BeFalse();
 
         Stream? opened = await PluginCallGuard.RunOrAsync<Stream?>(
-            "a plugin's OpenReadAsync call",
+            "shared",
+            "OpenReadAsync",
             () => throw new IOException("the volume went away"),
             null,
             NullLogger.Instance
@@ -93,7 +99,8 @@ public class PluginCallGuardTests
     {
         Func<Task> guarded = () =>
             PluginCallGuard.RunAsync(
-                "a plugin's TouchAsync call",
+                "shared",
+                "TouchAsync",
                 () => throw new IOException("the volume went away"),
                 NullLogger.Instance
             );
@@ -105,12 +112,103 @@ public class PluginCallGuardTests
     public async Task ACallThatSucceeds_IsHandedBackUntouched()
     {
         PluginWriteResult result = await PluginCallGuard.RunAsync(
-            "plugin 1: WriteSomething",
+            PluginId,
+            "WriteSomething",
             () => Task.FromResult(PluginWriteResult.Accepted()),
             PluginWriteResult.Refused,
             NullLogger.Instance
         );
 
         result.Ok.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Which plugin and which member are two facts, not one sentence: a log
+    /// pipeline can filter on "everything this plugin did" only when they
+    /// arrive as separate properties. The exception stays the first argument,
+    /// so the stack trace is attached to the entry rather than formatted into
+    /// its message.
+    /// </summary>
+    [Fact]
+    public async Task AThrowingCall_LogsThePluginAndTheMemberAsSeparateProperties()
+    {
+        List<KeyValuePair<string, object?>> logged = [];
+        Mock<ILogger> logger = new();
+        logger
+            .Setup(log =>
+                log.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+                )
+            )
+            .Callback(
+                new InvocationAction(invocation =>
+                    logged.AddRange(
+                        (IReadOnlyList<KeyValuePair<string, object?>>)invocation.Arguments[2]
+                    )
+                )
+            );
+
+        await PluginCallGuard.RunAsync(
+            PluginId,
+            "WriteSomething",
+            () => throw new IOException("the volume went away"),
+            PluginWriteResult.Refused,
+            logger.Object
+        );
+
+        logged
+            .Should()
+            .Contain(entry => entry.Key == "PluginId" && (string)entry.Value! == PluginId);
+        logged
+            .Should()
+            .Contain(entry => entry.Key == "Member" && (string)entry.Value! == "WriteSomething");
+    }
+
+    /// <summary>
+    /// The derived-audio facade is one object every plugin shares, so it has
+    /// no plugin of its own to name and says so rather than leaving the
+    /// property out: a missing field reads as a gap in the pipeline.
+    /// </summary>
+    [Fact]
+    public async Task TheSharedFacade_LogsItselfAsThePlugin()
+    {
+        List<KeyValuePair<string, object?>> logged = [];
+        Mock<ILogger> logger = new();
+        logger
+            .Setup(log =>
+                log.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+                )
+            )
+            .Callback(
+                new InvocationAction(invocation =>
+                    logged.AddRange(
+                        (IReadOnlyList<KeyValuePair<string, object?>>)invocation.Arguments[2]
+                    )
+                )
+            );
+
+        await PluginCallGuard.RunOrAsync(
+            "shared",
+            "ExistsAsync",
+            () => throw new IOException("the volume went away"),
+            false,
+            logger.Object
+        );
+
+        logged
+            .Should()
+            .Contain(entry => entry.Key == "PluginId" && (string)entry.Value! == "shared");
+        logged
+            .Should()
+            .Contain(entry => entry.Key == "Member" && (string)entry.Value! == "ExistsAsync");
     }
 }

--- a/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
+++ b/tests/NoMercy.Tests.Repositories/Plugins/PluginMusicAnalysisWriterTests.cs
@@ -414,6 +414,81 @@ public class PluginMusicAnalysisWriterTests : IDisposable
             .Be("vocal_regions_ms entry 0 must be [start, end] with start < end");
     }
 
+    /// <summary>
+    /// A null entry in the list is the same malformed region as a one-element
+    /// one, and gets the same words - never the
+    /// <see cref="NullReferenceException" /> reading through it would throw,
+    /// which the guard would hand back as "the server could not complete this
+    /// call" and tell the plugin author nothing.
+    /// </summary>
+    [Fact]
+    public async Task UpsertDjAnalysisAsync_RefusesANullVocalRegionEntry()
+    {
+        PluginTrackDjAnalysis record = ValidRecord(_trackId) with
+        {
+            VocalRegionsMs =
+            [
+                [1000, 5000],
+                null!,
+            ],
+        };
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(record);
+
+        result.Ok.Should().BeFalse();
+        result
+            .Refusal.Should()
+            .Be("vocal_regions_ms entry 1 must be [start, end] with start < end");
+    }
+
+    [Fact]
+    public async Task UpsertDjAnalysisAsync_RefusesANullCuePoint()
+    {
+        PluginTrackDjAnalysis record = ValidRecord(_trackId) with
+        {
+            CuePoints = [new PluginCuePoint(1000, "intro", "mixIn", 0.9), null!],
+        };
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(record);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Be("cue_points entry 1 must not be null");
+    }
+
+    [Fact]
+    public async Task UpsertDjAnalysisAsync_RefusesANullChord()
+    {
+        PluginTrackDjAnalysis record = ValidRecord(_trackId) with { Chords = [null!] };
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(record);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Be("chords entry 0 must not be null");
+    }
+
+    /// <summary>
+    /// The same refusal when the library never recorded a duration: the
+    /// millisecond-range check that reads through these entries is skipped
+    /// then, so the shape check has to stand on its own.
+    /// </summary>
+    [Fact]
+    public async Task UpsertDjAnalysisAsync_RefusesANullEntryWhenTheDurationIsUnknown()
+    {
+        PluginTrackDjAnalysis record = ValidRecord(_trackUnknownDurationId) with
+        {
+            CuePoints = [null!],
+        };
+
+        PluginWriteResult result = await CreateWriter(NewStoreMock().Object)
+            .UpsertDjAnalysisAsync(record);
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Be("cue_points entry 0 must not be null");
+    }
+
     [Fact]
     public async Task UpsertDjAnalysisAsync_RefusesNonAscendingPhraseStarts()
     {
@@ -573,6 +648,76 @@ public class PluginMusicAnalysisWriterTests : IDisposable
     }
 
     // --- RegisterStemAsync: refusals ---------------------------------------
+
+    /// <summary>
+    /// A plugin written against a looser language than C# can hand any of the
+    /// record's string members across as null. The format is the one that
+    /// reaches a <see cref="string.ToLowerInvariant" /> before anything else
+    /// looks at it, so it is the one that used to throw; all four are named in
+    /// words now, before any of them is read.
+    /// </summary>
+    [Fact]
+    public async Task RegisterStem_RefusesANullFormat()
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store.Setup(s => s.ExistsAsync(KeyOne, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        PluginTrackStem stem = ValidFullStem(_trackId, KeyOne) with { Format = null! };
+
+        Func<Task<PluginWriteResult>> act = () =>
+            CreateWriter(store.Object).RegisterStemAsync(stem);
+
+        PluginWriteResult result = (await act.Should().NotThrowAsync()).Which;
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Be("format must not be empty");
+
+        using MediaContext context = new(_options);
+        context.TrackStems.Any(row => row.TrackId == _trackId).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The other three, null and whitespace alike. The storage key keeps the
+    /// refusal it already had - a plugin gets one answer for "that key is not
+    /// mine", whether it was invented, stale, or never filled in at all.
+    /// </summary>
+    [Theory]
+    [InlineData("kind", null, "kind must not be empty")]
+    [InlineData("kind", "   ", "kind must not be empty")]
+    [InlineData("producer_version", null, "producer_version must not be empty")]
+    [InlineData("producer_version", "   ", "producer_version must not be empty")]
+    [InlineData("storage_key", null, "storage key  is not in the derived store")]
+    [InlineData("storage_key", "   ", "storage key     is not in the derived store")]
+    public async Task RegisterStem_RefusesANullOrBlankMember(
+        string field,
+        string? value,
+        string expected
+    )
+    {
+        Mock<IDerivedAudioStore> store = NewStoreMock();
+        store
+            .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        PluginTrackStem valid = ValidFullStem(_trackId, KeyOne);
+        PluginTrackStem stem = field switch
+        {
+            "kind" => valid with { Kind = value! },
+            "producer_version" => valid with { ProducerVersion = value! },
+            _ => valid with { StorageKey = value! },
+        };
+
+        Func<Task<PluginWriteResult>> act = () =>
+            CreateWriter(store.Object).RegisterStemAsync(stem);
+
+        PluginWriteResult result = (await act.Should().NotThrowAsync()).Which;
+
+        result.Ok.Should().BeFalse();
+        result.Refusal.Should().Be(expected);
+
+        using MediaContext context = new(_options);
+        context.TrackStems.Any(row => row.TrackId == _trackId).Should().BeFalse();
+    }
 
     [Fact]
     public async Task RegisterStemAsync_RefusesAnUnknownTrack()

--- a/tests/NoMercy.Tests.Storage/Concurrency/KeyedAsyncLockTests.cs
+++ b/tests/NoMercy.Tests.Storage/Concurrency/KeyedAsyncLockTests.cs
@@ -1,0 +1,107 @@
+// -----------------------------------------------------------------------------
+//  Copyright (c) 2024-present NoMercy Entertainment. All rights reserved.
+//
+//  This file is part of NoMercy MediaServer, source-available software (NOT open
+//  source). Personal use and contributions are welcome; distribution, resale,
+//  relicensing, and commercial exploitation are prohibited without explicit
+//  written consent. See LICENSE for full terms. Distributed WITHOUT ANY WARRANTY.
+//
+//  SPDX-License-Identifier: LicenseRef-NoMercy-Proprietary
+// -----------------------------------------------------------------------------
+
+using FluentAssertions;
+using NoMercy.Storage.Common;
+
+namespace NoMercy.Tests.Storage.Concurrency;
+
+/// <summary>
+/// The one keyed async lock: what every caller that serializes work per
+/// identifier - a content key, a path - depends on. Each test is bounded by a
+/// deadline, so a regression that would hang reports as a failed test rather
+/// than as a test run that stops.
+/// </summary>
+[Trait("Category", "Unit")]
+public class KeyedAsyncLockTests
+{
+    private static readonly TimeSpan Deadline = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task TwoAcquisitionsOfOneKey_Serialize()
+    {
+        KeyedAsyncLock locks = new();
+        using CancellationTokenSource deadline = new(Deadline);
+
+        IDisposable first = await locks.AcquireAsync("a", deadline.Token);
+
+        Task<IDisposable> second = locks.AcquireAsync("a", deadline.Token);
+        await Task.Delay(50, deadline.Token);
+        second.IsCompleted.Should().BeFalse("the key is already held");
+
+        first.Dispose();
+
+        IDisposable granted = await second;
+        granted.Dispose();
+    }
+
+    [Fact]
+    public async Task DifferentKeys_DoNotWaitOnEachOther()
+    {
+        KeyedAsyncLock locks = new();
+        using CancellationTokenSource deadline = new(Deadline);
+
+        using IDisposable first = await locks.AcquireAsync("a", deadline.Token);
+
+        Func<Task> acquiringAnother = async () =>
+        {
+            using IDisposable other = await locks.AcquireAsync("b", deadline.Token);
+        };
+
+        await acquiringAnother.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Dispose_ReleasesTheKeyForTheNextCaller()
+    {
+        KeyedAsyncLock locks = new();
+        using CancellationTokenSource deadline = new(Deadline);
+
+        using (await locks.AcquireAsync("a", deadline.Token)) { }
+
+        Func<Task> acquiringAgain = async () =>
+        {
+            using IDisposable again = await locks.AcquireAsync("a", deadline.Token);
+        };
+
+        await acquiringAgain.Should().NotThrowAsync();
+    }
+
+    /// <summary>
+    /// A waiter that gives up must not take the key with it: the holder's
+    /// release still has to hand it to whoever comes next, or one cancelled
+    /// call would wedge that key for the life of the process.
+    /// </summary>
+    [Fact]
+    public async Task ACancelledWait_ThrowsAndLeavesTheLockUsable()
+    {
+        KeyedAsyncLock locks = new();
+        using CancellationTokenSource deadline = new(Deadline);
+
+        IDisposable held = await locks.AcquireAsync("a", deadline.Token);
+
+        using CancellationTokenSource giveUp = new();
+        Task<IDisposable> waiting = locks.AcquireAsync("a", giveUp.Token);
+        await giveUp.CancelAsync();
+
+        Func<Task> waited = () => waiting;
+        await waited.Should().ThrowAsync<OperationCanceledException>();
+
+        held.Dispose();
+
+        Func<Task> acquiringAfterwards = async () =>
+        {
+            using IDisposable after = await locks.AcquireAsync("a", deadline.Token);
+        };
+
+        await acquiringAfterwards.Should().NotThrowAsync();
+    }
+}

--- a/tests/NoMercy.Tests.Storage/Concurrency/KeyedAsyncLockTests.cs
+++ b/tests/NoMercy.Tests.Storage/Concurrency/KeyedAsyncLockTests.cs
@@ -76,6 +76,34 @@ public class KeyedAsyncLockTests
     }
 
     /// <summary>
+    /// Disposing one release twice hands the key back once. A second release
+    /// would be a permit this lock never issued, and the key would then admit
+    /// two callers at a time - the one thing it exists to prevent, and
+    /// invisible until two writers land on the same content.
+    /// </summary>
+    [Fact]
+    public async Task DisposingTwice_ReleasesOnce()
+    {
+        KeyedAsyncLock locks = new();
+        using CancellationTokenSource deadline = new(Deadline);
+
+        IDisposable first = await locks.AcquireAsync("a", deadline.Token);
+        first.Dispose();
+        first.Dispose();
+
+        // The key is free again, so this one takes it - and must be its only
+        // holder, however many times the one before it was disposed.
+        using IDisposable second = await locks.AcquireAsync("a", deadline.Token);
+
+        Task<IDisposable> third = locks.AcquireAsync("a", deadline.Token);
+        await Task.Delay(50, deadline.Token);
+
+        third
+            .IsCompleted.Should()
+            .BeFalse("the double dispose must not have left a spare permit behind");
+    }
+
+    /// <summary>
     /// A waiter that gives up must not take the key with it: the holder's
     /// release still has to hand it to whoever comes next, or one cancelled
     /// call would wedge that key for the life of the process.


### PR DESCRIPTION
## Why

Closes #48, the residuals of the #47 review, so the derived-audio store and the plugin writer are clean before the automix plugin exercises them.

## What

1. **The touch/open-read window is closed.** `OpenReadAsync` now also returns null for a content file without a register row (it agrees with `ExistsAsync`), pinned by a test; a read costs two database round-trips, acceptable at this call volume. `TouchAsync` and `OpenReadAsync` keep the cheap existence pre-check outside the key lock (an unknown key still creates no lock entry) and re-check under the lock; `OpenReadAsync` touches and opens the stream while holding it. Tests interleave a delete between the pre-check and the lock through an `AfterPreCheck` hook.
2. **Malformed plugin input refuses in words.** A null entry inside `vocal_regions_ms`, `cue_points` or `chords`, and a null or empty `format`, `kind`, `storage_key` or `producer_version` on a stem, each get their documented refusal before any dereference.
3. **The orphan-content sweep has its own tests**: inside the grace window a file stays; folders that are not two characters are ignored; a file without a register row goes.
4. **One `KeyedAsyncLock`** (in `NoMercy.Storage`) replaces the store's hand-rolled semaphore dictionary at all four lock sites. The local storage driver keeps its own lock: it backs a synchronous member with a bounded wait, a different idiom; said in the code. The three other hand-rolled keyed-semaphore dictionaries (Providers, Networking, Encoder) are #49.
5. **One `StemFormats` vocabulary** for `opus`/`flac` and their content types, used by the audio tools and the writer.
6. **The two lost-write rules are named against each other** in the store (content-addressed: a lost race is success) and the writer (keyed rows: re-read, accept an identical row, refuse otherwise; no competing row means a real error, logged).
7. **`PluginCallGuard` logs `PluginId` and `Member` as separate structured fields** again (the shared derived-audio facade logs `shared`).

## Tests

Build 0 warnings. Database 261, MediaProcessing 1088, Repositories 649, Plugins 578, Service 200, Api 2337, Storage 733 (live-NAS cases skipped), NmSystem 858, all green locally; csharpier clean.

Closes #48.
